### PR TITLE
Try using a format for a market share placeholder

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -6,6 +6,7 @@ namespace WordPressdotorg\Theme\Main_2022;
  * Actions and filters.
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_assets' );
 
 /**
  * Enqueue scripts and styles.
@@ -19,5 +20,17 @@ function enqueue_assets() {
 		get_stylesheet_uri(),
 		array( 'wporg-parent-2021-style', 'wporg-global-fonts' ),
 		filemtime( __DIR__ . '/style.css' )
+	);
+}
+
+/**
+ * Enqueue scripts and styles for the editor.
+ */
+function enqueue_editor_assets() {
+	wp_enqueue_script(
+		'wporg-main-2022-formats',
+		get_stylesheet_directory_uri() . '/js/custom-formats.js',
+		array( 'wp-i18n', 'wp-element', 'wp-rich-text', 'wp-block-editor', 'wp-components' ),
+		filemtime( __DIR__ . '/js/custom-formats.js' )
 	);
 }

--- a/source/wp-content/themes/wporg-main-2022/js/custom-formats.js
+++ b/source/wp-content/themes/wporg-main-2022/js/custom-formats.js
@@ -1,0 +1,53 @@
+// This creates a button in the toolbar which inserts a custom, non-editable
+// HTML element `<wporg-percentage />`, with the visible content of "43%". That
+// could be a constant we pull from somewhere, but the string itself is saved in
+// the content as text, and wouldn't live-update. For that, it would need to be
+// replaced on the frontend too (a naive string replacement of the HTML element
+// would probably be fine).
+
+// The keyboard interaction is not quite right - if you arrow back after adding
+// the percentage, it moves through the text rather than jumping over it.
+// Using CSS to render the value, instead of a text node, would probably fix that.
+
+// Note: using plain JS for prototyping.
+
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const { createElement } = wp.element;
+const { create, insert, registerFormatType } = wp.richText;
+const { BlockControls } = wp.blockEditor;
+const { ToolbarButton } = wp.components;
+
+const name = 'wporg/percentage';
+
+const settings = {
+	title: __( 'Market Share', 'wporg' ),
+	tagName: 'wporg-percentage',
+	className: null,
+	active: false,
+
+	edit: function ( { isActive, value, onChange, onFocus } ) {
+		const onToggle = () => {
+			onChange(
+				insert(
+					value,
+					create( { html: '<wporg-percentage contenteditable="false">43%</wporg-percentage>' } )
+				)
+			);
+			onFocus();
+		};
+		return createElement( BlockControls, {}, [
+			createElement( ToolbarButton, {
+				key: 'button',
+				icon: 'admin-site-alt',
+				title: __( 'Market Share', 'wporg' ),
+				onClick: onToggle,
+				isPressed: isActive,
+			} ),
+		] );
+	},
+};
+
+registerFormatType( name, settings );


### PR DESCRIPTION
See #10 

I started trying something out and landed here. This uses the [Formatting API](https://developer.wordpress.org/block-editor/how-to-guides/format-api/) to insert an inline element we can control in JS.

I put [more of a write-up in the file](https://github.com/WordPress/wporg-main-2022/blob/try/formats-for-inline-values/source/wp-content/themes/wporg-main-2022/js/custom-formats.js), but to keep everything in one place I'll copy-paste it here.

This creates a button in the toolbar which inserts a custom, non-editable HTML element `<wporg-percentage />`, with the visible content of "43%". That could be a constant we pull from somewhere, but the string itself is saved in the content as text, and wouldn't live-update. For that, it would need to be replaced on the frontend too (a naive string replacement of the HTML element would probably be fine).

It renders something like this:

<img width="460" alt="Screen Shot 2022-07-21 at 11 07 57 AM" src="https://user-images.githubusercontent.com/541093/180248561-4266e39a-b7ee-4f41-b631-f75b651800ea.png">

I don't think this code should be used as-is, but the concept is a starting point for the issue in #10.
 