### PR TITLE
Force the import script to use a production server

### DIFF
--- a/env/import-content.php
+++ b/env/import-content.php
@@ -50,7 +50,7 @@ function sanitize_meta_input( $meta ) {
  * Filter CURL requests to bypass sandboxes and always hit a production server.
  * Docker doesn't use the proxy, so those requests will fail when wordpress.org is sandboxed.
  */
-function filter_curl_options( &$ch ) {
+function filter_curl_options( $ch ) {
 	curl_setopt( $ch, CURLOPT_CONNECT_TO, array( 'wordpress.org::w.org:' ) );
 }
 

--- a/env/import-content.php
+++ b/env/import-content.php
@@ -47,11 +47,22 @@ function sanitize_meta_input( $meta ) {
 }
 
 /**
+ * Filter CURL requests to bypass sandboxes and always hit a production server.
+ * Docker doesn't use the proxy, so those requests will fail when wordpress.org is sandboxed.
+ */
+function filter_curl_options( &$ch ) {
+	curl_setopt( $ch, CURLOPT_CONNECT_TO, array( 'wordpress.org::w.org:' ) );
+}
+
+/**
  * Import posts from a remote REST API to the local test site.
  *
  * @param string $rest_url The remote REST API endpoint URL.
  */
 function import_rest_to_posts( $rest_url ) {
+
+	add_action( 'http_api_curl', __NAMESPACE__ . '\filter_curl_options' );
+
 	$response = wp_remote_get( $rest_url );
 	$status_code = wp_remote_retrieve_response_code( $response );
 


### PR DESCRIPTION
This fixes errors when `wordpress.org` is locally sandboxed, since the sandbox server will reject un-proxied requests.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

If you've sandboxed `wordpress.org` in /etc/hosts you'll get 403 errors when running `yarn setup:refresh`. That's because Docker doesn't use the proxy, so the sandbox rejects those REST API requests.

The PR uses CURLOPT_CONNECT_TO to bypass the sandbox and connect to a production server.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #18, #22.

### How to test the changes in this Pull Request:

1. Sandbox `wordpress.org` in `/etc/hosts`
2. `yarn setup:refresh`

<!-- If you can, add the appropriate [Component] label(s). -->
