### PR TITLE
Allow wp-cli to regenerate the .htaccess file

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -26,6 +26,7 @@
 	"mappings": {
 		"env": "./env",
 		"wp-content/mu-plugins": "./source/wp-content/mu-plugins",
-		"wp-content/mu-plugins/0-sandbox.php": "./env/0-sandbox.php"
+		"wp-content/mu-plugins/0-sandbox.php": "./env/0-sandbox.php",
+		"wp-cli.local.yml": "./wp-cli.local.yml"
 	}
 }

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -5,7 +5,7 @@ root=$( dirname $( wp config path ) )
 wp theme activate wporg-main-2022
 
 wp rewrite structure '/%year%/%monthnum%/%postname%/'
-wp rewrite flush
+wp rewrite flush --hard
 
 wp option update blogname "WordPress.org"
 wp option update blogdescription "Blog Tool, Publishing Platform, and CMS"

--- a/wp-cli.local.yml
+++ b/wp-cli.local.yml
@@ -1,0 +1,2 @@
+apache_modules:
+  - mod_rewrite


### PR DESCRIPTION
I'm not sure if this actually solves the problem of `rewrite flush` not doing its job, but it does seem to overcome the issue with .htaccess.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

`wp rewrite flush` doesn't really flush the rules. At least not in a way that reliably includes all custom rules. This might be due to the lack of apache mod_rewrite in the default wp-cli config.


### How to test the changes in this Pull Request:

0. `yarn wp-env stop && yarn wp-env start`
1.  `yarn wp-env clean all` (this will nuke all local data)
2. `yarn wp-env run cli 'rm .htaccess'`
3. `yarn setup:wp`
4. `yarn wp-env run cli 'cat .htaccess'` (check that the new .htaccess file exists)
5. Also, confirm that custom rules were flushed (how?)



<!-- If you can, add the appropriate [Component] label(s). -->
