### PR TITLE
Templates: Remove top-level block gap spacing in page content

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/templates/front-page.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/front-page.html
@@ -1,11 +1,9 @@
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:query {"tagName":"main","query":"inherit"} -->
-<main class="wp-block-query">
-	<!-- wp:post-template -->
-		<!-- wp:post-content {"layout":{"inherit":true}} /-->
-	<!-- /wp:post-template -->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->
 </main>
-<!-- /wp:query -->
+<!-- /wp:group -->
 
 <!-- wp:wporg/global-footer {"style":"white-on-blue"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-download.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-download.html
@@ -1,11 +1,9 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
-<!-- wp:query {"tagName":"main","query":"inherit"} -->
-<main class="wp-block-query">
-	<!-- wp:post-template -->
-		<!-- wp:post-content {"layout":{"inherit":true}} /-->
-	<!-- /wp:post-template -->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->
 </main>
-<!-- /wp:query -->
+<!-- /wp:group -->
 
 <!-- wp:wporg/global-footer {"style":"black-on-white"} /-->


### PR DESCRIPTION
Fixes #23 — this updates the `post-content` block in the template to set its `blockGap` to `0px`. 

The `blockGap` value is used to set the margins on direct descendants, keeping a consistent rhythm between elements. It can be set in the UI for many blocks, it can also be set in the templates or in theme.json, globally or per-block. In general, we want the blockGap behavior, because it adds spacing between paragraphs on normal pages. The home & download pages are built differently, so on these pages specifically, the blockGap is removed.

### Screenshots

| Before | After |
|--------|-------|
| <img alt="" src="https://user-images.githubusercontent.com/541093/181380132-06b1928a-9d9c-4572-b176-c4fd184d3fed.png" /> | ![](https://user-images.githubusercontent.com/541093/182415639-04bc9791-6aaa-4100-8488-099c08502d9a.png) |
| ![](https://user-images.githubusercontent.com/541093/182415887-6ab2ecaf-9685-4297-865e-59c2637640d5.png) | ![](https://user-images.githubusercontent.com/541093/182415882-9c8fd4db-e5d7-4499-9f8b-d6a9d8b8294b.png) |

### How to test the changes in this Pull Request:

1. View the homepage
2. There should be no whitespace between sections — the colorful backgrounds should touch
3. View the download page
4. The border between the two columns should touch the light blue background below it
5. Create a new page with some regular text content, view it (you might need to short circuit the theme-switcher code)
6. There should still be space between paragraphs & other content
