### PR TITLE
Prevent arrow characters from becoming emoji

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -7,6 +7,7 @@ namespace WordPressdotorg\Theme\Main_2022;
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
+add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji' );
 
 /**
  * Enqueue scripts and styles.
@@ -46,3 +47,17 @@ add_filter(
 		);
 	}
 );
+
+/**
+ * Add the variation-selector unicode character to any arrow. This will force
+ * the twemoji script to skip these characters, leaving them as text.
+ *
+ * Can be removed once the `wp-exclude-emoji` issue is fixed.
+ * See https://core.trac.wordpress.org/ticket/52219.
+ *
+ * @param string $content Content of the current post.
+ * @return string The updated content.
+ */
+function prevent_arrow_emoji( $content ) {
+	return preg_replace( '/([←↑→↓↔↕↖↗↘↙])/u', '\1&#65038;', $content );
+}

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -7,7 +7,7 @@ namespace WordPressdotorg\Theme\Main_2022;
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
-add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji' );
+add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 
 /**
  * Enqueue scripts and styles.


### PR DESCRIPTION
Fixes #30. Text arrows added in the editor are converted to emoji, which is unexpected (and unwanted). This PR adds a filter over the content to prevent this on the set of arrows likely to be a problem (though up-right and up-left are _probably_ the only ones we'll use). It adds the text variation selector unicode character to these arrows, which forces the twemoji script to skip them, leaving them as text.

Once core fixes an issue with the `wp-exclude-emoji` class, we could switch to using that, but it would also require updating the containers for everywhere an arrow is used, so in the end this might be a better solution anyway? I've left the note about core regardless, and we can have that discussion when it's fixed.

### Screenshots

| Before | After |
|--------|-------|
| <img alt="" src="https://user-images.githubusercontent.com/541093/182669630-e7080f8e-8237-4363-8d0c-69b93301242b.png"> | <img alt="" src="https://user-images.githubusercontent.com/541093/182669633-b5eefdcc-6b83-409e-b5af-ab7584fade80.png"> |

### How to test the changes in this Pull Request:

1. Add arrows to your post content: `← ↑ → ↓ ↔ ↕ ↖ ↗ ↘ ↙`
2. The should be text arrows in the editor
3. Save your post & view it
4. The arrows should still be text arrows on the front end

