### PR TITLE
Create build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build and push to build branch.
+
+on:
+    push:
+        branches: [trunk]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+            - name: Install NodeJS
+              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'yarn'
+
+            - name: Install all dependencies
+              run: |
+                  composer install
+                  yarn
+
+            - name: Build
+              run: yarn workspaces run build
+
+            - name: Trim the repo down to just the theme
+              run: |
+                  rm -rf source/wp-content/themes/wporg-main-2022/node_modules
+                  mv source/wp-content/themes/wporg-main-2022 $RUNNER_TEMP
+                  git rm -rfq .
+                  rm -rf *
+                  mv $RUNNER_TEMP/wporg-main-2022/* .
+
+            - name: Add all the theme files
+              run: |
+                  git add * --force
+
+            - name: Commit and push
+              uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: build
+                  force: true
+                  message: 'Build: ${{ github.sha }}'


### PR DESCRIPTION
In order to deploy properly since [bb1591](https://github.com/WordPress/wporg-main-2022/commit/bb15910fdfe7076c8e01f6d342e76b5ffa14f63e
), we'll need to build dependencies. This uses https://github.com/WordPress/wporg-parent-2021/blob/trunk/.github/workflows/build.yml as the base template.
