### PR TITLE
Add smoke tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"backstop:test": "npm exec backstop test",
 		"lighthouse": "lighthouse-ci http://localhost:8888/ --accessibility=100 --best-practices=100 --seo=100",
 		"lighthouse:desktop": "lighthouse http://localhost:8888/ --view --preset=desktop --output-path=lighthouse.html",
-		"lighthouse:mobile": "lighthouse http://localhost:8888/ --view --screenEmulation.mobile --output-path=lighthouse.html"
+		"lighthouse:mobile": "lighthouse http://localhost:8888/ --view --screenEmulation.mobile --output-path=lighthouse.html",
+		"test": "./vendor/phpunit/phpunit/phpunit tests/phpunit"
 	},
 	"workspaces": [
 		"source/wp-content/themes/wporg-main-2022"

--- a/tests/phpunit/smokeTest.php
+++ b/tests/phpunit/smokeTest.php
@@ -1,0 +1,84 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class SmokeTest extends TestCase {
+
+	private $curl_body;
+	private $curl_error;
+
+	public function fetch_url( $url ) {
+		$ch = curl_init();
+
+		curl_setopt( $ch, CURLOPT_URL, $url );
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
+		curl_setopt( $ch, CURLOPT_HEADER, 0 );
+
+		$this->curl_body = curl_exec( $ch );
+		$this->curl_error = curl_error( $ch ) ?: null;
+
+		curl_close( $ch );
+
+		return $this->curl_body;
+	}
+
+	public function urls() {
+		return array(
+			['http://localhost:8888/'],
+			['http://localhost:8888/download/'],
+		);
+	}
+
+	/**
+	 * @dataProvider urls
+	 */
+	public function testHasBodyTag( $url ): void
+	{
+		$this->fetch_url( $url );
+
+		$this->assertStringContainsString( '<body', $this->curl_body );
+		$this->assertStringContainsString( '</body>', $this->curl_body );
+	}
+
+	/**
+	 * @dataProvider urls
+	 */
+	public function testClosingHtml( $url ): void
+	{
+		$this->fetch_url( $url );
+
+		$this->assertStringEndsWith( '</html>', rtrim( $this->curl_body ) );
+	}
+
+	/**
+	 * @dataProvider urls
+	 */
+	public function testHasTitle( $url ): void
+	{
+		$this->fetch_url( $url );
+
+		$this->assertRegExp( '#<title>[^<>]+ WordPress.org</title>#', $this->curl_body );
+	}
+
+	/**
+	 * @dataProvider urls
+	 */
+	public function testHasMetaDescription( $url ): void
+	{
+		$this->fetch_url( $url );
+
+		$this->assertRegExp( '#<meta name="description" content="[^"<>]+" />#', $this->curl_body );
+		$this->assertRegExp( '#<meta property="og:description" content="[^"<>]+" />#', $this->curl_body );
+	}
+
+	/**
+	 * @dataProvider urls
+	 */
+	public function testHasHrefLang( $url ): void
+	{
+		$this->markTestSkipped( 'Requires https://github.com/WordPress/wporg-main-2022/pull/54' );
+		$this->fetch_url( $url );
+
+		$this->assertRegExp( '#<link rel="alternate" hreflang="\w\w-\w\w" />#', $this->curl_body );
+	}
+
+}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This adds some basic smoke tests (mis)using phpunit.

The tests will fetch `http://localhost:8888` and `http://localhost:8888/download/` and run a few basic sanity tests on the HTML output.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

Sample output:

```bash
% yarn test
yarn run v1.22.18
$ ./vendor/phpunit/phpunit/phpunit tests/phpunit
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

........SS                                                        10 / 10 (100%)

Time: 6.05 seconds, Memory: 4.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 10, Assertions: 12, Skipped: 2.
✨  Done in 6.17s.
```


### How to test the changes in this Pull Request:

1. `yarn test`




<!-- If you can, add the appropriate [Component] label(s). -->
