### PR TITLE
Only load the download modal script if on the download page

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -25,22 +25,24 @@ function enqueue_assets() {
 		filemtime( __DIR__ . '/style.css' )
 	);
 
-	$path        = __DIR__ . '/build/index.js';
-	$deps_path   = __DIR__ . '/build/index.asset.php';
-	$script_info = file_exists( $deps_path )
-		? require $deps_path
-		: array(
-			'dependencies' => array(),
-			'version'      => filemtime( $path ),
-		);
+	if ( is_page( 'download' ) ) {
+		$path        = __DIR__ . '/build/index.js';
+		$deps_path   = __DIR__ . '/build/index.asset.php';
+		$script_info = file_exists( $deps_path )
+			? require $deps_path
+			: array(
+				'dependencies' => array(),
+				'version'      => filemtime( $path ),
+			);
 
-	wp_enqueue_script(
-		'wporg-main-2022-script',
-		get_stylesheet_directory_uri() . '/build/index.js',
-		$script_info['dependencies'],
-		$script_info['version'],
-		true
-	);
+		wp_enqueue_script(
+			'wporg-main-2022-script',
+			get_stylesheet_directory_uri() . '/build/index.js',
+			$script_info['dependencies'],
+			$script_info['version'],
+			true
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #58

The download modal script loads `wordpress/components` which is large and blocks page rendering. While we can't load the code only for the modal for now, we can choose to only load this dependency on the download page, thereby improving performance of the home page.

### How to test the changes in this Pull Request:

1. Load your local home page
2. Check that the `wporg-main-2022-script` is not loaded and there is no request for http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.min.js
3. Navigate to the download page
4. Click the Download WordPress button and the modal should still appear