### PR TITLE
Disable Jetpack auto-images to reduce query count

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -82,3 +82,10 @@ add_filter(
 function prevent_arrow_emoji( $content ) {
 	return preg_replace( '/([←↑→↓↔↕↖↗↘↙])/u', '\1&#65038;', $content );
 }
+
+/**
+ * Prevent Jetpack from looking for a non-existent featured image.
+ */
+add_filter( 'jetpack_images_pre_get_images', function() {
+	return new \WP_Error();
+} );

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -86,6 +86,9 @@ function prevent_arrow_emoji( $content ) {
 /**
  * Prevent Jetpack from looking for a non-existent featured image.
  */
-add_filter( 'jetpack_images_pre_get_images', function() {
-	return new \WP_Error();
-} );
+add_filter(
+	'jetpack_images_pre_get_images',
+	function() {
+		return new \WP_Error();
+	}
+);


### PR DESCRIPTION
This reduces the DB query count. It comes straight from the old theme, see https://github.com/WordPress/wporg-main-2022/issues/44#issuecomment-1206049420.

It's possible in future this might need to be selective if we decide we want that feature on some pages.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #44.

<!-- List out anyone who helped with this task. -->
Props dd32.

<!-- Don't forget to update the title with something descriptive. -->

<!-- If your change has a visual component, add a screenshot here. -->

### How to test the changes in this Pull Request:

1. Check the Debug Bar query count.
2. Apply the PR
3. Check the query count again - should be lower.

<!-- If you can, add the appropriate [Component] label(s). -->
