### PR TITLE
Theme: Add page content as patterns

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -10,7 +10,7 @@ require_once( __DIR__ . '/inc/hreflang.php' );
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
-add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
+add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 
 /**
  * Enqueue scripts and styles.

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Title: Download
+ * Slug: wporg-main-2022/download
+ * Categories:
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"0px"}}},"layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull" style="padding-top:80px;padding-right:0px;padding-bottom:80px;padding-left:0px"><!-- wp:heading {"textAlign":"center","level":1,"fontSize":"heading-1"} -->
+<h1 class="has-text-align-center has-heading-1-font-size">Get WordPress</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","className":"is-style-serif","fontSize":"heading-5"} -->
+<p class="has-text-align-center is-style-serif has-heading-5-font-size">Everything you need to set up your site just the way you want it.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull" id="download-hosting" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%","style":{"border":{"right":{"color":"var:preset|color|light-grey-1","width":"1px"}}}} -->
+<div class="wp-block-column" style="border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;flex-basis:50%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"80px","right":"60px","bottom":"80px","left":"0px"}}}} -->
+<div class="wp-block-group alignwide" id="download-install" style="padding-top:80px;padding-right:60px;padding-bottom:80px;padding-left:0px"><!-- wp:heading {"textAlign":"left","fontSize":"heading-4"} -->
+<h2 class="has-text-align-left has-heading-4-font-size">Download and install yourself</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"left","className":"is-style-short-text"} -->
+<p class="has-text-align-left is-style-short-text">For anyone comfortable getting their own hosting and domain.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"10px"}}} -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button" id="wporg__download-button"><a class="wp-block-button__link wp-element-button" href="[download_link]">Download WordPress [latest_version]</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"textColor":"blue-1","className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-blue-1-color has-text-color wp-element-button" href="https://wordpress.org/support/article/how-to-install-wordpress/">Installation guide</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:paragraph {"textColor":"charcoal-4","className":"is-style-short-text","fontSize":"small"} -->
+<p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size">Recommend PHP [recommended_php] or greater and MySQL [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"60px"}}}} -->
+<div class="wp-block-group alignwide" id="hosting" style="padding-top:80px;padding-right:0px;padding-bottom:80px;padding-left:60px"><!-- wp:heading {"textAlign":"left","fontSize":"heading-4"} -->
+<h2 class="has-text-align-left has-heading-4-font-size">Set up with a hosting provider</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"left","className":"is-style-short-text"} -->
+<p class="has-text-align-left is-style-short-text">For anyone looking for the simplest way to start.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://wordpress.org/main-test/hosting/">See all recommended hosts</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","backgroundColor":"blueberry-4","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-blueberry-4-background-color has-background" id="features"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"60px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:60px;flex-basis:50%"><!-- wp:list {"className":"is-style-features"} -->
+<ul class="is-style-features"><li>Simple</li><li>Intuitive</li><li>Extendable</li><li>Free</li><li>Open</li></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"layout":{"inherit":false}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px;flex-basis:50%"><!-- wp:heading {"fontSize":"heading-4"} -->
+<h2 class="has-heading-4-font-size">Powerful right out of the box</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">WordPress combines simplicity for users and publishers with under-the-hood complexity for developers. Discover the features that come standard with WordPress, and extend what the platform can do with the thousands of plugins available.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://wordpress.org/about/features/">See all WordPress features ↗</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"160px","right":"0px","bottom":"160px","left":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" id="resources" style="padding-top:160px;padding-right:0px;padding-bottom:160px;padding-left:0px"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"120px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"fontSize":"heading-2"} -->
+<h2 class="has-heading-2-font-size">You've got WordPress. What's next?</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">If you need help getting started, these resources can help you find your way.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:list {"className":"is-style-links-list"} -->
+<ul class="is-style-links-list"><li><a href="https://learn.wordpress.org/course/getting-started-with-wordpress-get-setup/">WordPress courses ↗</a></li><li><a href="https://developer.wordpress.org/">Developer resources ↗</a></li><li><a href="https://wordpress.org/support/">WordPress support ↗</a></li><li><a href="https://wordpress.org/support/forum/installation/">User forums ↗</a></li></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"120px","right":"0px","bottom":"120px","left":"0px"}}}} -->
+<div class="wp-block-group alignwide" id="mobile" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px"><!-- wp:heading {"textAlign":"center","fontSize":"heading-2"} -->
+<h2 class="has-text-align-center has-heading-2-font-size">Inspiration strikes anywhere</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Create and update content on the go with the WordPress app.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
+<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="Available in the Apple App Store" width="150" height="45"/></a></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
+<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="Available in the Google Play Store" width="150" height="45"/></a></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Title: Front Page
+ * Slug: wporg-main-2022/front-page
+ * Categories:
+ */
+
+?>
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"120px","right":"0px","bottom":"120px","left":"0px"},"blockGap":"30px"}},"layout":{"inherit":false}} -->
+<div class="wp-block-group alignwide" id="intro" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px"><!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns"><!-- wp:column {"width":"85%"} -->
+<div class="wp-block-column" style="flex-basis:85%"><!-- wp:heading {"level":1,"textColor":"charcoal-1","fontSize":"heading-cta"} -->
+<h1 class="has-charcoal-1-color has-text-color has-heading-cta-font-size">WordPress: Publish your <em><mark class="has-inline-color has-blueberry-1-color">passion</mark></em></h1>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"15%"} -->
+<div class="wp-block-column" style="flex-basis:15%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:paragraph {"align":"left","className":"is-style-short-text"} -->
+<p class="has-text-align-left is-style-short-text">Create a place for your business, your interests, or anything else—with the open source platform that powers the web.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/download">Get WordPress</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->
+
+<!-- wp:wporg/language-suggest {"align":"full"} -->
+<div class="wp-block-wporg-language-suggest alignfull"></div>
+<!-- /wp:wporg/language-suggest -->
+
+<!-- wp:cover {"url":"https://wordpress.org/main-test/files/2022/08/editor-bg-scaled.webp","id":9215,"dimRatio":0,"minHeight":670,"minHeightUnit":"px","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"0px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:80px;padding-right:0px;padding-bottom:80px;padding-left:0px;min-height:670px" id="editor"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-9215" alt="" src="https://wordpress.org/main-test/files/2022/08/editor-bg-scaled.webp" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}}},"textColor":"white","layout":{"inherit":false,"contentSize":"520px"}} -->
+<div class="wp-block-group has-white-color has-text-color has-link-color"><!-- wp:heading {"textAlign":"right","textColor":"pomegrade-3","fontSize":"heading-cta"} -->
+<h2 class="has-text-align-right has-pomegrade-3-color has-text-color has-heading-cta-font-size">Dream it, build it</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"left","className":"is-style-short-text"} -->
+<p class="has-text-align-left is-style-short-text">It’s not magic, it’s the WordPress Editor. Create custom sites with intuitive editing, flexible design tools, and powerful features to manage it all.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a rel="noreferrer noopener" href="/gutenberg" target="_blank">Explore the editor ↗</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"blueberry-4","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-blueberry-4-background-color has-background" id="benefits" style="padding-top:80px;padding-bottom:80px"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"100px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"40px","right":"100px"}}},"fontSize":"heading-2"} -->
+<h2 class="has-heading-2-font-size" style="margin-right:100px;margin-bottom:40px">Powerful and empowering</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"id":8923,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/main-test/files/2022/07/theme-styles.png" alt="" class="wp-image-8923"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"5px"}}} -->
+<div class="wp-block-column"><!-- wp:paragraph {"fontSize":"large"} -->
+<p class="has-large-font-size"><strong>Style it your way</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Design anything you imagine. Start with a blank canvas or choose from a wide variety of <a href="https://wordpress.org/themes/">themes</a> and <a href="https://wordpress.org/patterns/">patterns</a>. Customize every detail, from color and fonts to layouts and functionality.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"fontSize":"large"} -->
+<p class="has-large-font-size"><strong>Plug in and extend</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Make WordPress do whatever you need it to. Add a store, mailing list, portfolio, social feed, analytics; you’re in control with over 55,000 plugins.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"fontSize":"large"} -->
+<p class="has-large-font-size"><strong>Own what you make&nbsp;</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Your content, your design, and your data always belong to you. With WordPress you’re free to tell your story, grow your brand, or simply be yourself.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"fontSize":"large"} -->
+<p class="has-large-font-size"><strong>Create with confidence</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Built by an open source community with decades of experience, its passionate contributors are committed to keeping WordPress as stable and secure as possible.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"80px"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" id="showcase" style="padding-top:80px"><!-- wp:group {"align":"wide","layout":{"inherit":false}} -->
+<div class="wp-block-group alignwide"><!-- wp:heading {"textAlign":"left","fontSize":"heading-2"} -->
+<h2 class="has-text-align-left has-heading-2-font-size">One platform, millions of possibilities</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns"><!-- wp:column {"width":"40%"} -->
+<div class="wp-block-column" style="flex-basis:40%"><!-- wp:paragraph {"align":"left","className":"is-style-short-text"} -->
+<p class="has-text-align-left is-style-short-text">Global creative agencies, local businesses, and even your neighbor’s personal blog are already using WordPress.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"60%"} -->
+<div class="wp-block-column" style="flex-basis:60%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"30px","bottom":"30px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="margin-top:30px;margin-bottom:30px"><!-- wp:image {"id":9099,"width":105,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/main-test/files/2022/08/Spotify.png" alt="" class="wp-image-9099" width="105" height="33"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":9100,"width":79,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/main-test/files/2022/08/Time-Magazine.png" alt="" class="wp-image-9100" width="79" height="33"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":9101,"width":118,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/main-test/files/2022/08/Vogue.png" alt="" class="wp-image-9101" width="118" height="33"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":9098,"width":210,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/main-test/files/2022/08/Sony-Music.png" alt="" class="wp-image-9098" width="210" height="33"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":9102,"width":97,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/main-test/files/2022/08/Wired.png" alt="" class="wp-image-9102" width="97" height="33"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":9097,"width":76,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/main-test/files/2022/08/Disney.png" alt="" class="wp-image-9097" width="76" height="33"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
+
+<!-- wp:buttons {"align":"wide"} -->
+<div class="wp-block-buttons alignwide"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/showcase">Find inspiration</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:image {"align":"full","id":9190,"sizeSlug":"full","linkDestination":"none","style":{"color":[]}} -->
+<figure class="wp-block-image alignfull size-full"><img src="https://wordpress.org/main-test/files/2022/08/Showcase_2560.webp" alt="" class="wp-image-9190"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"160px","bottom":"160px"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" id="learning" style="padding-top:160px;padding-bottom:160px"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"100px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"fontSize":"heading-2"} -->
+<h2 class="has-heading-2-font-size">Build for yourself,<br>not by yourself</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Whether you’re an entrepreneur, professional developer, or first-time blogger, there’s a library of resources and learning tools ready for you. Plus, you have the whole WordPress community in your corner.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:list {"className":"is-style-links-list"} -->
+<ul class="is-style-links-list"><li><a href="https://learn.wordpress.org/">Learn with WordPress ↗</a></li><li><a href="https://wordpress.org/support/">Find support ↗</a></li><li><a href="https://developer.wordpress.org/">Dig into the code ↗</a></li><li><a href="https://www.meetup.com/pro/wordpress/">Meet local WordPress users ↗</a></li></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"100px"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"color":{"background":"#f6f6f6"}},"textColor":"blueberry-1","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-blueberry-1-color has-text-color has-background has-link-color" id="community" style="background-color:#f6f6f6;padding-bottom:100px"><!-- wp:cover {"url":"https://wordpress.org/main-test/files/2022/08/Community-Photo_2560.webp","id":9193,"dimRatio":0,"focalPoint":{"x":"0.50","y":"1.00"},"minHeight":500,"minHeightUnit":"px","isDark":false,"align":"full","style":{"color":[],"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"bottom":"60px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="margin-bottom:60px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;min-height:500px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-9193" alt="" src="https://wordpress.org/main-test/files/2022/08/Community-Photo_2560.webp" style="object-position:50% 100%" data-object-fit="cover" data-object-position="50% 100%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:heading {"textAlign":"left","align":"wide","style":{"spacing":{"margin":{"bottom":"40px"}}},"fontSize":"heading-cta"} -->
+<h2 class="alignwide has-text-align-left has-heading-cta-font-size" style="margin-bottom:40px"><em>Community</em> at its core</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%"} -->
+<div class="wp-block-column" style="flex-basis:33%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Behind the technology is a diverse collective of people, collaborating from around the world. We’re united by the spirit of open source, and the freedom to build, transform, and share without barriers.&nbsp;</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">From writing code and testing, to community outreach and translation, there are so many ways to contribute and everyone is welcome. Let’s shape the future of the web together.&nbsp;</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://make.wordpress.org/">Get involved</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"16%"} -->
+<div class="wp-block-column" style="flex-basis:16%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"},"blockGap":"0px"}},"className":"is-style-default"} -->
+<div class="wp-block-columns alignwide is-style-default" id="news" style="padding-top:80px;padding-bottom:80px"><!-- wp:column {"verticalAlignment":"top","width":"33%","className":"is-left-column","layout":{"inherit":false}} -->
+<div class="wp-block-column is-vertically-aligned-top is-left-column" style="flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"80px"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group" style="padding-right:80px"><!-- wp:heading {"fontSize":"heading-2"} -->
+<h2 class="has-heading-2-font-size">See what's new in WordPress</h2>
+<!-- /wp:heading -->
+
+<!-- wp:social-links {"iconColor":"blueberry-1","iconColorValue":"#3858e9","className":"is-style-logos-only"} -->
+<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"https://twitter.com/WordPress/","service":"twitter"} /-->
+
+<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook"} /--></ul>
+<!-- /wp:social-links -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"66%","layout":{"inherit":false}} -->
+<div class="wp-block-column" style="flex-basis:66%"><!-- wp:wporg/multisite-latest-posts -->
+<div class="wp-block-wporg-multisite-latest-posts" data-endpoint="https://wordpress.org/news/wp-json/wp/v2" data-per-page="3"></div>
+<!-- /wp:wporg/multisite-latest-posts -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p><a href="https://wordpress.org/news/">View all</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","right":"var:preset|spacing|60","bottom":"80px","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-right:var(--wp--preset--spacing--60);padding-bottom:80px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"wide"} -->
+<div class="wp-block-group alignwide"><!-- wp:heading {"align":"wide","className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+<h2 class="alignwide is-style-with-arrow has-inter-font-family has-heading-cta-font-size"><a href="https://wordpress.org/download/">Get started</a></h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"className":"is-style-short-text"} -->
+<p class="is-style-short-text">Find everything you need to get started, download the platform, find hosting, and more—whether it’s your first site or your ninety-first site. Get WordPress now.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/templates/front-page.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/front-page.html
@@ -1,8 +1,8 @@
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:group {"tagName":"main"} -->
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->
+	<!-- wp:pattern {"slug":"wporg-main-2022/front-page"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-main-2022/templates/page-download.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-download.html
@@ -1,8 +1,8 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
-<!-- wp:group {"tagName":"main"} -->
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->
+	<!-- wp:pattern {"slug":"wporg-main-2022/download"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
This PR pulls the content out of the editor and puts it into patterns, so that it can be under version control. Each pattern can then be loaded using the `pattern` block, an internal block that renders a block pattern. The patterns are just the same content that was in the post editor.

I decided to go with a pattern, rather than dropping the content into the HTML template, so that we can use PHP as needed (ex, for translation functions). I haven't added those yet, though.

In the future, we could try some kind of syncing system to copy down page content from a WP install?

Another iteration could look at hiding these from the site/page editor, so they can only be added via code.

### How to test the changes in this Pull Request:

1. View the branch
2. Make a change in the page content in the editor, like, delete everything
3. The page will still look the same
4. Make a change in the pattern code
5. It will be reflected on the front end
