### PR TITLE
Register the Rosetta menu location for the header

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -93,3 +93,15 @@ add_filter(
 		return new \WP_Error();
 	}
 );
+
+/**
+ * Register the Rosetta header menu.
+ */
+add_action(
+	'after_setup_theme',
+	function() {
+		register_nav_menus( array(
+			'rosetta_main' => 'Rosetta',
+		) );
+	}
+);

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -100,8 +100,10 @@ add_filter(
 add_action(
 	'after_setup_theme',
 	function() {
-		register_nav_menus( array(
-			'rosetta_main' => 'Rosetta',
-		) );
+		register_nav_menus(
+			array(
+				'rosetta_main' => 'Rosetta',
+			)
+		);
 	}
 );


### PR DESCRIPTION
The global header expects that the theme defines the rosetta menu location for rosetta sites.

See https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-main/functions.php#L29-L33

This is required in order to be able to activate the theme on test.wordpress.org.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| image  | image |

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] label(s). -->
