### PR TITLE
Stop lazy loading of content images above the fold to improve LCP

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -11,6 +11,7 @@ require_once( __DIR__ . '/inc/hreflang.php' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
 add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
+add_filter( 'wp_omit_loading_attr_threshold', __NAMESPACE__ . '\skip_lazyloading_on_homepage_images' );
 
 /**
  * Enqueue scripts and styles.
@@ -107,3 +108,14 @@ add_action(
 		);
 	}
 );
+
+/**
+ * Prevent lazy loading the images above the fold as this affects LCP performance.
+ */
+function skip_lazyloading_on_homepage_images( $omit_threshold ) {
+	if ( is_home() ) {
+		return 2;
+	}
+
+	return $omit_threshold;
+}

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -11,7 +11,7 @@ require_once( __DIR__ . '/inc/hreflang.php' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
 add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
-add_filter( 'wp_omit_loading_attr_threshold', __NAMESPACE__ . '\skip_lazyloading_on_homepage_images' );
+add_filter( 'wp_img_tag_add_loading_attr', __NAMESPACE__ . '\override_lazy_loading', 10, 2 );
 
 /**
  * Enqueue scripts and styles.
@@ -86,6 +86,22 @@ function prevent_arrow_emoji( $content ) {
 }
 
 /**
+ * Prevents adding loading="lazy" to the editor section's background.
+ *
+ * @param string|bool $value   The `loading` attribute value.
+ * @param string      $image   The HTML `img` tag to be filtered.
+ *
+ * @return string The filtered loading value.
+ */
+function override_lazy_loading( $value, $image ) {
+	if ( str_contains( $image, 'editor-bg' ) ) {
+		// False removes the `loading` attribute entirely.
+		return false;
+	}
+	return $value;
+}
+
+/**
  * Prevent Jetpack from looking for a non-existent featured image.
  */
 add_filter(
@@ -108,14 +124,3 @@ add_action(
 		);
 	}
 );
-
-/**
- * Prevent lazy loading the images above the fold as this affects LCP performance.
- */
-function skip_lazyloading_on_homepage_images( $omit_threshold ) {
-	if ( is_home() ) {
-		return 2;
-	}
-
-	return $omit_threshold;
-}


### PR DESCRIPTION
Partially fixes #45 

Content images which are above the fold shouldn't be lazy loaded as it affects the Largest Contentful Paint of the page, a key performance metric.

![Screen Shot 2022-08-12 at 2 50 17 PM](https://user-images.githubusercontent.com/1017872/184281791-8c174785-f40c-447b-95a5-80d7fa9576a0.jpg)

This PR adds a filter to skip X number of images as outlined on https://make.wordpress.org/core/2021/12/29/enhanced-lazy-loading-performance-in-5-9/, however the filter doesn't fire, @tellyworth suggested perhaps related to the content being in a pattern. Not sure if this being page content rather than post content makes a difference either.

The image in question is actually the first content image in the page, so if I understand correctly it should not be lazy loaded by default. It seems we're doing something differently to the way this optimization expects.

### Screenshots

| Before | After |
|--------|-------|
| image  | image |

### How to test the changes in this Pull Request:

1.
2.
3.