### PR TITLE
Add structured content to download page

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/page-meta-descriptions.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/page-meta-descriptions.php
@@ -151,7 +151,7 @@ function sites_attributes_schema() {
 		"softwareVersion": "<?php echo esc_js( do_shortcode( '[latest_version]' ) ); ?>",
 		"fileFormat": "application/zip",
 		"downloadUrl": "<?php echo esc_url( do_shortcode( '[download_link]' ) ); ?>",
-		"dateModified": "<?php echo esc_js( do_shortcode( '[latest_version_ts]' ) ); ?>",
+		"dateModified": "<?php echo esc_js( do_shortcode( '[latest_version_date]' ) ); ?>",
 		"applicationCategory": "WebApplication",
 		"offers": {
 			"@type": "Offer",

--- a/source/wp-content/themes/wporg-main-2022/inc/page-meta-descriptions.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/page-meta-descriptions.php
@@ -78,10 +78,6 @@ add_filter( 'jetpack_enable_open_graph', '__return_true' );
 function sites_attributes_schema() {
 	global $rosetta;
 
-	if ( ! is_front_page() ) {
-		return;
-	}
-
 	$og_tags         = custom_open_graph_tags();
 	$locale_language = 'en';
 	$name            = 'WordPress.org';
@@ -95,7 +91,7 @@ function sites_attributes_schema() {
 		);
 	}
 
-	?>
+	if ( is_front_page() ) : ?>
 <script type="application/ld+json">
 {
 	"@context":"https://schema.org",
@@ -139,7 +135,39 @@ function sites_attributes_schema() {
 	]
 }
 </script>
-	<?php
+	<?php elseif ( is_page( 'download' ) ) : ?>
+<script type="application/ld+json">
+[
+	{
+		"@context": "http://schema.org",
+		"@type": [
+			"SoftwareApplication",
+			"Product"
+		],
+		"name": "WordPress",
+		"operatingSystem": [ "Linux", "Windows", "Unix", "Apache", "NGINX" ],
+		"url": "<?php the_permalink(); ?>",
+		"description": "<?php echo esc_js( $og_tags['og:description'] ); ?>",
+		"softwareVersion": "<?php echo esc_js( do_shortcode( '[latest_version]' ) ); ?>",
+		"fileFormat": "application/zip",
+		"downloadUrl": "<?php echo esc_url( do_shortcode( '[download_link]' ) ); ?>",
+		"dateModified": "<?php echo esc_js( do_shortcode( '[latest_version_ts]' ) ); ?>",
+		"applicationCategory": "WebApplication",
+		"offers": {
+			"@type": "Offer",
+			"url": "<?php the_permalink(); ?>",
+			"price": "0.00",
+			"priceCurrency": "USD",
+			"seller": {
+				"@type": "Organization",
+				"name": "WordPress.org",
+				"url": "https://wordpress.org"
+			}
+		}
+	}
+]
+</script>
+	<?php endif;
 }
 add_action( 'wp_head', __NAMESPACE__ . '\sites_attributes_schema' );
 

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -95,3 +95,24 @@ add_shortcode(
 		return $link;
 	}
 );
+
+/**
+ * Shortcode for a formatted time when the latest version was published.
+ */
+add_shortcode(
+	'latest_version_ts',
+	function( $attrs = array() ) {
+		$format = $attrs['format'] ?? 'Y-m-d\TH:i:s\+00:00';
+
+		$timestamp = defined( 'WPORG_WP_RELEASES_PATH' ) ? filemtime( WPORG_WP_RELEASES_PATH . 'wordpress-' . WP_CORE_LATEST_RELEASE . '.zip' ) : time();
+
+		if ( defined( 'IS_ROSETTA_NETWORK' ) && IS_ROSETTA_NETWORK && ! empty( $GLOBALS['rosetta'] ) ) {
+			$rosetta_release = $GLOBALS['rosetta']->rosetta->get_latest_public_release();
+			if ( $rosetta_release ) {
+				$timestamp = $rosetta_release['builton'];
+			}
+		}
+
+		return gmdate( $format, $timestamp );
+	}
+);

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -97,10 +97,10 @@ add_shortcode(
 );
 
 /**
- * Shortcode for a formatted time when the latest version was published.
+ * Shortcode for a formatted date & time when the latest version was published.
  */
 add_shortcode(
-	'latest_version_ts',
+	'latest_version_date',
 	function( $attrs = array() ) {
 		$format = $attrs['format'] ?? 'Y-m-d\TH:i:s\+00:00';
 


### PR DESCRIPTION
Fixes #5 — This adds in the structured content from the old theme to the download page.

I also added a shortcode for the version time, to match how the version and URL are managed. It can be used with a `format` attribute, like so: `[latest_version_date format="Y-m-d" /]`. It defaults to the `Y-m-d\TH:i:s\+00:00` format.

### How to test the changes in this Pull Request:

1. Open the download page, view source
2. You should see a section with `<script type="application/ld+json">` and some JSON, make sure it matches the code currently on `wordpress.org/download`
3. Open the homepage, view source
4. Confirm the `<script type="application/ld+json">` code is still on the page (no change from trunk)
