### PR TITLE
Fix Download modal initialization

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/index.js
@@ -11,7 +11,7 @@ const initDownloadModal = () => {
 };
 
 const init = () => {
-	if ( document.body.classList.contains( 'page-template-page-download' ) ) {
+	if ( document.getElementById( 'wporg__download-button' ) ) {
 		initDownloadModal();
 	}
 };


### PR DESCRIPTION
Fixes #80 

Props @dd32 

### How to test the changes in this Pull Request:

1. Navigate to http://localhost:8888/download/
2. Ensure the Get WordPress button has the id `wporg__download-button`, (should be applied via the [pattern](https://github.com/WordPress/wporg-main-2022/blob/trunk/source/wp-content/themes/wporg-main-2022/patterns/download.php#L33))
3. Click the button
4. Observe the modal opening and the download being triggered