### PR TITLE
Replace image URLs with CDN

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
@@ -34,8 +34,8 @@
 <div class="wp-block-wporg-language-suggest alignfull"></div>
 <!-- /wp:wporg/language-suggest -->
 
-<!-- wp:cover {"url":"https://wordpress.org/files/2022/08/editor-bg-scaled-1.webp","id":11480,"dimRatio":0,"minHeight":670,"minHeightUnit":"px","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"0px"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-top:80px;padding-right:0px;padding-bottom:80px;padding-left:0px;min-height:670px" id="editor"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-11480" alt="" src="https://wordpress.org/files/2022/08/editor-bg-scaled-1.webp" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}}},"textColor":"white","layout":{"inherit":false,"contentSize":"520px"}} -->
+<!-- wp:cover {"url":"https://s.w.org/wp-content/blogs.dir/1/files/2022/08/editor-bg-scaled-1.webp","id":11480,"dimRatio":0,"minHeight":670,"minHeightUnit":"px","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"0px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:80px;padding-right:0px;padding-bottom:80px;padding-left:0px;min-height:670px" id="editor"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-11480" alt="" src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/editor-bg-scaled-1.webp" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}}},"textColor":"white","layout":{"inherit":false,"contentSize":"520px"}} -->
 <div class="wp-block-group has-white-color has-text-color has-link-color"><!-- wp:heading {"textAlign":"right","textColor":"pomegrade-3","fontSize":"heading-cta"} -->
 <h2 class="has-text-align-right has-pomegrade-3-color has-text-color has-heading-cta-font-size">Dream it, build&nbsp;it</h2>
 <!-- /wp:heading -->
@@ -58,7 +58,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":11481,"sizeSlug":"full","linkDestination":"custom"} -->
-<figure class="wp-block-image size-full"><a href="https://wordpress.org/themes/"><img src="https://wordpress.org/files/2022/08/theme-styles.png" alt="An illustration showing a grid of different type styles and color options, with a cursor arrow making a selection." class="wp-image-11481"/></a></figure>
+<figure class="wp-block-image size-full"><a href="https://wordpress.org/themes/"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/theme-styles.png" alt="An illustration showing a grid of different type styles and color options, with a cursor arrow making a selection." class="wp-image-11481"/></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -131,27 +131,27 @@
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="margin-top:50px;margin-bottom:50px"><!-- wp:image {"id":11474,"width":105,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Spotify.png" alt="Spotify logo" class="wp-image-11474" width="105" height="33"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Spotify.png" alt="Spotify logo" class="wp-image-11474" width="105" height="33"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":11475,"width":79,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Time-Magazine.png" alt="Time Magazine logo" class="wp-image-11475" width="79" height="33"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Time-Magazine.png" alt="Time Magazine logo" class="wp-image-11475" width="79" height="33"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":11476,"width":118,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Vogue.png" alt="Vogue Magazine logo" class="wp-image-11476" width="118" height="33"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Vogue.png" alt="Vogue Magazine logo" class="wp-image-11476" width="118" height="33"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":11473,"width":210,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Sony-Music.png" alt="Sony Music logo" class="wp-image-11473" width="210" height="33"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Sony-Music.png" alt="Sony Music logo" class="wp-image-11473" width="210" height="33"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":11479,"width":97,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Wired.png" alt="Wired Magazine logo" class="wp-image-11479" width="97" height="33"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Wired.png" alt="Wired Magazine logo" class="wp-image-11479" width="97" height="33"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":11482,"width":76,"height":33,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Disney.png" alt="Disney logo" class="wp-image-11482" width="76" height="33"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Disney.png" alt="Disney logo" class="wp-image-11482" width="76" height="33"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -166,7 +166,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:image {"align":"full","id":11477,"sizeSlug":"full","linkDestination":"none","style":{"color":[]}} -->
-<figure class="wp-block-image alignfull size-full"><img src="https://wordpress.org/files/2022/08/Showcase_2560.webp" alt="A gallery of screenshots showcasing various websites that use WordPress, and how they’ve each been uniquely designed using the platform." class="wp-image-11477"/></figure>
+<figure class="wp-block-image alignfull size-full"><img src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Showcase_2560.webp" alt="A gallery of screenshots showcasing various websites that use WordPress, and how they’ve each been uniquely designed using the platform." class="wp-image-11477"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -191,8 +191,8 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"100px"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"color":{"background":"#f6f6f6"}},"textColor":"blueberry-1","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-blueberry-1-color has-text-color has-background has-link-color" id="community" style="background-color:#f6f6f6;padding-bottom:100px"><!-- wp:cover {"url":"https://wordpress.org/files/2022/08/Community-Photo_2560.webp","id":11478,"dimRatio":0,"focalPoint":{"x":"0.50","y":"1.00"},"minHeight":500,"minHeightUnit":"px","isDark":false,"align":"full","style":{"color":[],"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"bottom":"60px"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="margin-bottom:60px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;min-height:500px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-11478" alt="A black and white bird’s eye view of the thousands of contributors who attended WordCamp Europe 2022. They are all standing in front of the venue with their hands up in celebration." src="https://wordpress.org/files/2022/08/Community-Photo_2560.webp" style="object-position:50% 100%" data-object-fit="cover" data-object-position="50% 100%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","fontSize":"large"} -->
+<div class="wp-block-group alignfull has-blueberry-1-color has-text-color has-background has-link-color" id="community" style="background-color:#f6f6f6;padding-bottom:100px"><!-- wp:cover {"url":"https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Community-Photo_2560.webp","id":11478,"dimRatio":0,"focalPoint":{"x":"0.50","y":"1.00"},"minHeight":500,"minHeightUnit":"px","isDark":false,"align":"full","style":{"color":[],"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"bottom":"60px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="margin-bottom:60px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;min-height:500px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-11478" alt="A black and white bird’s eye view of the thousands of contributors who attended WordCamp Europe 2022. They are all standing in front of the venue with their hands up in celebration." src="https://s.w.org/wp-content/blogs.dir/1/files/2022/08/Community-Photo_2560.webp" style="object-position:50% 100%" data-object-fit="cover" data-object-position="50% 100%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This uses CDN image URLs for front page images.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->


<!-- List out anyone who helped with this task. -->



### How to test the changes in this Pull Request:

1. Test before/after - should be no visual difference
2. Make sure images on the front page have `https://s.w.org/` URLs instead of `https://wordpress.org/`
3.

<!-- If you can, add the appropriate [Component] label(s). -->
