### PR TITLE
Content: Use the "Dots" style for the download page navigation

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -42,7 +42,7 @@
 <p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size">Recommend PHP [recommended_php] or greater and MySQL [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:navigation {"textColor":"blueberry-1","overlayMenu":"never","fontSize":"small"} -->
+<!-- wp:navigation {"textColor":"blueberry-1","overlayMenu":"never","fontSize":"small","className":"is-style-dots","style":{"spacing":{"blockGap":"0px"}}} -->
 <!-- wp:navigation-link {"label":"Releases","url":"https://wordpress.org/download/releases/","kind":"custom","isTopLevelLink":true} /-->
 
 <!-- wp:navigation-link {"label":"Nightly","url":"https://wordpress.org/download/beta-nightly/","kind":"custom","isTopLevelLink":true} /-->


### PR DESCRIPTION
Fixes #94 — The links were added in https://github.com/WordPress/wporg-main-2022/commit/e11c4a35144bf3c563c4afbbba1f0f6cb6dc883d, but I missed that they had little dots separating them. The Dots style was added as block style on the Navigation block in https://github.com/WordPress/wporg-parent-2021/pull/39. This applies that block style to this navigation.

### Screenshots

| Before | After |
|--------|-------|
| <img alt="" src="https://user-images.githubusercontent.com/541093/185245252-3bc08d16-00ab-4867-a2cb-a6ff9b555171.png"> | <img alt="" src="https://user-images.githubusercontent.com/541093/185245289-ec8e3654-9d5c-4eee-91a8-de13c7673c6f.png"> |

### How to test the changes in this Pull Request:

1. Check out the parent theme PR
2. Open the download page
3. The links below the download button should have `·` between them
