### PR TITLE
Build pattern files from post content

### DIFF
--- a/env/build-patterns.sh
+++ b/env/build-patterns.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Refresh pattern files from the staging site
+
+php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=front-page' --output 'source/wp-content/themes/wporg-main-2022/patterns/front-page.php'
+php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=download' --output 'source/wp-content/themes/wporg-main-2022/patterns/download.php'

--- a/env/build-patterns.sh
+++ b/env/build-patterns.sh
@@ -2,5 +2,7 @@
 
 # Refresh pattern files from the staging site
 
-php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=front-page' --output 'source/wp-content/themes/wporg-main-2022/patterns/front-page.php'
-php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=download' --output 'source/wp-content/themes/wporg-main-2022/patterns/download.php'
+#php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=front-page' --output 'source/wp-content/themes/wporg-main-2022/patterns/front-page.php'
+#php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=download' --output 'source/wp-content/themes/wporg-main-2022/patterns/download.php'
+
+php env/export-content.php --manifest 'env/page-manifest.json'

--- a/env/export-content.php
+++ b/env/export-content.php
@@ -55,6 +55,6 @@ EOF;
 	if ( false === $bytes ) {
 		die( 'Unable to write to ' . $output_path );
 	} else {
-		echo 'Wrote ' . number_format( $bytes ) . ' to ' . $output_path . "\n";
+		echo 'Wrote ' . number_format( $bytes ) . ' bytes to ' . $output_path . "\n";
 	}
 }

--- a/env/export-content.php
+++ b/env/export-content.php
@@ -1,0 +1,60 @@
+#!/usr/bin/php
+<?php
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+
+namespace WordPress_org\Main_2022\ImportTestContent;
+
+/**
+ * CLI script for exporting post content from the local DB to local pattern/template files.
+ *
+ * Intended to be run after import-content.php fetches the latest content from a remote prod/staging server.
+ *
+ * This is a vanilla PHP script, not a WP script.
+ *
+ */
+
+// This script should only be called in a CLI environment.
+if ( 'cli' != php_sapi_name() ) {
+	die();
+}
+
+$opts = getopt( 'u:o:', array( 'url:', 'output:' ) );
+
+$url = $opts['u'] ?? $opts['url'] ?? null;
+$output = $opts['o'] ?? $opts['output'] ?? null;
+
+if ( $url && $output ) {
+
+	$data = file_get_contents( $url );
+	if ( !$data ) {
+		die( "Unable to fetch {$url}\n" );
+	}
+
+	$posts = json_decode( $data );
+	$post = $posts[0] ?? null;
+	if ( !isset( $post->content_raw ) ) {
+		var_dump( $post );
+		die( "No content_raw available at {$url}\n" );
+	}
+
+	$header = <<<EOF
+<?php
+/**
+ * Title: {$post->title->rendered}
+ * Slug: wporg-main-2022/{$post->slug}
+ * Categories:
+ */
+
+?>
+
+EOF;
+
+	$output_path = $output;
+	$bytes = file_put_contents( $output_path, $header . $post->content_raw . "\n" );
+
+	if ( false === $bytes ) {
+		die( 'Unable to write to ' . $output_path );
+	} else {
+		echo 'Wrote ' . number_format( $bytes ) . ' to ' . $output_path . "\n";
+	}
+}

--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -3,6 +3,7 @@
 		"slug": "front-page"
 	},
 	{
-		"slug": "download"
+		"slug": "download",
+		"template": "page-download.html"
 	}
 ]

--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -1,0 +1,8 @@
+[
+	{
+		"slug": "front-page"
+	},
+	{
+		"slug": "download"
+	}
+]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"backstop:test": "npm exec backstop test",
 		"lighthouse": "lighthouse-ci http://localhost:8888/ --accessibility=100 --best-practices=100 --seo=100",
 		"lighthouse:desktop": "lighthouse http://localhost:8888/ --view --preset=desktop --output-path=lighthouse.html",
-		"lighthouse:mobile": "lighthouse http://localhost:8888/ --view --screenEmulation.mobile --output-path=lighthouse.html"
+		"lighthouse:mobile": "lighthouse http://localhost:8888/ --view --screenEmulation.mobile --output-path=lighthouse.html",
+		"build:patterns": "./env/build-patterns.sh"
 	},
 	"workspaces": [
 		"source/wp-content/themes/wporg-main-2022"


### PR DESCRIPTION
This adds a new `build:patterns` script that will generate updated pattern files in the theme, based on edited post content.

It includes some hard-coded parts initially, this is a starting point with some decisions still to make. For example:

* Currently it treats `w.org/main-test/` as the canonical source of content. Should that become w.org itself, or a staging site?
* Should it directly fetch the remote content (as it does now) or rely on 'setup:refresh' and use the local version of content?
* Which of those will make translation easier?
* Where should the URLs and corresponding output files be defined?
* How could it programatically discover newly created pages on the staging/canonical site?
* Should this be done locally by devs, or as part of the sandbox sync?

To use/test:

```bash
yarn build:patterns
```

..then `git diff` and check that it has generated updated files in `source/wp-content/themes/wporg-main-2022/patterns`.


