### PR TITLE
Preload the the heading fonts.

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -2,6 +2,8 @@
 
 namespace WordPressdotorg\Theme\Main_2022;
 
+use function WordPressdotorg\MU_Plugins\Global_Header_Footer\is_rosetta_site;
+
 require_once( __DIR__ . '/inc/page-meta-descriptions.php' );
 require_once( __DIR__ . '/inc/hreflang.php' );
 require_once( __DIR__ . '/inc/capabilities.php' );
@@ -62,12 +64,15 @@ function enqueue_assets() {
 
 	// Preload the heading font(s).
 	if ( is_callable( 'global_fonts_preload' ) ) {
-		// All headings.
-		global_fonts_preload( 'EB Garamond Latin' );
+		// TODO: Load required fonts for rosetta sites once they are supported.
+		if ( ! is_rosetta_site() ) {
+			// All headings.
+			global_fonts_preload( 'EB Garamond Latin' );
 
-		if ( is_front_page() ) {
-			// The heading on the front-page has some italic.
-			global_fonts_preload( 'EB Garamond Latin italic' );
+			if ( is_front_page() ) {
+				// The heading on the front-page has some italic.
+				global_fonts_preload( 'EB Garamond Latin italic' );
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -59,6 +59,17 @@ function enqueue_assets() {
 		);
 		wp_style_add_data( 'wporg-main-2022-download-style', 'rtl', 'replace' );
 	}
+
+	// Preload the heading font(s).
+	if ( is_callable( 'global_fonts_preload' ) ) {
+		// All headings.
+		global_fonts_preload( 'EB Garamond' );
+
+		if ( is_front_page() ) {
+			// The heading on the front-page has some italic.
+			global_fonts_preload( 'EB Garamond italic' );
+		}
+	}
 }
 
 /**

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -63,11 +63,11 @@ function enqueue_assets() {
 	// Preload the heading font(s).
 	if ( is_callable( 'global_fonts_preload' ) ) {
 		// All headings.
-		global_fonts_preload( 'EB Garamond' );
+		global_fonts_preload( 'EB Garamond Latin' );
 
 		if ( is_front_page() ) {
 			// The heading on the front-page has some italic.
-			global_fonts_preload( 'EB Garamond italic' );
+			global_fonts_preload( 'EB Garamond Latin italic' );
 		}
 	}
 }


### PR DESCRIPTION
This uses the changes in https://github.com/WordPress/wporg-mu-plugins/pull/247 to preload the homepage heading fonts.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #92

<!-- List out anyone who helped with this task. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| image  | image |

### How to test the changes in this Pull Request:

1. View source of https://wordpress.org/, note no preloaded fonts.
2. Apply https://github.com/WordPress/wporg-mu-plugins/pull/247 + This PR
3. View source of https://wordpress.org, note the preloaded fonts after the opening `<head>`

<!-- If you can, add the appropriate [Component] label(s). -->
