### PR TITLE
Add "Cycle Headings" block to animate through a list of headings.

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -5,6 +5,9 @@ namespace WordPressdotorg\Theme\Main_2022;
 require_once( __DIR__ . '/inc/page-meta-descriptions.php' );
 require_once( __DIR__ . '/inc/hreflang.php' );
 
+// Block files
+require_once( __DIR__ . '/src/cycle-headings/index.php' );
+
 /**
  * Actions and filters.
  */

--- a/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
@@ -9,9 +9,9 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"120px","right":"0px","bottom":"120px","left":"0px"},"blockGap":"30px"}},"layout":{"inherit":false}} -->
 <div class="wp-block-group alignwide" id="intro" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px"><!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"85%"} -->
-<div class="wp-block-column" style="flex-basis:85%"><!-- wp:heading {"level":1,"textColor":"charcoal-1","fontSize":"heading-cta"} -->
-<h1 class="has-charcoal-1-color has-text-color has-heading-cta-font-size">WordPress: Publish your <em>passion</em></h1>
-<!-- /wp:heading --></div>
+<div class="wp-block-column" style="flex-basis:85%">
+	<!-- wp:wporg/cycle-heading {"fontSize":"heading-cta"} /-->
+</div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"15%"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
@@ -8,14 +8,14 @@
 ?>
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"120px","right":"0px","bottom":"120px","left":"0px"},"blockGap":"30px"}},"layout":{"inherit":false}} -->
 <div class="wp-block-group alignwide" id="intro" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px"><!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
-<div class="wp-block-columns"><!-- wp:column {"width":"85%"} -->
-<div class="wp-block-column" style="flex-basis:85%">
+<div class="wp-block-columns"><!-- wp:column {"width":"80%"} -->
+<div class="wp-block-column" style="flex-basis:80%">
 	<!-- wp:wporg/cycle-headings {"fontSize":"heading-cta"} /-->
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"15%"} -->
-<div class="wp-block-column" style="flex-basis:15%"></div>
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/front-page.php
@@ -10,7 +10,7 @@
 <div class="wp-block-group alignwide" id="intro" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px"><!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"85%"} -->
 <div class="wp-block-column" style="flex-basis:85%">
-	<!-- wp:wporg/cycle-heading {"fontSize":"heading-cta"} /-->
+	<!-- wp:wporg/cycle-headings {"fontSize":"heading-cta"} /-->
 </div>
 <!-- /wp:column -->
 

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/cycle-heading",
+	"version": "0.1.0",
+	"title": "Cycle Headings",
+	"category": "design",
+	"icon": "heading",
+	"description": "Animate through a set of headings.",
+	"textdomain": "wporg",
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js"
+}

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
@@ -8,6 +8,22 @@
 	"icon": "heading",
 	"description": "Animate through a set of headings.",
 	"textdomain": "wporg",
+	"supports": {
+		"align": true,
+		"color": {
+			"background": true,
+			"text": true
+		},
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
 	"editorScript": "file:./index.js",
 	"viewScript": "file:./view.js",
 	"style": "file:./style-index.css"

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "wporg/cycle-heading",
+	"name": "wporg/cycle-headings",
 	"version": "0.1.0",
 	"title": "Cycle Headings",
 	"category": "design",

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/block.json
@@ -9,5 +9,6 @@
 	"description": "Animate through a set of headings.",
 	"textdomain": "wporg",
 	"editorScript": "file:./index.js",
-	"viewScript": "file:./view.js"
+	"viewScript": "file:./view.js",
+	"style": "file:./style-index.css"
 }

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/edit.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/edit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 
 /**
@@ -11,5 +10,9 @@ import { useBlockProps } from '@wordpress/block-editor';
  * @return {WPElement} Element to render.
  */
 export default function Edit() {
-	return <p { ...useBlockProps() }>{ __( '{{title}} – hello from the editor!', 'wporg' ) }</p>;
+	return (
+		<h1 { ...useBlockProps() }>
+			WordPress: Publish your <em>passion</em>
+		</h1>
+	);
 }

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/edit.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/edit.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	return <p { ...useBlockProps() }>{ __( '{{title}} – hello from the editor!', 'wporg' ) }</p>;
+}

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.js
@@ -8,6 +8,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import Edit from './edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	edit: Edit,

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
@@ -43,13 +43,19 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$headings = array(
-		'Publish your <em>passion</em>',
-		'Start your <em>podcast</em>',
-		'Lorem your <em>ipsum</em>',
+		__( 'Publish your <em>passion</em>', 'wporg' ),
+		__( 'Grow your <em>business</em>', 'wporg' ),
+		__( 'Flex your <em>freedom</em>', 'wporg' ),
 	);
 
-	$content = '<h1 class="screen-reader-text">WordPress: Publish your passion</h1>';
-	$content .= '<div aria-hidden="true">WordPress: <span class="wp-block-wporg-cycle-headings__container">' . $headings[0] . '</span></div>';
+	$content = '<h1 class="screen-reader-text">' . __( 'WordPress: Publish your passion', 'wporg' ) . '</h1>';
+	$content .= '<div aria-hidden="true">';
+	$content .= sprintf(
+		/* translators: %s Changing heading fragment, ex: "Publish your passion" */
+		__( 'WordPress: %s', 'wporg' ),
+		'<span class="wp-block-wporg-cycle-headings__container">' . $headings[0] . '</span>'
+	);
+	$content .= '</div>';
 
 	foreach ( $headings as $heading ) {
 		$content .= sprintf( '<p class="screen-reader-text">%s</p>', $heading );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
@@ -43,9 +43,9 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$headings = array(
-		'Publish your passion',
-		'Start your podcast',
-		'Do your thing',
+		'Publish your <em>passion</em>',
+		'Start your <em>podcast</em>',
+		'Do your <em>thing</em>',
 	);
 
 	$content = '<h1 class="screen-reader-text">WordPress: Publish your passion</h1>';

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
@@ -45,14 +45,14 @@ function render( $attributes, $content, $block ) {
 	$headings = array(
 		'Publish your <em>passion</em>',
 		'Start your <em>podcast</em>',
-		'Do your <em>thing</em>',
+		'Lorem your <em>ipsum</em>',
 	);
 
 	$content = '<h1 class="screen-reader-text">WordPress: Publish your passion</h1>';
 	$content .= '<div aria-hidden="true">WordPress: <span class="wp-block-wporg-cycle-headings__container">' . $headings[0] . '</span></div>';
 
 	foreach ( $headings as $heading ) {
-		$content .= sprintf( '<p class="screen-reader-text">WordPress: <span>%s</span></p>', $heading );
+		$content .= sprintf( '<p class="screen-reader-text">%s</p>', $heading );
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Block Name: Cycle Headings
+ * Description: Animate through a set of headings.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Main_2022\Cycle_Headings_Block;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/cycle-headings',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! empty( $block->block_type->view_script ) ) {
+		wp_enqueue_script( $block->block_type->view_script );
+		// Move to footer.
+		wp_script_add_data( $block->block_type->view_script, 'group', 1 );
+	}
+
+	$headings = array(
+		'Publish your passion',
+		'Start your podcast',
+		'Do your thing',
+	);
+
+	$content = '<h1 class="screen-reader-text">WordPress: Publish your passion</h1>';
+	$content .= '<div class="wp-block-wporg-cycle-heading-container"></div>';
+
+	foreach ( $headings as $heading ) {
+		$content .= sprintf( '<p>WordPress: %s</p>', $heading );
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$content
+	);
+}

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
@@ -49,10 +49,10 @@ function render( $attributes, $content, $block ) {
 	);
 
 	$content = '<h1 class="screen-reader-text">WordPress: Publish your passion</h1>';
-	$content .= '<div class="wp-block-wporg-cycle-heading-container"></div>';
+	$content .= '<div aria-hidden="true">WordPress: <span class="wp-block-wporg-cycle-heading-container">' . $headings[0] . '</span></div>';
 
 	foreach ( $headings as $heading ) {
-		$content .= sprintf( '<p>WordPress: %s</p>', $heading );
+		$content .= sprintf( '<p class="screen-reader-text">WordPress: <span>%s</span></p>', $heading );
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/index.php
@@ -49,7 +49,7 @@ function render( $attributes, $content, $block ) {
 	);
 
 	$content = '<h1 class="screen-reader-text">WordPress: Publish your passion</h1>';
-	$content .= '<div aria-hidden="true">WordPress: <span class="wp-block-wporg-cycle-heading-container">' . $headings[0] . '</span></div>';
+	$content .= '<div aria-hidden="true">WordPress: <span class="wp-block-wporg-cycle-headings__container">' . $headings[0] . '</span></div>';
 
 	foreach ( $headings as $heading ) {
 		$content .= sprintf( '<p class="screen-reader-text">WordPress: <span>%s</span></p>', $heading );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/style.scss
@@ -1,4 +1,4 @@
-.wp-block-wporg-cycle-heading {
+.wp-block-wporg-cycle-headings {
 	font-family: var(--wp--custom--heading--typography--font-family);
 	font-size: var(--wp--preset--font-size--heading-1);
 	font-weight: var(--wp--custom--heading--typography--font-weight);

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/style.scss
@@ -1,0 +1,16 @@
+.wp-block-wporg-cycle-heading {
+	font-family: var(--wp--custom--heading--typography--font-family);
+	font-size: var(--wp--preset--font-size--heading-1);
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--level-1--typography--line-height);
+
+	span.is-ready {
+		opacity: 0;
+		transition: opacity 0.2s cubic-bezier(0.63, 0, 0.54, 0.995);
+	}
+
+	span.fade-in {
+		opacity: 1;
+		transition: opacity 0.3s cubic-bezier(0.63, 0, 0.54, 0.995);
+	}
+}

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -4,7 +4,7 @@ const MS_DELAY_BETWEEN_ITEMS = 500;
 
 function textFragmentIterator() {
 	let currentIteration = 0;
-	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-headings p > span' ) ).map(
+	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-headings p' ) ).map(
 		( elem ) => elem.innerHTML
 	);
 

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -1,6 +1,6 @@
 // Set up the dynamic text in the hero section of the Home page.
-const MS_DURATION_PER_ITEM = 5000;
-const MS_DELAY_BETWEEN_ITEMS = 500; // Should equal the sum of transition duration in CSS.
+const DURATION_PER_ITEM_MS = 5000;
+const DELAY_BETWEEN_ITEMS_MS = 500; // Should equal the sum of transition duration in CSS.
 
 function textFragmentIterator() {
 	let currentIteration = 0;
@@ -20,7 +20,7 @@ function init() {
 
 	window.setTimeout( () => {
 		targetNode.classList.add( 'is-ready' );
-	}, MS_DURATION_PER_ITEM - 1 );
+	}, DURATION_PER_ITEM_MS - 1 );
 
 	window.setInterval( () => {
 		targetNode.classList.remove( 'fade-in' );
@@ -28,8 +28,8 @@ function init() {
 		window.setTimeout( () => {
 			targetNode.innerHTML = getNextTextFragment();
 			targetNode.classList.add( 'fade-in' );
-		}, MS_DELAY_BETWEEN_ITEMS );
-	}, MS_DURATION_PER_ITEM );
+		}, DELAY_BETWEEN_ITEMS_MS );
+	}, DURATION_PER_ITEM_MS );
 }
 
 const wantMotionQuery = window.matchMedia( '(prefers-reduced-motion)' );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -4,8 +4,8 @@ const MS_DELAY_BETWEEN_ITEMS = 500;
 
 function textFragmentIterator() {
 	let currentIteration = 0;
-	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-heading p' ) ).map(
-		( elem ) => elem.textContent
+	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-heading p > span' ) ).map(
+		( elem ) => elem.innerHTML
 	);
 
 	return () => {
@@ -25,7 +25,7 @@ window.setInterval( () => {
 	targetNode.classList.remove( 'fade-in' );
 
 	window.setTimeout( () => {
-		targetNode.textContent = getNextTextFragment();
+		targetNode.innerHTML = getNextTextFragment();
 		targetNode.classList.add( 'fade-in' );
 	}, MS_DELAY_BETWEEN_ITEMS );
 }, MS_DURATION_PER_ITEM );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -1,3 +1,6 @@
+// Code originally forked from https://wordpress.com/p2/
+// https://github.com/Automattic/p2/blob/master/themes/marketing/src/js/hero-dynamic-text.js
+
 // Set up the dynamic text in the hero section of the Home page.
 const DURATION_PER_ITEM_MS = 5000;
 const DELAY_BETWEEN_ITEMS_MS = 500; // Should equal the sum of transition duration in CSS.

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -1,5 +1,5 @@
 // Set up the dynamic text in the hero section of the Home page.
-const MS_DURATION_PER_ITEM = 4000;
+const MS_DURATION_PER_ITEM = 5000;
 const MS_DELAY_BETWEEN_ITEMS = 500;
 
 function textFragmentIterator() {

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -14,18 +14,26 @@ function textFragmentIterator() {
 	};
 }
 
-const getNextTextFragment = textFragmentIterator();
-const targetNode = document.querySelector( '.wp-block-wporg-cycle-heading-container' );
-
-window.setTimeout( () => {
-	targetNode.classList.add( 'is-ready' );
-}, MS_DURATION_PER_ITEM - 1 );
-
-window.setInterval( () => {
-	targetNode.classList.remove( 'fade-in' );
+function init() {
+	const getNextTextFragment = textFragmentIterator();
+	const targetNode = document.querySelector( '.wp-block-wporg-cycle-heading-container' );
 
 	window.setTimeout( () => {
-		targetNode.innerHTML = getNextTextFragment();
-		targetNode.classList.add( 'fade-in' );
-	}, MS_DELAY_BETWEEN_ITEMS );
-}, MS_DURATION_PER_ITEM );
+		targetNode.classList.add( 'is-ready' );
+	}, MS_DURATION_PER_ITEM - 1 );
+
+	window.setInterval( () => {
+		targetNode.classList.remove( 'fade-in' );
+
+		window.setTimeout( () => {
+			targetNode.innerHTML = getNextTextFragment();
+			targetNode.classList.add( 'fade-in' );
+		}, MS_DELAY_BETWEEN_ITEMS );
+	}, MS_DURATION_PER_ITEM );
+}
+
+const wantMotionQuery = window.matchMedia( '(prefers-reduced-motion)' );
+
+if ( ! wantMotionQuery.matches ) {
+	init();
+}

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -1,0 +1,31 @@
+// Set up the dynamic text in the hero section of the Home page.
+const MS_DURATION_PER_ITEM = 4000;
+const MS_DELAY_BETWEEN_ITEMS = 500;
+
+function textFragmentIterator() {
+	let currentIteration = 0;
+	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-heading p' ) ).map(
+		( elem ) => elem.textContent
+	);
+
+	return () => {
+		const index = ++currentIteration % fragments.length;
+		return fragments[ index ];
+	};
+}
+
+const getNextTextFragment = textFragmentIterator();
+const targetNode = document.querySelector( '.wp-block-wporg-cycle-heading-container' );
+
+window.setTimeout( () => {
+	targetNode.classList.add( 'is-ready' );
+}, MS_DURATION_PER_ITEM - 1 );
+
+window.setInterval( () => {
+	targetNode.classList.remove( 'fade-in' );
+
+	window.setTimeout( () => {
+		targetNode.textContent = getNextTextFragment();
+		targetNode.classList.add( 'fade-in' );
+	}, MS_DELAY_BETWEEN_ITEMS );
+}, MS_DURATION_PER_ITEM );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -4,7 +4,7 @@ const MS_DELAY_BETWEEN_ITEMS = 500;
 
 function textFragmentIterator() {
 	let currentIteration = 0;
-	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-heading p > span' ) ).map(
+	const fragments = Array.from( document.querySelectorAll( '.wp-block-wporg-cycle-headings p > span' ) ).map(
 		( elem ) => elem.innerHTML
 	);
 
@@ -16,7 +16,7 @@ function textFragmentIterator() {
 
 function init() {
 	const getNextTextFragment = textFragmentIterator();
-	const targetNode = document.querySelector( '.wp-block-wporg-cycle-heading-container' );
+	const targetNode = document.querySelector( '.wp-block-wporg-cycle-headings__container' );
 
 	window.setTimeout( () => {
 		targetNode.classList.add( 'is-ready' );

--- a/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/cycle-headings/view.js
@@ -1,6 +1,6 @@
 // Set up the dynamic text in the hero section of the Home page.
 const MS_DURATION_PER_ITEM = 5000;
-const MS_DELAY_BETWEEN_ITEMS = 500;
+const MS_DELAY_BETWEEN_ITEMS = 500; // Should equal the sum of transition duration in CSS.
 
 function textFragmentIterator() {
 	let currentIteration = 0;

--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -68,6 +68,10 @@
 		padding-left: var(--wp--preset--spacing--30);
 		padding-right: var(--wp--preset--spacing--30);
 	}
+
+	#intro .wp-block-columns {
+		display: block;
+	}
 }
 
 @media (max-width: 1000px) {


### PR DESCRIPTION
Add a new block, "Cycle Headings." This block renders "WordPress: _____", where the blank space cycles through a set of phrases.

- Publish your passion
- Grow your business
- Flex your freedom.

These change after 5 seconds.

Semantically, it renders a hidden heading (h1) & paragraphs, and this visual content is hidden from screen readers. JS is used to swap the displayed text, with a CSS transition on the opacity. This a version of the code used on [the p2 landing site](https://wordpress.com/p2/), tweaked to work with the block output.

The front-page template is updated to use this block.

Fixes #101.

Screen reader users will hear "Heading level 1: WordPress: Publish your passion. Publish your passion. Grow your business. Flex your freedom."

There is no change to the headings if you're using "prefers reduced motion", just to be safe.

### Screenshots

https://user-images.githubusercontent.com/541093/186962227-4ffb1c4c-e38f-4cd1-b50d-fcc6c47ce58a.mp4

In the editor, it's just a static block with the main heading. Eventually we could offer some way to enter a few headings & pass them through as attributes (TBH I could add this pretty quickly now, just as some text inputs in the sidebar). Font size & spacing can be controlled here, though it defaults to the H1 styling.

<img width="1062" alt="Screen Shot 2022-08-26 at 1 42 30 PM" src="https://user-images.githubusercontent.com/541093/186962240-a0c22d80-101c-4010-9885-51126e400bb5.png">

_Fonts don't load in the editor on local envs, it's correct on w.org_

### How to test the changes in this Pull Request:

1. Build the branch, `yarn workspace wporg-main-2022-theme build`
2. Load the front page
3. Wait 5 seconds, you should see the heading change
4. It should cycle through all 3 headings

Optionally…
- Try with a screen reader - it should make sense
- Try with reduced motion on (will need to reload the page) - it won't change