### PR TITLE
Allow post content edits to be viewed by Editors

### DIFF
--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -90,6 +90,8 @@ add_action(
 						);
 
 						if ( $count > 0 ) {
+							$_wp_current_template_content = str_replace( [ '"layout":{"inherit":true},"className":"entry-content",', ' entry-content' ], '', $_wp_current_template_content );
+
 							add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_preview_indicator', 1000 );
 						}
 					}

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -56,6 +56,7 @@ function admin_bar_preview_indicator( $wp_admin_bar ) {
 		[
 			'id'    => 'preview-indicator',
 			'title' => '<span class="ab-icon dashicons-admin-appearance"></span> ' . $text,
+			'href'  => get_permalink( get_queried_object_id() ),
 			'meta'  => [
 				'class' => 'preview-indicator',
 			],

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -15,6 +15,11 @@ namespace WordPressdotorg\MU_Plugins\Theme_Switcher;
  * Helper to check the requested page against our new page list.
  */
 function should_use_new_theme() {
+	// Front-page sites only.
+	if ( function_exists( '\get_blog_details' ) && '/' !== \get_blog_details( null, false )->path ) {
+		return false;
+	}
+
 	// Request to resolve a template.
 	if ( isset( $_GET['_wp-find-template'] ) ) {
 		return true;

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -52,10 +52,6 @@ if ( 'production' !== wp_get_environment_type() ) {
 // Only if the user is logged in and can edit posts:
 // Override the block template, to force loading post_content instead of the hard-coded pattern file.
 // This is so that content and design can be edited or created in-place.
-// TODO:
-// * Make this work cleanly and sensibly for posts that use the old theme;
-// * Add a better indicator of post content vs pattern content than 'THIS IS POST CONTENT'
-// * Figure out permissions etc so that preview links can be sent to reviewers
 add_action(
 	'init',
 	function() {

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -25,6 +25,11 @@ function should_use_new_theme() {
 		return true;
 	}
 
+	// Preview. Can't call is_preview() this early in the process.
+	if ( isset( $_GET['preview'] ) && isset( $_GET['preview_id'] ) ) {
+		return true;
+	}
+
 	$new_theme_pages = array(
 		'/',
 		'/download/',
@@ -60,12 +65,31 @@ add_action(
 				function( $template ) {
 					global $_wp_current_template_content;
 
-					$_wp_current_template_content = preg_replace(
-						'#<!-- wp:pattern {"slug":"wporg-main-2022/[\w-]+"} /-->#',
-						'<p>THIS IS POST CONTENT</p><!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->',
-						$_wp_current_template_content,
-						1
-					);
+					if ( is_preview() ) {
+						$count = 0;
+						$_wp_current_template_content = preg_replace(
+							'#<!-- wp:pattern {"slug":"wporg-main-2022/[\w-]+"} /-->#',
+							'<!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->',
+							$_wp_current_template_content,
+							1,
+							$count
+						);
+
+						if ( $count > 0 ) {
+							add_action( 'admin_bar_menu', function( $wp_admin_bar ) {
+								$text = 'Previewing post content';
+
+								$wp_admin_bar->add_node( [
+									'id'    => 'preview-indicator',
+									'title' => '<span class="ab-icon dashicons-admin-appearance"></span> ' . $text,
+									'meta'  => [
+										'class' => 'preview-indicator',
+									]
+								] );
+							}, 1000 );
+
+						}
+					}
 
 					return $template;
 				}

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -41,11 +41,15 @@ function should_use_new_theme() {
 // Always show admin bar.
 add_filter( 'show_admin_bar', '__return_true' );
 
-if ( 'production' !== wp_get_environment_type() ) {
-	if ( ! should_use_new_theme() ) {
+if ( ! should_use_new_theme() ) {
+	if ( 'local' === wp_get_environment_type() ) {
 		// Enable the old parent & child themes.
 		add_filter( 'template', function() { return 'wporg'; } );
 		add_filter( 'stylesheet', function() { return 'wporg-main'; } );
+	} else {
+		// Slightly different paths for old themes on sandbox/producton
+		add_filter( 'template', function() { return 'pub/wporg'; } );
+		add_filter( 'stylesheet', function() { return 'pub/wporg-main'; } );
 	}
 }
 

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -38,8 +38,10 @@ function should_use_new_theme() {
 	return isset( $_SERVER['REQUEST_URI'] ) && in_array( $_SERVER['REQUEST_URI'], $new_theme_pages );
 }
 
-// Always show admin bar.
-add_filter( 'show_admin_bar', '__return_true' );
+// Always show admin bar on local test site
+if ( 'local' === wp_get_environment_type() ) {
+	add_filter( 'show_admin_bar', '__return_true' );
+}
 
 if ( ! should_use_new_theme() ) {
 	if ( 'local' === wp_get_environment_type() ) {

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -49,6 +49,20 @@ if ( 'production' !== wp_get_environment_type() ) {
 	}
 }
 
+function admin_bar_preview_indicator( $wp_admin_bar ) {
+	$text = 'Previewing post content';
+
+	$wp_admin_bar->add_node(
+		[
+			'id'    => 'preview-indicator',
+			'title' => '<span class="ab-icon dashicons-admin-appearance"></span> ' . $text,
+			'meta'  => [
+				'class' => 'preview-indicator',
+			],
+		]
+	);
+}
+
 // Only if the user is logged in and can edit posts:
 // Override the block template, to force loading post_content instead of the hard-coded pattern file.
 // This is so that content and design can be edited or created in-place.
@@ -72,24 +86,7 @@ add_action(
 						);
 
 						if ( $count > 0 ) {
-							add_action(
-								'admin_bar_menu',
-								function( $wp_admin_bar ) {
-									$text = 'Previewing post content';
-
-									$wp_admin_bar->add_node(
-										[
-											'id'    => 'preview-indicator',
-											'title' => '<span class="ab-icon dashicons-admin-appearance"></span> ' . $text,
-											'meta'  => [
-												'class' => 'preview-indicator',
-											],
-										]
-									);
-								},
-								1000
-							);
-
+							add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_preview_indicator', 1000 );
 						}
 					}
 

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -49,11 +49,6 @@ function should_use_new_theme() {
 	return ( 'wporg-main-2022' === get_option( 'stylesheet' ) );
 }
 
-// Always show admin bar on local test site
-if ( 'local' === wp_get_environment_type() ) {
-	add_filter( 'show_admin_bar', '__return_true' );
-}
-
 if ( ! should_use_new_theme() ) {
 	if ( 'local' === wp_get_environment_type() ) {
 		// Enable the old parent & child themes.

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -51,18 +51,25 @@ if ( 'production' !== wp_get_environment_type() ) {
 // * Make this work cleanly and sensibly for posts that use the old theme;
 // * Add a better indicator of post content vs pattern content than 'THIS IS POST CONTENT'
 // * Figure out permissions etc so that preview links can be sent to reviewers
-add_action( 'init', function() {
-	if ( current_user_can( 'edit_posts' ) ) {
-		add_filter( 'template_include', function( $template ) {
-			global $_wp_current_template_content;
+add_action(
+	'init',
+	function() {
+		if ( current_user_can( 'edit_posts' ) ) {
+			add_filter(
+				'template_include',
+				function( $template ) {
+					global $_wp_current_template_content;
 
-			$_wp_current_template_content = preg_replace(
-				'#<!-- wp:pattern {"slug":"wporg-main-2022/[\w-]+"} /-->#',
-				'<p>THIS IS POST CONTENT</p><!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->',
-				$_wp_current_template_content,
-			1 );
+					$_wp_current_template_content = preg_replace(
+						'#<!-- wp:pattern {"slug":"wporg-main-2022/[\w-]+"} /-->#',
+						'<p>THIS IS POST CONTENT</p><!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->',
+						$_wp_current_template_content,
+						1
+					);
 
-			return $template;
-		} );
+					return $template;
+				}
+			);
+		}
 	}
-} );
+);

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -76,17 +76,23 @@ add_action(
 						);
 
 						if ( $count > 0 ) {
-							add_action( 'admin_bar_menu', function( $wp_admin_bar ) {
-								$text = 'Previewing post content';
+							add_action(
+								'admin_bar_menu',
+								function( $wp_admin_bar ) {
+									$text = 'Previewing post content';
 
-								$wp_admin_bar->add_node( [
-									'id'    => 'preview-indicator',
-									'title' => '<span class="ab-icon dashicons-admin-appearance"></span> ' . $text,
-									'meta'  => [
-										'class' => 'preview-indicator',
-									]
-								] );
-							}, 1000 );
+									$wp_admin_bar->add_node(
+										[
+											'id'    => 'preview-indicator',
+											'title' => '<span class="ab-icon dashicons-admin-appearance"></span> ' . $text,
+											'meta'  => [
+												'class' => 'preview-indicator',
+											],
+										]
+									);
+								},
+								1000
+							);
 
 						}
 					}

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -49,6 +49,9 @@ if ( 'production' !== wp_get_environment_type() ) {
 	}
 }
 
+/**
+ * Action to add text indicator to the admin bar when previewing post content (as opposed to a pattern file)
+ */
 function admin_bar_preview_indicator( $wp_admin_bar ) {
 	$text = 'Previewing post content';
 

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -43,3 +43,26 @@ if ( 'production' !== wp_get_environment_type() ) {
 		add_filter( 'stylesheet', function() { return 'wporg-main'; } );
 	}
 }
+
+// Only if the user is logged in and can edit posts:
+// Override the block template, to force loading post_content instead of the hard-coded pattern file.
+// This is so that content and design can be edited or created in-place.
+// TODO:
+// * Make this work cleanly and sensibly for posts that use the old theme;
+// * Add a better indicator of post content vs pattern content than 'THIS IS POST CONTENT'
+// * Figure out permissions etc so that preview links can be sent to reviewers
+add_action( 'init', function() {
+	if ( current_user_can( 'edit_posts' ) ) {
+		add_filter( 'template_include', function( $template ) {
+			global $_wp_current_template_content;
+
+			$_wp_current_template_content = preg_replace(
+				'#<!-- wp:pattern {"slug":"wporg-main-2022/[\w-]+"} /-->#',
+				'<p>THIS IS POST CONTENT</p><!-- wp:post-content {"layout":{"inherit":true},"style":{"spacing":{"blockGap":"0px"}}} /-->',
+				$_wp_current_template_content,
+			1 );
+
+			return $template;
+		} );
+	}
+} );

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -102,7 +102,9 @@ function replace_template_content_for_preview( $template ) {
 
 		if ( $count > 0 ) {
 			$_wp_current_template_content = str_replace( [ '"layout":{"inherit":true},"className":"entry-content",', ' entry-content' ], '', $_wp_current_template_content );
+		}
 
+		if ( false !== strpos( $_wp_current_template_content, '<!-- wp:post-content ' ) ) {
 			add_action( 'admin_bar_menu', __NAMESPACE__ . '\admin_bar_preview_indicator', 1000 );
 		}
 	}

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -36,7 +36,7 @@ function should_use_new_theme() {
 	}
 
 	// Check if the page being requested isn't supported by the new theme, it should fall-back to the old theme if so.
-	$request_uri     = explode( '?', $_SERVER['REQUEST_URI'] ?? '/' )[0];
+	$request_uri     = isset( $_SERVER['REQUEST_URI'] ) ? explode( '?', esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '/' )[0] : '/';
 	$new_theme_pages = array(
 		'/',
 		'/download/',

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -35,12 +35,18 @@ function should_use_new_theme() {
 		return true;
 	}
 
+	// Check if the page being requested isn't supported by the new theme, it should fall-back to the old theme if so.
+	$request_uri     = explode( '?', $_SERVER['REQUEST_URI'] ?? '/' )[0];
 	$new_theme_pages = array(
 		'/',
 		'/download/',
 	);
+	if ( ! in_array( $request_uri, $new_theme_pages ) ) {
+		return false;
+	}
 
-	return isset( $_SERVER['REQUEST_URI'] ) && in_array( $_SERVER['REQUEST_URI'], $new_theme_pages );
+	// If the new theme is the active theme, we should use it, otherwise, we should use the old theme.
+	return ( 'wporg-main-2022' === get_option( 'stylesheet' ) );
 }
 
 // Always show admin bar on local test site


### PR DESCRIPTION
Still WIP, but this adds another piece of the editing workflow: allow Editors to see post_content when viewing the site, overriding the pattern file. That way they can preview and "publish" their edits, and reviewers with the appropriate creds can see it.

This could be used in staging or production, depending on how confident we are and what makes sense for the workflow.

Still a few things to resolve:

* Make this work cleanly and sensibly for posts that use the old theme;
* Add a better indicator of post content vs pattern content than 'THIS IS POST CONTENT'
* Figure out permissions etc so that preview links can be sent to reviewers (if that even makes sense)

To test:

1. Run `yarn setup:refresh` to make sure you have some post content.
2. View `localhost:8888` while logged out and confirm it matches main-test content.
3. Log in and edit the front page post content with an obvious change. Click Update.
4. View `localhost:8888` while logged *in* and confirm you can see your change. Also `THIS IS POST CONTENT` at the top.
5. View `localhost:8888` while logged *out* and confirm you see the original pattern without your change.

Logged in view example with edit (red heading):

<img width="1357" alt="Screen Shot 2022-08-29 at 5 24 57 pm" src="https://user-images.githubusercontent.com/7200686/187146752-dc7bae4e-5216-4c7d-a912-af365a0dfe09.png">

Logged out view showing the pattern file instead of edited post_content:
<img width="1302" alt="Screen Shot 2022-08-29 at 5 24 44 pm" src="https://user-images.githubusercontent.com/7200686/187146878-5b4f194f-c85e-4bb9-8284-c929e063a566.png">

This would look better on a prod server because of missing media files.


See #55.