### PR TITLE
Theme: Add workaround for unsupported CSS4 selectors

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -227,3 +227,34 @@
 	padding-left: 0;
 	margin-bottom: 0;
 }
+
+
+/*
+ * Workaround for Gutenberg CSS4 selectors on older browsers.
+ *
+ * @link https://github.com/WordPress/gutenberg/issues/43723.
+ *
+ * Reproducing gutenberg_get_layout_style() isn't practical, so this just hardcodes the needed values.
+ *
+ * Remove this when the above issue is fixed in a stable release.
+ */
+.wp-block-group[class*="wp-container-"],
+.wp-block-columns[class*="wp-container-"],
+.wp-block-group[class*="wp-container-"] > *,
+.wp-block-columns[class*="wp-container-"] > *,
+[class*="wp-container-"] .wp-block-buttons {
+	margin-left: auto !important;
+	margin-right: auto !important;
+}
+
+.wp-block-group[class*="wp-container-"].entry-content,
+.wp-block-group[class*="wp-container-"][class*="is-content-justification-"] > * {
+	margin-left: unset !important;
+	margin-right: unset !important;
+}
+
+#benefits .wp-block-group[class*="wp-container-"],
+#community .wp-block-group[class*="wp-container-"],
+#editor .wp-block-group[class*="wp-container-"] {
+	max-width: 520px;
+}

--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -238,23 +238,18 @@
  *
  * Remove this when the above issue is fixed in a stable release.
  */
-.wp-block-group[class*="wp-container-"],
-.wp-block-columns[class*="wp-container-"],
-.wp-block-group[class*="wp-container-"] > *,
-.wp-block-columns[class*="wp-container-"] > *,
-[class*="wp-container-"] .wp-block-buttons {
+body .is-layout-constrained > * {
+	max-width: var(--wp--style--global--content-size);
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
 
-.wp-block-group[class*="wp-container-"].entry-content,
-.wp-block-group[class*="wp-container-"][class*="is-content-justification-"] > * {
-	margin-left: unset !important;
-	margin-right: unset !important;
+body .is-layout-constrained > .alignwide {
+	max-width: var(--wp--style--global--wide-size);
 }
 
-#benefits .wp-block-group[class*="wp-container-"],
-#community .wp-block-group[class*="wp-container-"],
-#editor .wp-block-group[class*="wp-container-"] {
-	max-width: 520px;
+body .is-layout-constrained > .alignfull {
+	max-width: unset;
+	margin-left: unset !important;
+	margin-right: unset !important;
 }

--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -238,6 +238,7 @@
  *
  * Remove this when the above issue is fixed in a stable release.
  */
+
 body .is-layout-constrained > * {
 	max-width: var(--wp--style--global--content-size);
 	margin-left: auto !important;


### PR DESCRIPTION
Some Gutenberg blocks use CSS4 selectors, which don't work on some older browsers that should still be supported. This adds some temporary styles to work around that while the upstream bug is being fixed.

Fixes #78



### Screenshots

* [before](https://user-images.githubusercontent.com/484068/187569996-a5bbdd48-7563-49ee-bea5-e06e75c5a7fb.png)
* [after](https://user-images.githubusercontent.com/484068/187569895-5cb11bf4-4ce4-43fb-ba5a-73bcef3cad38.png)

### Testing

Compare the Homepage and Download page in an older browser, like [Opera 70](https://get.opera.com/ftp/pub/opera/desktop/70.0.3728.95/), against a modern browser. You may want to [disable autoupdates](https://superuser.com/questions/828009/how-to-disable-automatic-updates-in-opera) so it remains at an older version.
