### PR TITLE
Tools: Add CSS & JS linting to the GitHub action

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,13 @@ jobs:
               run: |
                   yarn setup:tools
 
-            # Once we have JS & CSS to lint, add that here.
+            - name: Lint CSS
+              run: |
+                  yarn workspace wporg-main-2022-theme lint:css
+
+            - name: Lint JS
+              run: |
+                  yarn workspace wporg-main-2022-theme lint:js
 
             - name: Lint PHP
               run: |

--- a/source/wp-content/themes/wporg-main-2022/package.json
+++ b/source/wp-content/themes/wporg-main-2022/package.json
@@ -13,10 +13,17 @@
 	"devDependencies": {
 		"@wordpress/scripts": "23.6.0"
 	},
+	"eslintConfig": {
+		"extends": "../../../../.eslintrc.js"
+	},
+	"stylelint": {
+		"extends": "../../../../.stylelintrc"
+	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"start": "wp-scripts start",
 		"lint:js": "wp-scripts lint-js src",
+		"lint:css": "wp-scripts lint-style *.css src/**/*.scss",
 		"format": "wp-scripts format src"
 	}
 }


### PR DESCRIPTION
Automatic lint checking in a github workflow was added in #21, but we didn't have CSS or JS to check yet. Now we do, so this PR adds in the linters to the "Static Analysis (Linting)" action.

### How to test the changes in this Pull Request:

The extra tests should run in the "Checks" tab.