### PR TITLE
Only revert to old theme on sites with `wporg-main-2022` active

### DIFF
--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -49,15 +49,18 @@ function should_use_new_theme() {
 	return ( 'wporg-main-2022' === get_option( 'stylesheet' ) );
 }
 
-if ( ! should_use_new_theme() ) {
-	if ( 'local' === wp_get_environment_type() ) {
-		// Enable the old parent & child themes.
-		add_filter( 'template', function() { return 'wporg'; } );
-		add_filter( 'stylesheet', function() { return 'wporg-main'; } );
-	} else {
-		// Slightly different paths for old themes on sandbox/producton
-		add_filter( 'template', function() { return 'pub/wporg'; } );
-		add_filter( 'stylesheet', function() { return 'pub/wporg-main'; } );
+// Only on sites running the new theme, decide if we need to downgrade to the old one.
+if ( 'wporg-main-2022' === get_option( 'stylesheet' ) ) {
+	if ( ! should_use_new_theme() ) {
+		if ( 'local' === wp_get_environment_type() ) {
+			// Enable the old parent & child themes.
+			add_filter( 'template', function() { return 'wporg'; } );
+			add_filter( 'stylesheet', function() { return 'wporg-main'; } );
+		} else {
+			// Slightly different paths for old themes on sandbox/producton
+			add_filter( 'template', function() { return 'pub/wporg'; } );
+			add_filter( 'stylesheet', function() { return 'pub/wporg-main'; } );
+		}
 	}
 }
 


### PR DESCRIPTION
The old logic was backwards, it forced the main theme active on other sites. That triggered some fatals on the forums requiring a revert.

