### PR TITLE
Fix export context bug

### DIFF
--- a/env/refresh.sh
+++ b/env/refresh.sh
@@ -2,5 +2,5 @@
 
 # Refresh the content from the server
 
-npm run wp-env run cli "php env/import-content.php --url 'https://wordpress.org/main-test/wp-json/wp/v2/posts?context=wporg_export&per_page=50'"
-npm run wp-env run cli "php env/import-content.php --url 'https://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&per_page=50'"
+npm run wp-env run cli "php env/import-content.php --url 'https://wordpress.org/wp-json/wp/v2/posts?context=wporg_export&per_page=50'"
+npm run wp-env run cli "php env/import-content.php --url 'https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&per_page=50'"

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -25,8 +25,10 @@ function should_use_new_theme() {
 		return true;
 	}
 
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? explode( '?', esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '/' )[0] : '/';
+
 	// Admin page or an API request.
-	if ( is_admin() || wp_is_json_request() ) {
+	if ( is_admin() || wp_is_json_request() || 0 === strpos( $request_uri, '/wp-json/wp/' ) ) {
 		return true;
 	}
 
@@ -36,7 +38,6 @@ function should_use_new_theme() {
 	}
 
 	// Check if the page being requested isn't supported by the new theme, it should fall-back to the old theme if so.
-	$request_uri     = isset( $_SERVER['REQUEST_URI'] ) ? explode( '?', esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '/' )[0] : '/';
 	$new_theme_pages = array(
 		'/',
 		'/download/',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

The recent change to `theme-switcher.php` in production broke the export context, so `https://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export` no longer works.

This fixes it by ensuring the correct filters are added.

### How to test the changes in this Pull Request:

1. Copy `theme-switcher.php` to your sandbox.
2. Confirm that `https://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export` does not trigger an error when sandboxed.

Note that I've also changed `setup:refresh` to fetch content from production rather than main-test, since the test site is no longer in use. It's impossible to test that script against a sandbox though, since Docker will always hit production servers.

<!-- If you can, add the appropriate [Component] label(s). -->
