### PR TITLE
Add a new Designer role & permission checks

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Theme\Main_2022;
 
 require_once( __DIR__ . '/inc/page-meta-descriptions.php' );
 require_once( __DIR__ . '/inc/hreflang.php' );
+require_once( __DIR__ . '/inc/capabilities.php' );
 
 // Block files
 require_once( __DIR__ . '/src/random-heading/index.php' );

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -182,6 +182,8 @@ function get_designer_role_caps() {
 	$role_caps['edit_others_pages']    = true;
 	$role_caps['publish_pages']        = true;
 	$role_caps['edit_pages']           = true;
+	unset( $role_caps['delete_posts'] ); // Mainly to prevent deleting media
+
 
 	return $role_caps;
 }

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -11,9 +11,15 @@ add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_meta_caps', 20, 4 ); // Needs 
 add_action( 'admin_init', __NAMESPACE__ . '\add_or_update_designer_role' );
 add_filter( 'rest_request_before_callbacks', __NAMESPACE__ . '\check_caps_for_page_update', 10, 3 );
 
-
-//$response = apply_filters( 'rest_request_before_callbacks', $response, $handler, $request );
-
+/**
+ * Filter a rest api request, run fine-grained permission checks for Designer users.
+ *
+ * @param mixed           $response Result to send to the client.
+ * @param array           $handler  Route handler used for the request.
+ * @param WP_REST_Request $request  Request used to generate the response.
+ *
+ * @return mixed
+ */
 function check_caps_for_page_update( $response, $handler, $request ) {
 	// Extra permissions check for designers when changing a page.
 	// Note: this is specific to the post edit API route. It won't affect other methods of updating a page, such as other endpoints or direct PHP calls.
@@ -70,14 +76,14 @@ function check_caps_for_page_update( $response, $handler, $request ) {
  * @return mixed
  */
 function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
-	if ( 'edit_page' === $current_cap || 'edit_post' === $current_cap ) {
+	//if ( 'edit_page' === $current_cap || 'edit_post' === $current_cap ) {
 		// Special safety limits for Designer role when editing pages
-		if ( user_can( $user_id, 'designer' ) ) {
+		//if ( user_can( $user_id, 'designer' ) ) {
 
 			//TODO: can we intercept other page edits here? Or better to hook edit filters like with rest_request_before_callbacks above?
 			// $required_caps[] = 'do_not_allow';
-		}
-	}
+		//}
+	//}
 
 	return $required_caps;
 }

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -19,34 +19,34 @@ function check_caps_for_page_update( $response, $handler, $request ) {
 	// Note: this is specific to the post edit API route. It won't affect other methods of updating a page, such as other endpoints or direct PHP calls.
 	// It's probably sufficient for the purpose of this plugin, which is a safety measure, not a security check.
 	if ( current_user_can( 'designer' ) ) {
-		if ( 'PUT' === $request->get_method() && $request->has_param('id') && $request->get_route() == rest_get_route_for_post( $request->get_param('id') ) ) {
-			if ( 'page' === get_post_type( $request->get_param('id') ) ) {
-				$page = get_post( $request->get_param('id') );
-				if ( $request->has_param('status') && 'publish' !== $request->get_param('status') && 'publish' === get_post_status( $page->ID ) ) {
+		if ( 'PUT' === $request->get_method() && $request->has_param( 'id' ) && $request->get_route() == rest_get_route_for_post( $request->get_param( 'id' ) ) ) {
+			if ( 'page' === get_post_type( $request->get_param( 'id' ) ) ) {
+				$page = get_post( $request->get_param( 'id' ) );
+				if ( $request->has_param( 'status' ) && 'publish' !== $request->get_param( 'status' ) && 'publish' === get_post_status( $page->ID ) ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
 						__( 'Sorry, you are not allowed to change the post status.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
-				} elseif ( $request->has_param('password') && $request->get_param('password') !== $page->post_password ) {
+				} elseif ( $request->has_param( 'password' ) && $request->get_param( 'password' ) !== $page->post_password ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
 						__( 'Sorry, you are not allowed to change the post password.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
-				} elseif ( $request->has_param('slug') && $request->get_param('slug') !== $page->post_name ) {
+				} elseif ( $request->has_param( 'slug' ) && $request->get_param( 'slug' ) !== $page->post_name ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
 						__( 'Sorry, you are not allowed to change the post slug.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
-				} elseif ( $request->has_param('featured_media') && $request->get_param( 'featured_media' ) !== get_post_thumbnail_id( $page ) ) {
+				} elseif ( $request->has_param( 'featured_media' ) && $request->get_param( 'featured_media' ) !== get_post_thumbnail_id( $page ) ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
 						__( 'Sorry, you are not allowed to change the featured image.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
-				} elseif ( $request->has_param('template') && $request->get_param('templae') !== $page->page_template ) {
+				} elseif ( $request->has_param( 'template' ) && $request->get_param( 'templae' ) !== $page->page_template ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
 						__( 'Sorry, you are not allowed to change the featured image.', 'wporg' ),
@@ -75,7 +75,7 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 		if ( user_can( $user_id, 'designer' ) ) {
 
 			//TODO: can we intercept other page edits here? Or better to hook edit filters like with rest_request_before_callbacks above?
-			#$required_caps[] = 'do_not_allow';
+			// $required_caps[] = 'do_not_allow';
 		}
 	}
 

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -58,6 +58,12 @@ function check_caps_for_page_update( $response, $handler, $request ) {
 						__( 'Sorry, you are not allowed to change the template.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
+				} elseif ( $request->has_param( 'title' ) && $request->get_param( 'title' ) !== html_entity_decode( $page->post_title ) ) {
+					$response = new \WP_Error(
+						'rest_forbidden',
+						__( 'Sorry, you are not allowed to change the title.', 'wporg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -52,7 +52,7 @@ function check_caps_for_page_update( $response, $handler, $request ) {
 						__( 'Sorry, you are not allowed to change the featured image.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
-				} elseif ( $request->has_param( 'template' ) && $request->get_param( 'templae' ) !== $page->page_template ) {
+				} elseif ( $request->has_param( 'template' ) && $request->get_param( 'template' ) !== $page->page_template ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
 						__( 'Sorry, you are not allowed to change the template.', 'wporg' ),

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -55,7 +55,7 @@ function check_caps_for_page_update( $response, $handler, $request ) {
 				} elseif ( $request->has_param( 'template' ) && $request->get_param( 'templae' ) !== $page->page_template ) {
 					$response = new \WP_Error(
 						'rest_forbidden',
-						__( 'Sorry, you are not allowed to change the featured image.', 'wporg' ),
+						__( 'Sorry, you are not allowed to change the template.', 'wporg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
 				}

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace WordPressdotorg\Theme\Main_2022;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_meta_caps', 20, 4 ); // Needs to fire after meta caps in wporg-internal-notes.
+add_action( 'admin_init', __NAMESPACE__ . '\add_or_update_designer_role' );
+add_filter( 'rest_request_before_callbacks', __NAMESPACE__ . '\check_caps_for_page_update', 10, 3 );
+
+
+//$response = apply_filters( 'rest_request_before_callbacks', $response, $handler, $request );
+
+function check_caps_for_page_update( $response, $handler, $request ) {
+	// Extra permissions check for designers when changing a page.
+	// Note: this is specific to the post edit API route. It won't affect other methods of updating a page, such as other endpoints or direct PHP calls.
+	// It's probably sufficient for the purpose of this plugin, which is a safety measure, not a security check.
+	if ( current_user_can( 'designer' ) ) {
+		if ( 'PUT' === $request->get_method() && $request->has_param('id') && $request->get_route() == rest_get_route_for_post( $request->get_param('id') ) ) {
+			if ( 'page' === get_post_type( $request->get_param('id') ) ) {
+				$page = get_post( $request->get_param('id') );
+				if ( $request->has_param('status') && 'publish' !== $request->get_param('status') && 'publish' === get_post_status( $page->ID ) ) {
+					$response = new \WP_Error(
+						'rest_forbidden',
+						__( 'Sorry, you are not allowed to change the post status.', 'wporg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				} elseif ( $request->has_param('password') && $request->get_param('password') !== $page->post_password ) {
+					$response = new \WP_Error(
+						'rest_forbidden',
+						__( 'Sorry, you are not allowed to change the post password.', 'wporg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				} elseif ( $request->has_param('slug') && $request->get_param('slug') !== $page->post_name ) {
+					$response = new \WP_Error(
+						'rest_forbidden',
+						__( 'Sorry, you are not allowed to change the post slug.', 'wporg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				} elseif ( $request->has_param('featured_media') && $request->get_param( 'featured_media' ) !== get_post_thumbnail_id( $page ) ) {
+					$response = new \WP_Error(
+						'rest_forbidden',
+						__( 'Sorry, you are not allowed to change the featured image.', 'wporg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				} elseif ( $request->has_param('template') && $request->get_param('templae') !== $page->page_template ) {
+					$response = new \WP_Error(
+						'rest_forbidden',
+						__( 'Sorry, you are not allowed to change the featured image.', 'wporg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+			}
+		}
+	}
+	return $response;
+}
+
+/**
+ * Map primitive caps to our custom caps.
+ *
+ * @param array  $required_caps
+ * @param string $current_cap
+ * @param int    $user_id
+ * @param mixed  $args
+ *
+ * @return mixed
+ */
+function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
+	if ( 'edit_page' === $current_cap || 'edit_post' === $current_cap ) {
+		// Special safety limits for Designer role when editing pages
+		if ( user_can( $user_id, 'designer' ) ) {
+
+			//TODO: can we intercept other page edits here? Or better to hook edit filters like with rest_request_before_callbacks above?
+			#$required_caps[] = 'do_not_allow';
+		}
+	}
+
+	return $required_caps;
+}
+
+
+
+/**
+ * Add the Designer role if it doesn't exist yet, or ensure it has the correct capabilities.
+ *
+ * Once a role has been added, and is stored in the database, it can't be changed using `add_role` because it
+ * will return early.
+ *
+ * @return \WP_Role|null
+ */
+function add_or_update_designer_role() {
+	$role_caps = get_designer_role_caps();
+	$new_role  = get_role( 'designer' );
+
+	if ( is_null( $new_role ) ) {
+		$new_role = add_role(
+			'designer',
+			__( 'Designer', 'wporg' ),
+			$role_caps
+		);
+	} else {
+		$caps_to_remove = array_diff(
+			array_keys( $new_role->capabilities, true, true ),
+			array_keys( $role_caps, true, true )
+		);
+
+		foreach ( $caps_to_remove as $remove ) {
+			$new_role->remove_cap( $remove );
+		}
+
+		$caps_to_add = array_diff(
+			array_keys( $role_caps, true, true ),
+			array_keys( $new_role->capabilities, true, true )
+		);
+
+		foreach ( $caps_to_add as $add ) {
+			$new_role->add_cap( $add );
+		}
+	}
+
+	return $new_role;
+}
+
+/**
+ * Generate a list of capabilities for the Designer role.
+ *
+ * A Designer is essentially in between Author and Editor. They can edit existing pages, but can't delete or un-publish something.
+ *
+ * @return bool[]
+ */
+function get_designer_role_caps() {
+	// Start with an author, and add extra caps.
+	$role_caps = get_role( 'author' )->capabilities;
+
+	$role_caps['edit_published_pages'] = true;
+	$role_caps['edit_others_pages']    = true;
+	$role_caps['publish_pages']        = true;
+	$role_caps['edit_pages']           = true;
+
+	return $role_caps;
+}

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -184,6 +184,5 @@ function get_designer_role_caps() {
 	$role_caps['edit_pages']           = true;
 	unset( $role_caps['delete_posts'] ); // Mainly to prevent deleting media
 
-
 	return $role_caps;
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This adds a new `Designer` user role, with some custom cap checks intended to prevent accidental edits to live pages.

The Designer role is in between Author and Editor. They can edit pages, including published pages and other author's pages. But they can't:

* Change a Published page to a different status like Draft
* Alter critical metadata on pages
* Change a page's template or visibility

Known limitations as of opening this PR:

* It's not checking all page metadata. Probably needs some refinement to decide exactly what should be disallowed.
* It's mostly hooked into the REST API, so it prevents accidental edits with Gutenberg but doesn't yet cover other things like ~~Quick Edit~~. (Now covers Quick Edit)

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #55, #108.

<!-- List out anyone who helped with this task. -->


<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

Example of a Designer user after clicking "Switch to draft":
<img width="1175" alt="Screen Shot 2022-09-08 at 5 03 40 pm" src="https://user-images.githubusercontent.com/7200686/189056700-5cd0b207-2bcb-4fdf-8fff-af8f7d2f2d63.png">


### How to test the changes in this Pull Request:

1. Create a new user `designer` with the Designer role.
2. Log in as `designer`.
3. Confirm that you can edit any page and change the post content.
4. Confirm that you can't change the post status, template, featured image, etc - they should generate an error message similar to the screenshot.
5. Confirm that Editor/Admin users can still change the post status etc.

<!-- If you can, add the appropriate [Component] label(s). -->
