### PR TITLE
Fix spacing of elements on frontend

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -15,6 +15,27 @@
  * templates or theme.json settings.
  */
 
+/* stylelint-disable max-line-length */
+
+/*
+ * Temporarary fix for https://github.com/WordPress/wporg-main-2022/issues/120
+ * Spacing vars are undefined in frontend
+ * Vars copied from https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/theme.json#L466
+ */
+
+/* stylelint-enable max-line-length */
+:root {
+	--wp--preset--spacing--10: 10px;
+	--wp--preset--spacing--20: 20px;
+	--wp--preset--spacing--30: 30px;
+	--wp--preset--spacing--40: 40px;
+	--wp--preset--spacing--50: clamp(40px, calc(100vw / 16), 60px);
+	--wp--preset--spacing--60: clamp(20px, calc(100vw / 18), 80px);
+	--wp--preset--spacing--70: 100px;
+	--wp--preset--spacing--80: clamp(80px, calc(100vw / 7), 120px);
+	--wp--preset--spacing--90: clamp(80px, calc(100vw / 7), 160px);
+}
+
 /*
  * Override inline paddings with the spacing preset.
  */


### PR DESCRIPTION
Temporarily fixes #120 

Spacing variables which are supposed to come from the parent theme are undefined.

Vars copied from https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/theme.json#L466

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| ![Screen Shot 2022-09-13 at 10 00 05 AM](https://user-images.githubusercontent.com/1017872/189766252-e6fe1a99-e8c4-46f0-8e01-78100af47f99.jpg) | ![Screen Shot 2022-09-13 at 10 00 36 AM](https://user-images.githubusercontent.com/1017872/189766282-8efc4adc-db89-467e-9dbe-de00fe19e9ae.jpg) |

### How to test
1. Copy `main.css` into the main theme in your w.org sandbox
2. Observe that paddings are restored in front page
3. Also check at mobile size
4. Check Download page too