### PR TITLE
Add/use latest news

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -255,9 +255,7 @@
 
 <!-- wp:column {"width":"66%","layout":{"inherit":false}} -->
 <div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"15px"}}}} -->
-<div class="wp-block-group" style="margin-top:15px"><!-- wp:wporg/latest-news -->
-<div class="wp-block-wporg-latest-news" data-per-page="3"></div>
-<!-- /wp:wporg/latest-news -->
+<div class="wp-block-group" style="margin-top:15px"><!-- wp:wporg/latest-news /-->
 
 <!-- wp:spacer {"height":"20px"} -->
 <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -255,9 +255,9 @@
 
 <!-- wp:column {"width":"66%","layout":{"inherit":false}} -->
 <div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"15px"}}}} -->
-<div class="wp-block-group" style="margin-top:15px"><!-- wp:wporg/multisite-latest-posts -->
-<div class="wp-block-wporg-multisite-latest-posts" data-endpoint="https://wordpress.org/news/wp-json/wp/v2" data-per-page="3"></div>
-<!-- /wp:wporg/multisite-latest-posts -->
+<div class="wp-block-group" style="margin-top:15px"><!-- wp:wporg/latest-news -->
+<div class="wp-block-wporg-latest-news" data-per-page="4"></div>
+<!-- /wp:wporg/latest-news -->
 
 <!-- wp:spacer {"height":"20px"} -->
 <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -256,7 +256,7 @@
 <!-- wp:column {"width":"66%","layout":{"inherit":false}} -->
 <div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"15px"}}}} -->
 <div class="wp-block-group" style="margin-top:15px"><!-- wp:wporg/latest-news -->
-<div class="wp-block-wporg-latest-news" data-per-page="4"></div>
+<div class="wp-block-wporg-latest-news" data-per-page="3"></div>
 <!-- /wp:wporg/latest-news -->
 
 <!-- wp:spacer {"height":"20px"} -->


### PR DESCRIPTION
Update front-page template to apply changes made in `wporg-mu-plugins` block.

Needs to be deployed at the same time as: https://github.com/WordPress/wporg-mu-plugins/pull/267.
