### PR TITLE
Update inline styles & class names when using RTL display

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -25,6 +25,35 @@
 
 
 /*
+ * Fix border bug on RTL sites.
+ * See https://github.com/WordPress/gutenberg/issues/44169.
+ */
+
+html[dir="rtl"] :where([style*="border-left-width"]),
+html[dir="rtl"] :where([style*="border-left-color"]),
+html[dir="rtl"] :where([style*="border-right-width"]),
+html[dir="rtl"] :where([style*="border-right-color"]) {
+	border-right-style: initial;
+	border-left-style: initial;
+}
+
+/**
+ * The following styles are flipped so that when RTLCSS runs, they're correct.
+ * For some reason, `rtl:ignore` does not work.
+ */
+
+html[dir="rtl"] :where([style*="border-left-width"]),
+html[dir="rtl"] :where([style*="border-left-color"]) {
+	border-right-style: solid;
+}
+
+html[dir="rtl"] :where([style*="border-right-width"]),
+html[dir="rtl"] :where([style*="border-right-color"]) {
+	border-left-style: solid;
+}
+
+
+/*
  * Spacing for small screens.
  */
 


### PR DESCRIPTION
Fixes #123 — Flip the left/right spacing & text alignment classes when using an RTL display. In some places, we've added padding or margin to a section, which when flipped, breaks the visual alignment. The padding/margin should also get flipped. Likewise, text alignment should be flipped (although in most cases the alignment has [been removed](https://github.com/WordPress/wporg-main-2022/commit/682017ddb362c17605ba5f0dec1482c56005f1e7)).

When combined with #125, there shouldn't be any more visual bugs in RTL.

### Screenshots

| LTR | RTL Before | RTL After |
|-----|------------|-----------|
| ![ltr-php-benefits](https://user-images.githubusercontent.com/541093/190427026-2b830811-098a-48d3-a3d7-a4811c0a4916.png) | ![before-php-benefits](https://user-images.githubusercontent.com/541093/190423473-4daa128b-2588-435f-bd32-184dc39cba06.png) | ![after-php-benefits](https://user-images.githubusercontent.com/541093/190423466-2be2138a-e12c-482d-a8e8-ef621572bb5f.png) |
| ![ltr-php-download](https://user-images.githubusercontent.com/541093/190427028-70b9351f-e827-4e1f-8195-59c676fb0fdf.png) | ![before-php-download](https://user-images.githubusercontent.com/541093/190423474-ac3d7c0b-12df-462d-b66f-082cc91d670c.png) | ![after-php-download](https://user-images.githubusercontent.com/541093/190426545-ec13a362-1de9-4344-9c06-5952e23ac60f.png) |
| ![ltr-php-latest-news](https://user-images.githubusercontent.com/541093/190427032-5bbbd145-fe1a-4bfa-a045-c2313c2d27d8.png) | ![before-php-latest-news](https://user-images.githubusercontent.com/541093/190423476-26425884-03c1-4a06-a2f3-fa6f981cb8b7.png) | ![after-php-latest-news](https://user-images.githubusercontent.com/541093/190423471-b9595be5-48dd-46dc-bd09-10671bc2851f.png) |

### How to test the changes in this Pull Request:

1. Set your site language to an RTL language (`he_IL` works, or Arabic) in Settings, the locale files will download and your site will flip
2. View the homepage, download page
3. The content is flipped, but everything should still look aligned at the edges (for example, the "Powerful and empowering" heading)
