### PR TITLE
New page: Mobile

### DIFF
--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -6,5 +6,9 @@
 	{
 		"slug": "download",
 		"template": "page-download.html"
+	},
+	{
+		"slug": "mobile",
+		"template": "page-mobile.html"
 	}
 ]

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -41,6 +41,7 @@ function should_use_new_theme() {
 	$new_theme_pages = array(
 		'/',
 		'/download/',
+		'/mobile/',
 	);
 	if ( ! in_array( $request_uri, $new_theme_pages ) ) {
 		return false;

--- a/source/wp-content/themes/wporg-main-2022/patterns/mobile.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/mobile.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Title: Mobile
+ * Slug: wporg-main-2022/mobile
+ * Categories:
+ */
+
+?>
+<!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--50);flex-basis:50%"><!-- wp:heading {"level":1,"fontSize":"heading-3"} -->
+<h1 class="has-heading-3-font-size"><?php _e( 'WordPress Mobile Apps', 'wporg' ); ?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Inspiration strikes any time, anywhere. WordPress mobile apps put the power of publishing in your hands, making it easy to create and consume content. Write, edit, and publish posts to your site, check stats, and get inspired with great posts in the Reader. And of course, they’re open source, just like WordPress.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+<div class="wp-block-group"><!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
+<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php _e( 'Download on the Apple App Store', 'wporg' ); ?>" width="150" height="45" /></a></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
+<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php _e( 'Get it on Google Play', 'wporg' ); ?>" width="150" height="45" /></a></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"textColor":"charcoal-4","className":"is-style-short-text","fontSize":"small"} -->
+<p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size"><?php _e( 'Requires a hosted website with WordPress 4.0 or higher. <a href="https://apps.wordpress.com/get/?campaign=wporg" data-type="URL" data-id="https://apps.wordpress.com/get/?campaign=wporg">Learn more</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:image {"id":12081,"sizeSlug":"full","linkDestination":"media"} -->
+<figure class="wp-block-image size-full"><a href="https://wordpress.org/files/2022/09/mobile-illustration.png"><img src="https://i2.wp.com/wordpress.org/files/2022/09/mobile-illustration.png?fit=1148%2C614&amp;ssl=1" alt="" class="wp-image-12081" /></a></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/mobile.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/mobile.php
@@ -9,11 +9,11 @@
 <!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--50);flex-basis:50%"><!-- wp:heading {"level":1,"fontSize":"heading-3"} -->
-<h1 class="has-heading-3-font-size"><?php _e( 'WordPress Mobile Apps', 'wporg' ); ?></h1>
+<h1 class="has-heading-3-font-size"><?php _e( 'WordPress mobile apps', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'Inspiration strikes any time, anywhere. WordPress mobile apps put the power of publishing in your hands, making it easy to create and consume content. Write, edit, and publish posts to your site, check stats, and get inspired with great posts in the Reader. And of course, they’re open source, just like WordPress.', 'wporg' ); ?></p>
+<p><?php _e( 'Inspiration strikes any time, anywhere. WordPress mobile apps put the power of publishing in your hands. And of course, they’re open source, just like WordPress.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
@@ -27,13 +27,13 @@
 <!-- /wp:group -->
 
 <!-- wp:paragraph {"textColor":"charcoal-4","className":"is-style-short-text","fontSize":"small"} -->
-<p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size"><?php _e( 'Requires a hosted website with WordPress 4.0 or higher. <a href="https://apps.wordpress.com/get/?campaign=wporg" data-type="URL" data-id="https://apps.wordpress.com/get/?campaign=wporg">Learn more</a>', 'wporg' ); ?></p>
+<p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size"><?php _e( 'Requires a hosted website with WordPress 4.0 or higher.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:image {"id":12081,"sizeSlug":"full","linkDestination":"media"} -->
-<figure class="wp-block-image size-full"><a href="https://wordpress.org/files/2022/09/mobile-illustration.png"><img src="https://i2.wp.com/wordpress.org/files/2022/09/mobile-illustration.png?fit=1148%2C614&amp;ssl=1" alt="" class="wp-image-12081" /></a></figure>
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:image {"id":12081,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://i2.wp.com/wordpress.org/files/2022/09/mobile-illustration.png?fit=1148%2C614&amp;ssl=1" alt="" class="wp-image-12081" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-mobile.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-mobile.html
@@ -1,0 +1,9 @@
+<!-- wp:wporg/global-header {"style":"black-on-white"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/mobile"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"style":"black-on-white"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-mobile.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-mobile.html
@@ -1,4 +1,4 @@
-<!-- wp:wporg/global-header {"style":"black-on-white"} /-->
+<!-- wp:wporg/global-header /-->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">


### PR DESCRIPTION
Fixes #117 — Add the mobile page to the new theme allowed-list, and to the page-manifest so that we download & sync this content too.

**Screenshot**

![](https://user-images.githubusercontent.com/541093/191130010-a4dc7457-51d2-4ade-89f9-5e6a086dc83c.png)

**To test**

1. View `/mobile/`
2. It should use the new theme, and the content should match the screenshot

Requesting review just to confirm the steps for deploying a new page — I've added it to `theme-switcher.php`, and that will be deployed to mu-plugins after syncing the theme.