### PR TITLE
Block: Download Counter

### DIFF
--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -28,7 +28,7 @@ function should_use_new_theme() {
 	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? explode( '?', esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '/' )[0] : '/';
 
 	// Admin page or an API request.
-	if ( is_admin() || wp_is_json_request() || 0 === strpos( $request_uri, '/wp-json/wp/' ) ) {
+	if ( is_admin() || wp_is_json_request() || 0 === strpos( $request_uri, '/wp-json/wp' ) ) {
 		return true;
 	}
 

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -7,6 +7,7 @@ require_once( __DIR__ . '/inc/hreflang.php' );
 require_once( __DIR__ . '/inc/capabilities.php' );
 
 // Block files
+require_once( __DIR__ . '/src/download-counter/index.php' );
 require_once( __DIR__ . '/src/random-heading/index.php' );
 
 /**

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -76,6 +76,28 @@ add_shortcode(
 );
 
 /**
+ * Shortcode to display the latest branch of WordPress (ex, 5.7, 6.0).
+ */
+add_shortcode(
+	'latest_branch',
+	function() {
+		global $wp_version;
+		$latest_branch = '';
+
+		if ( defined( 'WP_CORE_STABLE_BRANCH' ) ) {
+			$latest_branch = WP_CORE_STABLE_BRANCH;
+		} else {
+			// Fallback if the constant is undefined.
+			if ( preg_match( '/[0-9]+\.[0-9]/', $wp_version, $matches ) ) {
+				$latest_branch = $matches[0];
+			}
+		}
+
+		return $latest_branch;
+	}
+);
+
+/**
  * Shortcode for a link to the latest version of WordPress.
  */
 add_shortcode(

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -76,24 +76,25 @@ add_shortcode(
 );
 
 /**
- * Shortcode to display the latest branch of WordPress (ex, 5.7, 6.0).
+ * Shortcode to display the current stable branch of WordPress (ex, 5.7, 6.0).
  */
 add_shortcode(
-	'latest_branch',
+	'stable_branch',
 	function() {
 		global $wp_version;
-		$latest_branch = '';
+		$stable_branch = '';
 
 		if ( defined( 'WP_CORE_STABLE_BRANCH' ) ) {
-			$latest_branch = WP_CORE_STABLE_BRANCH;
+			$stable_branch = WP_CORE_STABLE_BRANCH;
 		} else {
-			// Fallback if the constant is undefined.
+			// Fallback if the constant is undefined. This isn't exactly correct,
+			// but displays something for testing purposes.
 			if ( preg_match( '/[0-9]+\.[0-9]/', $wp_version, $matches ) ) {
-				$latest_branch = $matches[0];
+				$stable_branch = $matches[0];
 			}
 		}
 
-		return $latest_branch;
+		return $stable_branch;
 	}
 );
 

--- a/source/wp-content/themes/wporg-main-2022/patterns/counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/counter.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal"} -->
 <p class="has-normal-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
@@ -16,8 +16,8 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:cover {"overlayColor":"charcoal-1","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full"} -->
-<div class="wp-block-cover alignfull" style="min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
+<!-- wp:cover {"overlayColor":"charcoal-2","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full"} -->
+<div class="wp-block-cover alignfull" style="min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-2-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":1,"fontSize":"heading-3"} -->
 <h1 class="has-heading-3-font-size"><em><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></em></h1>
 <!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/counter.php
@@ -22,6 +22,6 @@
 <h1 class="has-heading-3-font-size"><em><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></em></h1>
 <!-- /wp:heading -->
 
-<!-- wp:wporg/download-counter {"textColor":"blueberry-2"} /--></div>
+<!-- wp:wporg/download-counter {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"textColor":"blueberry-2"} /--></div>
 <!-- /wp:group --></div></div>
 <!-- /wp:cover -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/counter.php
@@ -17,13 +17,11 @@
 <!-- /wp:group -->
 
 <!-- wp:cover {"overlayColor":"charcoal-1","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full"} -->
-<div class="wp-block-cover alignfull" style="min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:heading -->
-<h2><?php _e( 'Number of WordPress [latest_branch] downloads', 'wporg' ); ?></h2>
+<div class="wp-block-cover alignfull" style="min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":1,"fontSize":"heading-3"} -->
+<h1 class="has-heading-3-font-size"><em><?php _e( 'Number of WordPress [latest_branch] downloads', 'wporg' ); ?></em></h1>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"textColor":"pomegrade-2"} -->
-<p class="has-pomegrade-2-color has-text-color"><?php _e( 'counter block', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
+<!-- wp:wporg/download-counter {"textColor":"blueberry-2"} /--></div>
 <!-- /wp:group --></div></div>
 <!-- /wp:cover -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/counter.php
@@ -22,6 +22,6 @@
 <h1 class="has-heading-3-font-size"><em><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></em></h1>
 <!-- /wp:heading -->
 
-<!-- wp:wporg/download-counter {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"textColor":"blueberry-2"} /--></div>
+<!-- wp:wporg/download-counter {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":"200"}},"textColor":"blueberry-2"} /--></div>
 <!-- /wp:group --></div></div>
 <!-- /wp:cover -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/counter.php
@@ -19,7 +19,7 @@
 <!-- wp:cover {"overlayColor":"charcoal-1","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full"} -->
 <div class="wp-block-cover alignfull" style="min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":1,"fontSize":"heading-3"} -->
-<h1 class="has-heading-3-font-size"><em><?php _e( 'Number of WordPress [latest_branch] downloads', 'wporg' ); ?></em></h1>
+<h1 class="has-heading-3-font-size"><em><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></em></h1>
 <!-- /wp:heading -->
 
 <!-- wp:wporg/download-counter {"textColor":"blueberry-2"} /--></div>

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/block.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/download-counter",
+	"version": "0.1.0",
+	"title": "Download Counter",
+	"category": "design",
+	"icon": "",
+	"description": "Display the download counter for a given WordPress version.",
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"align": true,
+		"color": {
+			"background": true,
+			"text": true
+		},
+		"html": false,
+		"multiple": false,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js"
+}

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/index.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useBlockProps } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit() {
+	const [ count, setCount ] = useState( '1,000,000' );
+	useEffect( async () => {
+		const realCount = await apiFetch( { path: '/wporg/v1/core-downloads/' } );
+		setCount( realCount );
+	}, [] );
+
+	return <div { ...useBlockProps() }>{ count }</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/index.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Block Name: Download Counter
+ * Description: Display the download counter for a given WordPress version.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Main_2022\Download_Counter_Block;
+
+use WP_REST_Request;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\add_counter_endpoint' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/download-counter',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! empty( $block->block_type->view_script ) ) {
+		wp_enqueue_script( $block->block_type->view_script );
+		// Move to footer.
+		wp_script_add_data( $block->block_type->view_script, 'group', 1 );
+	}
+
+	$branch = WP_CORE_STABLE_BRANCH;
+	// If set, use the URL query string parameter for the branch.
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	if ( isset( $_GET['branch'] ) && validate_branch( wp_unslash( $_GET['branch'] ) ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$branch = wp_unslash( $_GET['branch'] );
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %1$s data-branch="%2$s">%3$s</div>',
+		$wrapper_attributes,
+		$branch,
+		get_download_count( $branch )
+	);
+}
+
+/**
+ * Validate that the given string is a valid branch.
+ *
+ * @param string $branch
+ *
+ * @return boolean
+ */
+function validate_branch( $branch ) {
+	return (
+		preg_match( '/^[0-9]+\.[0-9]$/', $branch ) &&
+		version_compare( WP_CORE_STABLE_BRANCH, $branch, '>=' )
+	);
+}
+
+/**
+ * Set up the counter endpoints.
+ */
+function add_counter_endpoint() {
+	register_rest_route(
+		'wporg/v1',
+		'/core-downloads/',
+		array(
+			'methods' => 'GET',
+			'callback' => function( WP_REST_Request $request ) {
+				return get_download_count( WP_CORE_STABLE_BRANCH );
+			},
+			'permission_callback' => '__return_true',
+		)
+	);
+	register_rest_route(
+		'wporg/v1',
+		'/core-downloads/(?P<branch>[0-9.]+)',
+		array(
+			'methods' => 'GET',
+			'callback' => function( WP_REST_Request $request ) {
+				$branch = $request->get_param( 'branch' );
+				return get_download_count( $branch ?? WP_CORE_STABLE_BRANCH );
+			},
+			'permission_callback' => '__return_true',
+			'args' => array(
+				'branch' => array(
+					'validate_callback' => function( $param, $request, $key ) {
+						return validate_branch( $param );
+					},
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Return the current download count for a branch.
+ *
+ * @param string $branch A version number, will fetch download count for this version.
+ *
+ * @return WP_Error|int The download count (or error).
+ */
+function get_download_count( $branch ) {
+	global $wpdb;
+
+	if ( 'local' === wp_get_environment_type() ) {
+		// Generate a semi-random number like a download count.
+		// 8 digits to have a suitably long number, based on the current time so it generally trends upward.
+		// Add a random offset so the number changes more every 5 seconds.
+		$num = substr( time(), -9 ) + rand( 10, 100 );
+	} else {
+		$num = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT SUM(downloads) FROM download_counts WHERE `release` LIKE %s AND `release` NOT LIKE %s',
+				$wpdb->esc_like( $branch ) . '%',
+				'%-%'
+			)
+		);
+	}
+	// @todo some error checking.
+
+	return esc_html( number_format_i18n( $num ) );
+}

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/index.php
@@ -136,7 +136,6 @@ function get_download_count( $branch ) {
 			)
 		);
 	}
-	// @todo some error checking.
 
 	return esc_html( number_format_i18n( $num ) );
 }

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
@@ -19,8 +19,10 @@ const init = () => {
 			}
 
 			setInterval( async () => {
-				const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }` } );
-				element.innerHTML = count;
+				try {
+					const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }` } );
+					element.innerHTML = count;
+				} catch ( error ) {}
 			}, 5000 );
 		} );
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+const init = () => {
+	const containers = document.querySelectorAll( '.wp-block-wporg-download-counter' );
+	if ( containers ) {
+		containers.forEach( ( element ) => {
+			const { branch } = element.dataset;
+
+			// Update the version string if the branch is different, only if the previous element is a heading 1.
+			const heading = element.previousElementSibling;
+			if ( 'H1' === heading.tagName.toUpperCase() ) {
+				const [ version ] = heading.innerHTML.match( /[0-9]+\.[0-9]/ ) || [];
+				if ( version ) {
+					heading.innerHTML = heading.innerHTML.replace( version, branch );
+				}
+			}
+
+			setInterval( async () => {
+				const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }` } );
+				element.innerHTML = count;
+			}, 5000 );
+		} );
+	}
+};
+
+window.addEventListener( 'load', init );

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
@@ -21,7 +21,7 @@ const init = () => {
 			setInterval( async () => {
 				try {
 					const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }` } );
-					element.innerHTML = count;
+					element.textContent = count;
 				} catch ( error ) {}
 			}, 5000 );
 		} );

--- a/source/wp-content/themes/wporg-main-2022/theme.json
+++ b/source/wp-content/themes/wporg-main-2022/theme.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"settings": {}
+	"settings": {},
+	"styles": {
+		"blocks": {
+			"wporg/download-counter": {
+				"typography": {
+					"fontFamily": "monospace",
+					"fontSize": "clamp(40px, calc(100vw / 8), 120px)",
+					"lineHeight": "1"
+				}
+			}
+		}
+	}
 }

--- a/source/wp-content/themes/wporg-main-2022/theme.json
+++ b/source/wp-content/themes/wporg-main-2022/theme.json
@@ -6,7 +6,7 @@
 		"blocks": {
 			"wporg/download-counter": {
 				"typography": {
-					"fontFamily": "monospace",
+					"fontFamily": "var(--wp--preset--font-family--monospace)",
 					"fontSize": "clamp(40px, calc(100vw / 8), 120px)",
 					"lineHeight": "1"
 				}


### PR DESCRIPTION
Fixes #130, See #129 — This adds a new block for the Download Counter. It live-updates from a new API endpoint every 5 seconds.

The new API endpoint is `/wporg/v1/core-downloads/[branch]/`, and it uses the same SQL request as the current page. On local sites it uses a workaround to avoid calling a table that doesn't exist, that's described in the code.

There's also a new shortcode, for `stable_branch`, which is a different constant (`WP_CORE_STABLE_BRANCH`) than the existing `latest_release` shortcode. This is used in the heading on the Counter page.

⚠️  This branch is built on #131 (`add/download-subpages`), not `trunk`. The other branch enables the new theme on the download subpages so this can be tested.

### Screenshots

Design-wise, there was a comment about using a monospace font to prevent the numbers jumping around - I went ahead and applied that, but we can still try out different styles. I didn't add any animation, so it just updates to the next number.

https://user-images.githubusercontent.com/541093/194117814-133151c3-399d-4652-9a1a-3f289e9cefb0.mp4

Old version data is still accessible with the `?branch=5.9` query parameter (a current feature of the page).

![counter-past](https://user-images.githubusercontent.com/541093/194117828-2bdbc0c2-4113-43cc-9f58-6f08888c7040.png)

The font scales down on small screens.

![counter-small](https://user-images.githubusercontent.com/541093/194117830-14de6d73-cb5f-499c-966b-2922b752884e.png)

In the editor, the block doesn't live-update, but it does display the latest count.

![editor](https://user-images.githubusercontent.com/541093/194119657-a947978d-a20b-4605-a683-983827a18a20.png)

### How to test the changes in this Pull Request:

This works best on a sandbox, since you can see the real download counts, but it's still possible to test locally.

1. View the Counter page
2. Try passing different branches, ex: `/download/counter/?branch=5.9`
3. Use the block on other pages to test the editor interface — font, color, & spacing should be customizable
