### PR TITLE
Block: Release Tables

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -9,6 +9,7 @@ require_once( __DIR__ . '/inc/capabilities.php' );
 // Block files
 require_once( __DIR__ . '/src/download-counter/index.php' );
 require_once( __DIR__ . '/src/random-heading/index.php' );
+require_once( __DIR__ . '/src/release-tables/index.php' );
 
 /**
  * Actions and filters.

--- a/source/wp-content/themes/wporg-main-2022/patterns/releases.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/releases.php
@@ -30,6 +30,8 @@
 
 <!-- wp:paragraph -->
 <p><?php _e( 'Curious about which jazzers we highlighted for each release? <a href="https://wordpress.org/about/history/">It’s on the History page</a>.', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph -->
+
+<!-- wp:wporg/release-tables /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/block.json
@@ -15,18 +15,8 @@
 		"multiple": false,
 		"spacing": {
 			"margin": [ "top", "bottom" ],
-			"padding": false,
-			"blockGap": true
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"__experimentalFontFamily": true,
-			"__experimentalFontStyle": true,
-			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true
-		},
-		"__experimentalLayout": true
+			"padding": false
+		}
 	},
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css",

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/block.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/release-tables",
+	"version": "0.1.0",
+	"title": "Release Tables",
+	"category": "design",
+	"icon": "",
+	"description": "Display the list of releases.",
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"align": true,
+		"html": false,
+		"multiple": false,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": false,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true
+		},
+		"__experimentalLayout": true
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
+}

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { Disabled } from '@wordpress/components';
+import { registerBlockType } from '@wordpress/blocks';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+function Edit( { attributes, name } ) {
+	return (
+		<div { ...useBlockProps() }>
+			<Disabled>
+				<ServerSideRender block={ name } attributes={ attributes } />
+			</Disabled>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
@@ -207,11 +207,11 @@ function render_table_row( $version ) {
 	$row = '<tr>';
 	$row .= '<th class="wp-block-wporg-release-tables__cell-version" scope="row">' . esc_html( $version['version'] ) . '</th>';
 	$row .= '<td class="wp-block-wporg-release-tables__cell-date">' . esc_html( date_i18n( get_option( 'date_format' ), $version['builton'] ) ) . '</td>';
-	$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-zip"><a href="%1$s">zip</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['zip_url'] ) );
+	$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-zip"><a href="%1$s">zip</a><br /><small>(<a href="%1$s.md5">md5</a> &#183; <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['zip_url'] ) );
 
 	// Some releases don't have tar.gz builds.
 	if ( $version['targz_url'] ) {
-		$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-targz"><a href="%1$s">tar.gz</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['targz_url'] ) );
+		$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-targz"><a href="%1$s">tar.gz</a><br /><small>(<a href="%1$s.md5">md5</a> &#183; <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['targz_url'] ) );
 	} else {
 		$row .= '<td class="wp-block-wporg-release-tables__cell-targz"></td>';
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Block Name: Release Tables
+ * Description: Display the list of releases.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Main_2022\Release_Tables_Block;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/release-tables',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! empty( $block->block_type->view_script ) ) {
+		wp_enqueue_script( $block->block_type->view_script );
+		// Move to footer.
+		wp_script_add_data( $block->block_type->view_script, 'group', 1 );
+	}
+
+	if ( defined( 'IS_ROSETTA_NETWORK' ) && IS_ROSETTA_NETWORK ) {
+		$releases = $GLOBALS['rosetta']->rosetta->get_releases_breakdown();
+	} else {
+		$releases = \WordPressdotorg\Releases\get_breakdown();
+	}
+
+	if ( empty( $releases ) ) {
+		return '';
+	}
+
+	$block_content = '';
+
+	if ( isset( $releases['latest'] ) ) {
+		$block_content .= '<div class="wp-block-wporg-release-tables__section">';
+		$block_content .= render_heading( __( 'Latest release', 'wporg' ), 'latest' );
+		$block_content .= render_table( [ $releases['latest'] ] );
+		$block_content .= '</div>';
+	}
+
+	if ( isset( $releases['branches'] ) ) {
+		$show_branches = array_slice( $releases['branches'], 0, 2 );
+		foreach ( $show_branches as $branch => $branch_releases ) {
+			$block_content .= '<div class="wp-block-wporg-release-tables__section">';
+			$block_content .= render_heading(
+				/* translators: Version number. */
+				sprintf( esc_html__( '%s Branch', 'wporg' ), $branch ),
+				sprintf( 'branch-%s', sanitize_key( $branch ) )
+			);
+			$block_content .= render_table( $branch_releases );
+			$block_content .= '</div>';
+		}
+
+		$more_branches = array_slice( $releases['branches'], 2 );
+		if ( $more_branches ) {
+			$block_content .= render_heading( __( 'Past releases', 'wporg' ), 'past' );
+			foreach ( $more_branches as $branch => $branch_releases ) {
+				$block_content .= '<div class="wp-block-wporg-release-tables__section">';
+				$block_content .= render_heading(
+					/* translators: Version number. */
+					sprintf( esc_html__( '%s Branch', 'wporg' ), $branch ),
+					sprintf( 'branch-%s', sanitize_key( $branch ) ),
+					true
+				);
+				$block_content .= render_table( $branch_releases );
+				$block_content .= '</div>';
+			}
+		}
+	}
+
+	if ( isset( $releases['betas'] ) ) {
+		$block_content .= '<div class="wp-block-wporg-release-tables__section">';
+		$block_content .= render_heading( __( 'Beta &amp; RC releases', 'wporg' ), 'betas', true );
+		$block_content .= '<!-- wp:paragraph --><p>';
+		$block_content .= esc_html__( 'These were testing releases and are only available here for archival purposes.', 'wporg' );
+		$block_content .= '</p><!-- /wp:paragraph -->';
+		$block_content .= render_table( $releases['betas'] );
+		$block_content .= '</div>';
+	}
+
+	if ( isset( $releases['mu'] ) && count( $releases['mu'] ) ) {
+		$block_content .= '<div class="wp-block-wporg-release-tables__section">';
+		$block_content .= render_heading( __( 'MU releases', 'wporg' ), 'mu', true );
+		$block_content .= '<!-- wp:paragraph --><p>';
+		$block_content .= esc_html__( 'WordPress MU releases made prior to MU being merged into WordPress 3.0.', 'wporg' );
+		$block_content .= '</p><!-- /wp:paragraph -->';
+		$block_content .= render_table( $releases['mu'] );
+		$block_content .= '</div>';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		do_blocks( $block_content )
+	);
+}
+
+/**
+ * Render a release heading with ID.
+ *
+ * @param string $text The heading text.
+ * @param string $id The string to use for the HTML id attribute.
+ *
+ * @return string Returns the heading markup.
+ */
+function render_heading( $text, $id, $subheading = false ) {
+	if ( ! $id ) {
+		$id = sanitize_key( $text );
+	}
+
+	$back_to_top = '';
+	if ( 'latest' !== $id ) {
+		$back_to_top = '<a class="wp-block-wporg-release-tables__link-top" href="#latest">' . __( 'Back to top', 'wporg' ) . '</a>';
+	}
+
+	if ( $subheading ) {
+		return sprintf(
+			'<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"0px"}}},"fontSize":"heading-4"} --><h3 class="has-heading-4-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:0px" id="%s">%s %s</h3><!-- /wp:heading -->',
+			esc_attr( $id ),
+			esc_html( $text ),
+			$back_to_top
+		);
+	}
+
+	return sprintf(
+		'<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"0px"}}},"fontSize":"heading-3"} --><h2 class="has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:0px" id="%s">%s %s</h2><!-- /wp:heading -->',
+		esc_attr( $id ),
+		esc_html( $text ),
+		$back_to_top
+	);
+}
+
+/**
+ * Render a release table.
+ *
+ * @param array $releases A list of release versions.
+ *
+ * @return string Returns the table markup.
+ */
+function render_table( $releases ) {
+	$table = '<!-- wp:table {"className":"is-style-stripes","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} --><figure class="wp-block-table is-style-stripes" style="margin-top:var(--wp--preset--spacing--20)">';
+	$table .= '<table>';
+	$table .= '<thead>';
+	$table .= '<tr>';
+	$table .= '<th scope="col" width="15%">' . esc_html__( 'Version', 'wporg' ) . '</th>';
+	$table .= '<th scope="col" width="35%">' . esc_html__( 'Release date', 'wporg' ) . '</th>';
+	$table .= '<th scope="col" width="25%">' . esc_html__( 'Download zip', 'wporg' ) . '</th>';
+	$table .= '<th scope="col" width="25%">' . esc_html__( 'Download tar.gz', 'wporg' ) . '</th>';
+	$table .= '</tr>';
+	$table .= '</thead>';
+	$table .= '<tbody>';
+	foreach ( $releases as $version ) {
+		$table .= render_table_row( $version );
+	}
+	$table .= '</tbody></table>';
+	$table .= '</figure><!-- /wp:table -->';
+	return $table;
+}
+
+/**
+ * Render a release row.
+ *
+ * @param array $version A list of links and data about a given release version.
+ *
+ * @return string Returns the row markup.
+ */
+function render_table_row( $version ) {
+	$row = '<tr>';
+	$row .= '<th scope="row">' . esc_html( $version['version'] ) . '</th>';
+	$row .= '<td>' . esc_html( date_i18n( get_option( 'date_format' ), $version['builton'] ) ) . '</td>';
+	$row .= sprintf( '<td><a href="%1$s">zip</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['zip_url'] ) );
+
+	// Some releases don't have tar.gz builds.
+	if ( $version['targz_url'] ) {
+		$row .= sprintf( '<td><a href="%1$s">tar.gz</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['targz_url'] ) );
+	} else {
+		$row .= '<td></td>';
+	}
+	$row .= '</tr>';
+	return $row;
+}

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
@@ -42,11 +42,12 @@ function render( $attributes, $content, $block ) {
 		wp_script_add_data( $block->block_type->view_script, 'group', 1 );
 	}
 
-	if ( defined( 'IS_ROSETTA_NETWORK' ) && IS_ROSETTA_NETWORK ) {
-		$releases = $GLOBALS['rosetta']->rosetta->get_releases_breakdown();
-	} else {
-		$releases = \WordPressdotorg\Releases\get_breakdown();
+	if ( ! function_exists( '\WordPressdotorg\Releases\get_breakdown' ) ) {
+		return '';
 	}
+
+	// @todo Use the rosetta function when launched on rosetta sites.
+	$releases = \WordPressdotorg\Releases\get_breakdown();
 
 	if ( empty( $releases ) ) {
 		return '';

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
@@ -180,10 +180,10 @@ function render_table( $releases ) {
 	$table .= '<table>';
 	$table .= '<thead>';
 	$table .= '<tr>';
-	$table .= '<th scope="col" width="15%">' . esc_html__( 'Version', 'wporg' ) . '</th>';
-	$table .= '<th scope="col" width="35%">' . esc_html__( 'Release date', 'wporg' ) . '</th>';
-	$table .= '<th scope="col" width="25%">' . esc_html__( 'Download zip', 'wporg' ) . '</th>';
-	$table .= '<th scope="col" width="25%">' . esc_html__( 'Download tar.gz', 'wporg' ) . '</th>';
+	$table .= '<th scope="col" class="wp-block-wporg-release-tables__cell-version"><span class="screen-reader-text">' . esc_html__( 'Version', 'wporg' ) . '</span></th>';
+	$table .= '<th scope="col" class="wp-block-wporg-release-tables__cell-date"><span class="screen-reader-text">' . esc_html__( 'Release date', 'wporg' ) . '</span></th>';
+	$table .= '<th scope="col" class="wp-block-wporg-release-tables__cell-zip"><span class="screen-reader-text">' . esc_html__( 'Download zip', 'wporg' ) . '</span></th>';
+	$table .= '<th scope="col" class="wp-block-wporg-release-tables__cell-targz"><span class="screen-reader-text">' . esc_html__( 'Download tar.gz', 'wporg' ) . '</span></th>';
 	$table .= '</tr>';
 	$table .= '</thead>';
 	$table .= '<tbody>';
@@ -204,15 +204,15 @@ function render_table( $releases ) {
  */
 function render_table_row( $version ) {
 	$row = '<tr>';
-	$row .= '<th scope="row">' . esc_html( $version['version'] ) . '</th>';
-	$row .= '<td>' . esc_html( date_i18n( get_option( 'date_format' ), $version['builton'] ) ) . '</td>';
-	$row .= sprintf( '<td><a href="%1$s">zip</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['zip_url'] ) );
+	$row .= '<th class="wp-block-wporg-release-tables__cell-version" scope="row">' . esc_html( $version['version'] ) . '</th>';
+	$row .= '<td class="wp-block-wporg-release-tables__cell-date">' . esc_html( date_i18n( get_option( 'date_format' ), $version['builton'] ) ) . '</td>';
+	$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-zip"><a href="%1$s">zip</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['zip_url'] ) );
 
 	// Some releases don't have tar.gz builds.
 	if ( $version['targz_url'] ) {
-		$row .= sprintf( '<td><a href="%1$s">tar.gz</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['targz_url'] ) );
+		$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-targz"><a href="%1$s">tar.gz</a><br /><small>(<a href="%1$s.md5">md5</a> | <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['targz_url'] ) );
 	} else {
-		$row .= '<td></td>';
+		$row .= '<td class="wp-block-wporg-release-tables__cell-targz"></td>';
 	}
 	$row .= '</tr>';
 	return $row;

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
@@ -13,14 +13,6 @@
 	li {
 		display: inline-block;
 		padding: 0 calc(var(--wp--preset--spacing--10) / 2);
-
-		&:first-child {
-			padding-left: 0;
-		}
-
-		&:last-child {
-			padding-right: 0;
-		}
 	}
 
 	a {

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
@@ -1,8 +1,8 @@
-.wp-block-wporg-release-tables .wp-block-table thead th {
-	padding: 0;
+.wp-block-wporg-release-tables thead th {
+	padding: 0 !important;
 	height: 0;
-	border-top: none;
-	border-bottom: none;
+	border-top: none !important;
+	border-bottom: none !important;
 }
 
 .wp-block-wporg-release-tables [role="tablist"] {

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
@@ -1,0 +1,6 @@
+.wp-block-wporg-release-tables__link-top {
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--small);
+	font-weight: 400;
+	float: right;
+}

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
@@ -1,3 +1,10 @@
+.wp-block-wporg-release-tables .wp-block-table thead th {
+	padding: 0;
+	height: 0;
+	border-top: none;
+	border-bottom: none;
+}
+
 .wp-block-wporg-release-tables [role="tablist"] {
 	margin: var(--wp--preset--spacing--20) auto 0;
 	padding: 0;
@@ -30,4 +37,49 @@
 
 .wp-block-wporg-release-tables__section[aria-hidden="true"] {
 	display: none;
+}
+
+.wp-block-wporg-release-tables th,
+.wp-block-wporg-release-tables td {
+	box-sizing: border-box;
+}
+
+.wp-block-wporg-release-tables__cell-version {
+	width: 15%;
+
+	tbody & {
+		white-space: nowrap;
+	}
+}
+
+.wp-block-wporg-release-tables__cell-date {
+	width: 35%;
+}
+
+.wp-block-wporg-release-tables__cell-zip {
+	width: 25%;
+}
+
+.wp-block-wporg-release-tables__cell-targz {
+	width: 25%;
+}
+
+@media (max-width: 599px) {
+	.wp-block-wporg-release-tables__cell-date,
+	.wp-block-wporg-release-tables__cell-zip small,
+	.wp-block-wporg-release-tables__cell-targz small {
+		display: none;
+	}
+
+	.wp-block-wporg-release-tables__cell-version {
+		width: 40%;
+	}
+
+	.wp-block-wporg-release-tables__cell-zip {
+		width: 30%;
+	}
+
+	.wp-block-wporg-release-tables__cell-targz {
+		width: 30%;
+	}
 }

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/style.scss
@@ -1,6 +1,33 @@
-.wp-block-wporg-release-tables__link-top {
-	font-family: var(--wp--preset--font-family--inter);
-	font-size: var(--wp--preset--font-size--small);
-	font-weight: 400;
-	float: right;
+.wp-block-wporg-release-tables [role="tablist"] {
+	margin: var(--wp--preset--spacing--20) auto 0;
+	padding: 0;
+	list-style: none;
+
+	li {
+		display: inline-block;
+		padding: 0 calc(var(--wp--preset--spacing--10) / 2);
+
+		&:first-child {
+			padding-left: 0;
+		}
+
+		&:last-child {
+			padding-right: 0;
+		}
+	}
+
+	a {
+		display: inline-block;
+		padding: calc(var(--wp--preset--spacing--10) / 2);
+		font-size: var(--wp--preset--font-size--small);
+		line-height: var(--wp--custom--body--small--typography--line-height);
+
+		&[aria-selected="true"] {
+			background-color: var(--wp--preset--color--blueberry-4);
+		}
+	}
+}
+
+.wp-block-wporg-release-tables__section[aria-hidden="true"] {
+	display: none;
 }

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/view.js
@@ -6,8 +6,36 @@ const init = () => {
 	const containers = document.querySelectorAll( '.wp-block-wporg-release-tables' );
 	if ( containers ) {
 		containers.forEach( ( element ) => {
-			console.log( element );
+			const tabs = element.querySelectorAll( 'ul[role="tablist"] a' );
+
+			tabs.forEach( ( tab ) => {
+				tab.onclick = () => {
+					// Unselect selected tabs, hide all tables.
+					element
+						.querySelectorAll( 'a[role="tab"][aria-selected="true"]' )
+						.forEach( ( elem ) => elem.setAttribute( 'aria-selected', false ) );
+					element
+						.querySelectorAll( '.wp-block-wporg-release-tables__section[aria-hidden="false"]' )
+						.forEach( ( elem ) => elem.setAttribute( 'aria-hidden', true ) );
+
+					// Show the selected table.
+					const id = tab.getAttribute( 'aria-controls' );
+					tab.setAttribute( 'aria-selected', true );
+					document.getElementById( id ).setAttribute( 'aria-hidden', false );
+				};
+			} );
 		} );
+
+		// If linked to a table directly, make sure that's selected.
+		if ( window.location.hash ) {
+			const id = window.location.hash.replace( '#', '' );
+			const section = document.getElementById( id );
+			const tab = document.querySelector( `a[role="tab"][aria-controls=${ id }]` );
+			if ( section && tab ) {
+				tab.setAttribute( 'aria-selected', true );
+				section.setAttribute( 'aria-hidden', false );
+			}
+		}
 	}
 };
 

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/view.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+
+const init = () => {
+	const containers = document.querySelectorAll( '.wp-block-wporg-release-tables' );
+	if ( containers ) {
+		containers.forEach( ( element ) => {
+			console.log( element );
+		} );
+	}
+};
+
+window.addEventListener( 'load', init );


### PR DESCRIPTION
 See #129 — This adds a new block for all the release tables on https://wordpress.org/download/releases/.

It displays the latest release, then the last two version branches. Below that, it has a list of past versions, betas, and the MU releases. Clicking one of those toggles the table to be visible. This is using a tab-panel pattern for accessibility. It also updates and reads from the URL hash, so if you link to `https://wordpress.org/download/releases/#betas`, the beta table will be displayed.

I haven't changed anything about the source data, so we don't have the release code name. We can iterate on adding that later.

⚠️  This branch is built on #131 (`add/download-subpages`), not `trunk`. The other branch enables the new theme on the download subpages so this can be tested.

### Screenshots

| Desktop | Mobile | Editor
|--------|-------|-------|
| ![releases-1200](https://user-images.githubusercontent.com/541093/195408693-fcf7753b-238c-44c0-818a-9a21380b00f3.png) | ![releases-480](https://user-images.githubusercontent.com/541093/195408689-ff659961-57c2-4a3f-bf2f-28fe4c9e5424.png) | ![releases-editor](https://user-images.githubusercontent.com/541093/195408696-52cba1ec-cecf-42a9-98e5-3d6b92cdb0cf.png) |

![releases-old-open](https://user-images.githubusercontent.com/541093/195408806-57cb37a9-449e-4a8b-8a11-7fde671508f1.png)

### How to test the changes in this Pull Request:

1. Make sure your `wporg-parent-2021` is up to date (the default table styling has been updated)
2. If testing locally, you'll need to mock the release data — drop [this file](https://gist.github.com/ryelle/5a36ea8090e1bf095a1c5b5496561786) into your `mu-plugins` folder.
3. View the releases page
4. There should be tables matching the screenshots
5. The links under "Past releases" should work to toggle between older version tables

