### PR TITLE
Add translator strings for preloading required fonts

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -66,14 +66,19 @@ function enqueue_assets() {
 
 	// Preload the heading font(s).
 	if ( is_callable( 'global_fonts_preload' ) ) {
-		// TODO: Load required fonts for rosetta sites once they are supported.
-		if ( ! is_rosetta_site() ) {
-			// All headings.
-			global_fonts_preload( 'EB Garamond Latin' );
+		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext. */
+		$heading_subsets = explode( ',', _x( 'latin', 'Heading font subsets, comma separated', 'wporg' ) );
+		// All headings.
+		foreach ( $heading_subsets as $heading_subset ) {
+			global_fonts_preload( 'EB Garamond', $heading_subset );
+		}
 
-			if ( is_front_page() ) {
-				// The heading on the front-page has some italic.
-				global_fonts_preload( 'EB Garamond Latin italic' );
+		if ( is_front_page() ) {
+			/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext. */
+			$front_page_heading_subsets = explode( ',', _x( 'latin', 'Front page heading font subsets, comma separated', 'wporg' ) );
+			// The heading on the front-page has some italic.
+			foreach ( $front_page_heading_subsets as $front_page_heading_subset ) {
+				global_fonts_preload( 'EB Garamond italic', $front_page_heading_subset );
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -67,19 +67,13 @@ function enqueue_assets() {
 	// Preload the heading font(s).
 	if ( is_callable( 'global_fonts_preload' ) ) {
 		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext. */
-		$heading_subsets = explode( ',', _x( 'latin', 'Heading font subsets, comma separated', 'wporg' ) );
+		$subsets = _x( 'latin', 'Heading font subsets, comma separated', 'wporg' );
 		// All headings.
-		foreach ( $heading_subsets as $heading_subset ) {
-			global_fonts_preload( 'EB Garamond', $heading_subset );
-		}
+		global_fonts_preload( 'EB Garamond', $subsets );
 
 		if ( is_front_page() ) {
-			/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext. */
-			$front_page_heading_subsets = explode( ',', _x( 'latin', 'Front page heading font subsets, comma separated', 'wporg' ) );
 			// The heading on the front-page has some italic.
-			foreach ( $front_page_heading_subsets as $front_page_heading_subset ) {
-				global_fonts_preload( 'EB Garamond italic', $front_page_heading_subset );
-			}
+			global_fonts_preload( 'EB Garamond italic', $subsets );
 		}
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #136 

<!-- Don't forget to update the title with something descriptive. -->
Translators now have the option to add necessary fonts for preloading to rosetta sites.

<!-- If your change has a visual component, add a screenshot here. -->

<!-- If you can, add the appropriate [Component] label(s). -->
