### PR TITLE
Ensure Designers can only edit pages that already have a block template

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -91,12 +91,12 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 			$post = get_post( $args[0] );
 			if ( $post && 'page' === $post->post_type ) {
 				// There ought to be a way to do this using a function like `locate_block_template()`, but if there is I can't figure out how.
-				if ( 'page' === get_option( 'show_on_front' ) && $post->ID == get_option( 'page_on_front' ) ) {
+				if ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_on_front' ) == $post->ID ) {
 					$maybe_template = get_stylesheet_directory() . '/templates/front-page.html';
 				} else {
 					$maybe_template = get_stylesheet_directory() . '/templates/page-' . $post->post_name . '.html';
 				}
-				if ( !file_exists( $maybe_template ) ) {
+				if ( ! file_exists( $maybe_template ) ) {
 					$required_caps[] = 'do_not_allow';
 				}
 			}

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -86,6 +86,16 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 		// Special safety limits for Designer role when editing pages
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( user_can( $user_id, 'designer' ) ) {
+			// If a block template doesn't exist for this page then updates will be live, so stop designer users from editing the page.
+			// Note that this means a dev will need to create the template first before a designer can edit a page, even if it's an existing page.
+			$post = get_post( $args[0] );
+			if ( $post && 'page' === $post->post_type ) {
+				// There ought to be a way to do this using a function like `locate_block_template()`, but if there is I can't figure out how.
+				$maybe_template = get_stylesheet_directory() . '/templates/page-' . $post->post_name . '.html';
+				if ( !file_exists( $maybe_template ) ) {
+					$required_caps[] = 'do_not_allow';
+				}
+			}
 			if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD']
 				&& isset( $_POST['action'] ) && 'inline-save' === $_POST['action']
 				&& isset( $_POST['post_type'] ) && 'page' === $_POST['post_type'] ) {

--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -91,7 +91,11 @@ function map_meta_caps( $required_caps, $current_cap, $user_id, $args ) {
 			$post = get_post( $args[0] );
 			if ( $post && 'page' === $post->post_type ) {
 				// There ought to be a way to do this using a function like `locate_block_template()`, but if there is I can't figure out how.
-				$maybe_template = get_stylesheet_directory() . '/templates/page-' . $post->post_name . '.html';
+				if ( 'page' === get_option( 'show_on_front' ) && $post->ID == get_option( 'page_on_front' ) ) {
+					$maybe_template = get_stylesheet_directory() . '/templates/front-page.html';
+				} else {
+					$maybe_template = get_stylesheet_directory() . '/templates/page-' . $post->post_name . '.html';
+				}
 				if ( !file_exists( $maybe_template ) ) {
 					$required_caps[] = 'do_not_allow';
 				}


### PR DESCRIPTION

Editing a page without a block template means changes would immediately go live. This prevents it entirely, which means the workflow requires a dev to create the page template before a designer can start editing.


### How to test the changes in this Pull Request:

1. Log in as a Designer user
2. Go to wp-admin / Pages / All Pages
3. Pages that have templates (like Download) should have an Edit button; others (like Enterprise currently) should not.

<!-- If you can, add the appropriate [Component] label(s). -->
