### PR TITLE
Update css for Content overflow issue in wporg main

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -85,6 +85,8 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	.entry-content.entry-content > .alignfull .alignfull {
 		margin-left: calc(var(--wp--preset--spacing--60) * -1) !important;
 		margin-right: calc(var(--wp--preset--spacing--60) * -1) !important;
+		display: contents;
+		width: 100%;
 	}
 
 	/* Adjust spacing & font size of feature list items */


### PR DESCRIPTION
I have fixed following issue "Content overflow issue in Homepage" and "Hamburger menu issue due to content overflow on Homepage." which is mentioned in meta ticket.
[https://meta.trac.wordpress.org/ticket/6587](https://meta.trac.wordpress.org/ticket/6587)
[https://meta.trac.wordpress.org/ticket/6603](https://meta.trac.wordpress.org/ticket/6603)

