### PR TITLE
Add template, pattern and styles for Enterprise page

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2274,12 +2274,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "3edc3f99f11a33ddd24552687dc27cc59f8a2bc6"
+                "reference": "9276ce3861afbdcc91bfe43aa9fd6ba63d3b5646"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/3edc3f99f11a33ddd24552687dc27cc59f8a2bc6",
-                "reference": "3edc3f99f11a33ddd24552687dc27cc59f8a2bc6",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/9276ce3861afbdcc91bfe43aa9fd6ba63d3b5646",
+                "reference": "9276ce3861afbdcc91bfe43aa9fd6ba63d3b5646",
                 "shasum": ""
             },
             "require-dev": {
@@ -2317,7 +2317,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2023-01-09T23:35:45+00:00"
+            "time": "2023-01-10T20:53:46+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",

--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -8,6 +8,11 @@
 		"template": "page-download.html"
 	},
 	{
+		"slug": "enterprise-2",
+		"pattern": "enterprise.php",
+		"template": "page-enterprise.html"
+	},
+	{
 		"slug": "beta-nightly",
 		"pattern": "download-beta-nightly.php",
 		"template": "page-beta-nightly.html"

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -46,6 +46,7 @@ function should_use_new_theme() {
 		'/download/releases/',
 		'/download/source/',
 		'/mobile/',
+		'/enterprise/',
 	);
 	if ( ! in_array( $request_uri, $new_theme_pages ) ) {
 		return false;

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -46,7 +46,7 @@ function should_use_new_theme() {
 		'/download/releases/',
 		'/download/source/',
 		'/mobile/',
-		'/enterprise/',
+		'/enterprise-2/',
 	);
 	if ( ! in_array( $request_uri, $new_theme_pages ) ) {
 		return false;

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -20,8 +20,8 @@
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--60);flex-basis:45%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);flex-basis:45%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","placeholder":"\u003c?php _e( 'Content…', 'wporg' ); ?\u003e","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
 <p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7"><?php _e( 'WordPress content management system has grown to become a dominant market leader. Discover how today&#039;s biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
@@ -78,16 +78,15 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
-<div class="wp-block-columns alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"verticalAlignment":"bottom","width":"33%","className":"wporg-hidden-mobile"} -->
-<div class="wp-block-column is-vertically-aligned-bottom wporg-hidden-mobile" style="flex-basis:33%"><!-- wp:image {"width":402,"height":588,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" width="402" height="588" /></figure>
-<!-- /wp:image --></div>
+<!-- wp:cover {"url":"https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png","id":14920,"dimRatio":0,"focalPoint":{"x":0,"y":1},"isDark":false,"align":"full","className":"wporg-enterprise-use-cases","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<div class="wp-block-cover alignfull is-light wporg-enterprise-use-cases" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-14920" alt="" src="https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png" style="object-position:0% 100%" data-object-fit="cover" data-object-position="0% 100%" /><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:column {"verticalAlignment":"bottom","width":"33%"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:33%"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"67%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:67%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"heading-3"} -->
+<!-- wp:column {"width":"67%"} -->
+<div class="wp-block-column" style="flex-basis:67%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"heading-3"} -->
 <h2 class="wp-block-heading has-heading-3-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><?php _e( 'Enterprise use cases', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
@@ -140,12 +139,13 @@
 <!-- /wp:columns --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
-<!-- /wp:group -->
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
-<div class="wp-block-columns alignfull wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13887,"width":58,"height":60,"sizeSlug":"full","linkDestination":"none"} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;margin-top:0"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
+<div class="wp-block-columns alignwide wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"width":"0px","style":"none"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
+<div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"id":13887,"width":58,"height":60,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="58" height="60" /></figure>
 <!-- /wp:image -->
 
@@ -158,8 +158,8 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13886,"width":50,"height":61,"sizeSlug":"full","linkDestination":"none"} -->
+<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"width":"0px","style":"none"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
+<div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"id":13886,"width":50,"height":61,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="50" height="61" /></figure>
 <!-- /wp:image -->
 
@@ -172,8 +172,8 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13885,"width":63,"height":59,"sizeSlug":"full","linkDestination":"none"} -->
+<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"width":"0px","style":"none"}}} -->
+<div class="wp-block-column" style="border-style:none;border-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"id":13885,"width":63,"height":59,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="63" height="59" /></figure>
 <!-- /wp:image -->
 
@@ -188,10 +188,10 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"full","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-5px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
-<h2 class="alignfull wp-block-heading is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-5px"><?php _e( '<a href="https://wordpress.org/download/">Try WordPress</a>', 'wporg' ); ?></h2>
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","className":"wporg-enterprise-try-wordpress","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull wporg-enterprise-try-wordpress has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"5rem","right":"var:preset|spacing|edge-space","bottom":"5rem","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="padding-top:5rem;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:5rem;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"align":"full","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px","fontSize":"99px"}},"className":"wp-block-heading is-style-with-arrow","fontFamily":"inter"} -->
+<h2 class="wp-block-heading alignfull is-style-with-arrow has-inter-font-family" style="font-size:99px;font-style:normal;font-weight:300;letter-spacing:-2px"><?php _e( '<a href="https://wordpress.org/download/">Try WordPress</a>', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"full","style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|70"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}}} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/11/wordpress-enterprise-header-1024x313.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>"/></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
@@ -29,50 +29,53 @@
 <!-- /wp:columns -->
 
 <!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
-<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:image {"align":"center","id":14621,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/NYP.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" class="wp-image-14621"/></figure>
+<div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+
+<!-- wp:image {"align":"center","width":190,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/NYP-1.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" width="190" height="24"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14622,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Sun.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" class="wp-image-14622"/></figure>
+<!-- wp:image {"align":"center","width":76,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/Sun-1.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" width="76" height="24"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14623,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/People.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" class="wp-image-14623"/></figure>
+<!-- wp:image {"align":"center","width":81,"height":32,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/People-1.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" width="81" height="32"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14624,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/RD.png" alt="<?php _e( 'Reader\'s Digest logo', 'wporg' ); ?>" class="wp-image-14624"/></figure>
+<!-- wp:image {"align":"center","width":196,"height":27,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/RD-1.png" alt="<?php _e( 'Reader\'s Digest logo', 'wporg' ); ?>" width="196" height="27"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14625,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/WWD.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" class="wp-image-14625"/></figure>
+<!-- wp:image {"align":"center","width":88,"height":26,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/WWD-1.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" width="88" height="26"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14626,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Variety.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" class="wp-image-14626"/></figure>
+<!-- wp:image {"align":"center","width":104,"height":29,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/Variety-1.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" width="104" height="29"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14627,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Spotify.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" class="wp-image-14627"/></figure>
+<!-- wp:image {"align":"center","width":114,"height":36,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/Spotify-1.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" width="114" height="36"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14628,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/TED.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" class="wp-image-14628"/></figure>
+<!-- wp:image {"align":"center","width":69,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/TED-1.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" width="69" height="25"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14629,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/facebook.png" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" class="wp-image-14629"/></figure>
+<!-- wp:image {"align":"center","width":129,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/facebook-1.png" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" width="129" height="25"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14630,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/microsoft.png" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-14630"/></figure>
+<!-- wp:image {"width":141,"height":30,"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/microsoft-1.png" alt="<?php _e( 'Microsoft Logo', 'wporg' ); ?>" width="141" height="30"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","id":14631,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/CNN.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" class="wp-image-14631"/></figure>
+<!-- wp:image {"align":"center","width":72,"height":34,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/CNN-1.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" width="72" height="34"/></figure>
 <!-- /wp:image --></div>
+
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -7,32 +7,30 @@
 
 ?>
 
-<!-- wp:cover {"overlayColor":"charcoal-2","minHeightUnit":"px","align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-<div class="wp-block-cover alignfull" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-	<span aria-hidden="true" class="wp-block-cover__background has-charcoal-2-background-color has-background-dim-100 has-background-dim"></span>
-	<div class="wp-block-cover__inner-container">
+<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90"}}}} -->
+<div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/11/wordpress-enterprise-header-1024x313.png" alt="WordPress Enterprise"/></figure>
+<!-- /wp:image -->
 
-	<!-- wp:media-text {"mediaId":13919,"mediaType":"image","mediaWidth":52,"verticalAlignment":"center","imageFill":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|90","bottom":"var:preset|spacing|40","left":"var:preset|spacing|10"}}}} -->
-	<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--10);grid-template-columns:52% auto">
+<!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
+<h1 class="wp-block-heading screen-reader-text">WordPress Enterprise</h1>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
 
-	<figure class="wp-block-media-text__media"><img src="https://wordpress.org/files/2022/11/wordpress-enterprise-header-1024x313.png" alt="WordPress Enterprise Heading" class="wp-image-13919 size-full"/></figure><div class="wp-block-media-text__content">
+<!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","bottom":"var:preset|spacing|40","top":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:45%"><!-- wp:group {"className":"wporg-enterprise-intro","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"Content…","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
+<p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7">WordPress content management system has grown to become a dominant market leader. Discover how today's biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
 
-	<!-- wp:group {"className":"wporg-enterprise-intro","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
-	<div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"Content…","style":{"typography":{"lineHeight":1.7},"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"className":"is-style-default","fontSize":"small"} -->
-	<p class="has-text-align-center is-style-default has-small-font-size" style="margin-top:var(--wp--preset--spacing--50);line-height:1.7">WordPress content management system has grown to become a dominant market leader. Discover how today's biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group -->
-
-	</div>
-	</div>
-	<!-- /wp:media-text -->
-	</div>
-</div>
-<!-- /wp:cover -->
-
-<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","textColor":"white","className":"is-style-default","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-default has-white-color has-charcoal-2-background-color has-text-color has-background"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
-<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:image {"align":"center","id":14621,"sizeSlug":"full","linkDestination":"none"} -->
+<!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:image {"align":"center","id":14621,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/NYP.png" alt="New York Post logo" class="wp-image-14621"/></figure>
 <!-- /wp:image -->
 
@@ -76,6 +74,7 @@
 <figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/CNN.png" alt="CNN logo" class="wp-image-14631"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
@@ -87,8 +86,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"63%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:63%"><!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading"} -->
-<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Enterprise use cases</h3>
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:63%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"heading-3"} -->
+<h2 class="wp-block-heading has-heading-3-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Enterprise use cases</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
@@ -97,8 +96,8 @@
 
 <!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","bottom":"var:preset|spacing|50"},"blockGap":"0"}}} -->
-<div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading is-style-default","fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading is-style-default has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Media and publishing</h2>
+<div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading is-style-default","fontSize":"large","fontFamily":"inter"} -->
+<h3 class="wp-block-heading is-style-default has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Media and publishing</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}},"fontSize":"small"} -->
@@ -107,8 +106,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"var:preset|spacing|50","left":"0"},"blockGap":"0"}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">E-commerce</h2>
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">E-commerce</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}},"fontSize":"small"} -->
@@ -119,8 +118,8 @@
 
 <!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","top":"0","bottom":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;font-style:normal;font-weight:600">Content marketing</h2>
+<div class="wp-block-column" style="padding-top:0;padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;font-style:normal;font-weight:600">Content marketing</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
@@ -129,8 +128,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"0","padding":{"bottom":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Higher education</h2>
+<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Higher education</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","right":"0","bottom":"0","left":"0"}}},"fontSize":"small"} -->
@@ -149,8 +148,8 @@
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="Extensibility icon" class="wp-image-13887" width="55"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
-<h3 class="wp-block-heading">Extensibility</h3>
+<!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
+<h4 class="wp-block-heading">Extensibility</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -163,8 +162,8 @@
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="Security icon" class="wp-image-13886" width="47"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
-<h3 class="wp-block-heading">Security</h3>
+<!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
+<h4 class="wp-block-heading">Security</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -177,8 +176,8 @@
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="Open Source Icon" class="wp-image-13885" width="62"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
-<h3 class="wp-block-heading">Open source</h3>
+<!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
+<h4 class="wp-block-heading">Open source</h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -188,14 +187,14 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}},"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-<div class="wp-block-group alignwide has-link-color" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:heading {"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
-<h2 class="alignwide wp-block-heading is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/download/">Try WordPress</a></h2>
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"full","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+<h2 class="wp-block-heading alignfull is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/download/">Try WordPress</a></h2>
 <!-- /wp:heading -->
 
-<!-- wp:columns {"style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|70"}}}} -->
-<div class="wp-block-columns" style="border-radius:0px;padding-top:var(--wp--preset--spacing--70)"><!-- wp:column {"className":"wp-block-navigation"} -->
+<!-- wp:columns {"align":"full","style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|70"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}}} -->
+<div class="wp-block-columns alignfull has-link-color" style="border-radius:0px;padding-top:var(--wp--preset--spacing--70)"><!-- wp:column {"className":"wp-block-navigation"} -->
 <div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
 <h5 class="wp-block-heading">Case studies</h5>
 <!-- /wp:heading -->
@@ -246,7 +245,7 @@
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://vimeo.com/374961815/040fe06be7">Gutenberg for Enterprise</a>↗</li>
+<li><a href="https://vimeo.com/374961815/040fe06be7">Gutenberg for Enterprise↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -11,18 +11,18 @@
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/11/wordpress-enterprise-header-1024x313.png" alt="WordPress Enterprise"/></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/11/wordpress-enterprise-header-1024x313.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
-<h1 class="wp-block-heading screen-reader-text">WordPress Enterprise</h1>
+<h1 class="wp-block-heading screen-reader-text"><?php _e( 'WordPress Enterprise', 'wporg' ); ?></h1>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","bottom":"var:preset|spacing|40","top":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:45%"><!-- wp:group {"className":"wporg-enterprise-intro","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 <div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"Content…","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
-<p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7">WordPress content management system has grown to become a dominant market leader. Discover how today's biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.</p>
+<p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7"><?php _e( 'WordPress content management system has grown to become a dominant market leader. Discover how today\'s biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -31,47 +31,47 @@
 <!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
 <div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:image {"align":"center","id":14621,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/NYP.png" alt="New York Post logo" class="wp-image-14621"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/NYP.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" class="wp-image-14621"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14622,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Sun.png" alt="The Sun logo" class="wp-image-14622"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Sun.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" class="wp-image-14622"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14623,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/People.png" alt="People logo" class="wp-image-14623"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/People.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" class="wp-image-14623"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14624,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/RD.png" alt="Reader's Digest logo" class="wp-image-14624"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/RD.png" alt="<?php _e( 'Reader\'s Digest logo', 'wporg' ); ?>" class="wp-image-14624"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14625,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/WWD.png" alt="WWD logo" class="wp-image-14625"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/WWD.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" class="wp-image-14625"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14626,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Variety.png" alt="Variety logo" class="wp-image-14626"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Variety.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" class="wp-image-14626"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14627,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Spotify.png" alt="Spotify logo" class="wp-image-14627"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Spotify.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" class="wp-image-14627"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14628,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/TED.png" alt="TED logo" class="wp-image-14628"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/TED.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" class="wp-image-14628"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14629,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/facebook.png" alt="Facebook logo" class="wp-image-14629"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/facebook.png" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" class="wp-image-14629"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14630,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/microsoft.png" alt="Microsoft logo" class="wp-image-14630"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/microsoft.png" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-14630"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"center","id":14631,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/CNN.png" alt="CNN logo" class="wp-image-14631"/></figure>
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/CNN.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" class="wp-image-14631"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
@@ -81,37 +81,37 @@
 <div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":"top","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"width":"37%","className":"wporg-hidden-mobile"} -->
 <div class="wp-block-column wporg-hidden-mobile" style="flex-basis:37%"><!-- wp:image {"id":14095,"sizeSlug":"full"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2022/12/enterprise-use-cases-full.png" alt="Enterprise Use Cases Image" class="wp-image-14095"/></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2022/12/enterprise-use-cases-full.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" class="wp-image-14095"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"63%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
 <div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:63%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"heading-3"} -->
-<h2 class="wp-block-heading has-heading-3-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Enterprise use cases</h2>
+<h2 class="wp-block-heading has-heading-3-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><?php _e( 'Enterprise use cases', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
-<p style="padding-bottom:var(--wp--preset--spacing--60)">Whether as a primary or secondary content management system (CMS), you'll find WordPress being used by enterprises at scale wherever there's a requirement for flexible, cost-effective, and secure creation and distribution of content. Explore some of the platform's most popular use cases for enterprises:</p>
+<p style="padding-bottom:var(--wp--preset--spacing--60)"><?php _e( 'Whether as a primary or secondary content management system (CMS), you\'ll find WordPress being used by enterprises at scale wherever there\'s a requirement for flexible, cost-effective, and secure creation and distribution of content. Explore some of the platform\'s most popular use cases for enterprises:', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","bottom":"var:preset|spacing|50"},"blockGap":"0"}}} -->
 <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading is-style-default","fontSize":"large","fontFamily":"inter"} -->
-<h3 class="wp-block-heading is-style-default has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Media and publishing</h3>
+<h3 class="wp-block-heading is-style-default has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600"><?php _e( 'Media and publishing', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10)">WordPress powers the sites people visit multiple times every day for news, information, and entertainment.</p>
+<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10)"><?php _e( 'WordPress powers the sites people visit multiple times every day for news, information, and entertainment.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"var:preset|spacing|50","left":"0"},"blockGap":"0"}}} -->
 <div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">E-commerce</h3>
+<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600"><?php _e( 'E-commerce', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10)">Organizations around the world choose WordPress as their e-commerce solution of choice.</p>
+<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10)"><?php _e( 'Organizations around the world choose WordPress as their e-commerce solution of choice.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -119,21 +119,21 @@
 <!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","top":"0","bottom":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-column" style="padding-top:0;padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;font-style:normal;font-weight:600">Content marketing</h3>
+<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;font-style:normal;font-weight:600"><?php _e( 'Content marketing', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">WordPress will help you get your brand's story in front of your potential customers quickly and easily.</p>
+<p class="has-small-font-size"><?php _e( 'WordPress will help you get your brand\'s story in front of your potential customers quickly and easily.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"0","padding":{"bottom":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Higher education</h3>
+<h3 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600"><?php _e( 'Higher education', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","right":"0","bottom":"0","left":"0"}}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10);padding-right:0;padding-bottom:0;padding-left:0">Educational institutions use WordPress to power everything, from a departmental blog to an entire university system.</p>
+<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10);padding-right:0;padding-bottom:0;padding-left:0"><?php _e( 'Educational institutions use WordPress to power everything, from a departmental blog to an entire university system.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
@@ -145,43 +145,43 @@
 <div class="wp-block-group alignfull" style="margin-top:0"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
 <div class="wp-block-columns alignfull wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
 <div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13887,"width":55,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="Extensibility icon" class="wp-image-13887" width="55"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="55"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
-<h4 class="wp-block-heading">Extensibility</h4>
+<h4 class="wp-block-heading"><?php _e( 'Extensibility', 'wporg' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Enterprise-level extensions for WordPress span a broad range of functionality, from enhanced search and advanced on-page SEO, to AI-driven content augmentation and developer power tools.</p>
+<p><?php _e( 'Enterprise-level extensions for WordPress span a broad range of functionality, from enhanced search and advanced on-page SEO, to AI-driven content augmentation and developer power tools.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
 <div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13886,"width":47,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="Security icon" class="wp-image-13886" width="47"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="47"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
-<h4 class="wp-block-heading">Security</h4>
+<h4 class="wp-block-heading"><?php _e( 'Security', 'wporg' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>WordPress has strict security standards that make it a popular CMS for enterprise companies around the world. While its popularity might make it a target, it has proven itself as a secure platform.</p>
+<p><?php _e( 'WordPress has strict security standards that make it a popular CMS for enterprise companies around the world. While its popularity might make it a target, it has proven itself as a secure platform.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
 <div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13885,"width":62,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="Open Source Icon" class="wp-image-13885" width="62"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="62"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
-<h4 class="wp-block-heading">Open source</h4>
+<h4 class="wp-block-heading"><?php _e( 'Open source', 'wporg' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>WordPress is open source software. This means the source code is made freely available and may be distributed and modified subject to the GPL license.</p>
+<p><?php _e( 'WordPress is open source software. This means the source code is made freely available and may be distributed and modified subject to the GPL license.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
@@ -190,66 +190,66 @@
 <!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"full","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
-<h2 class="wp-block-heading alignfull is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/download/">Try WordPress</a></h2>
+<h2 class="wp-block-heading alignfull is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/download/"><?php _e( 'Try WordPress', 'wporg' ); ?></a></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"full","style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|70"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}}} -->
 <div class="wp-block-columns alignfull has-link-color" style="border-radius:0px;padding-top:var(--wp--preset--spacing--70)"><!-- wp:column {"className":"wp-block-navigation"} -->
-<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
-<h5 class="wp-block-heading">Case studies</h5>
+<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":3,"className":"wp-block-heading","fontSize":"heading-5"} -->
+<h3 class="wp-block-heading has-heading-5-font-size"><?php _e( 'Case studies', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:list {"className":"is-style-default","fontSize":"small"} -->
 <ul class="is-style-default has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf">Abril (PDF)↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf"><?php _e( 'Abril (PDF)', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf">KFF (PDF)↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf"><?php _e( 'KFF (PDF)', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf">NewsCorp Australia (PDF)↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf"><?php _e( 'NewsCorp Australia (PDF)', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"className":"wp-block-navigation"} -->
-<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
-<h5 class="wp-block-heading">White paper references</h5>
+<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":3,"className":"wp-block-heading","fontSize":"heading-5"} -->
+<h3 class="wp-block-heading has-heading-5-font-size"><?php _e( 'White paper references', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:list {"fontSize":"small"} -->
 <ul class="has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf">IDC Report (PDF)↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf"><?php _e( 'IDC Report (PDF)', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf">WP as a Content Hub (PDF)↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf"><?php _e( 'WP as a Content Hub (PDF)', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf">Personalization (PDF)↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf"><?php _e( 'Personalization (PDF)', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"className":"wp-block-navigation"} -->
-<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
-<h5 class="wp-block-heading">Tutorials</h5>
+<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":3,"className":"wp-block-heading","fontSize":"heading-5"} -->
+<h3 class="wp-block-heading has-heading-5-font-size"><?php _e( 'Tutorials', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:list {"fontSize":"small"} -->
 <ul class="has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://vimeo.com/443114625/c2f798174f">Drive Digital Commerce with Content Marketing↗</a></li>
+<li><a href="https://vimeo.com/443114625/c2f798174f"><?php _e( 'Drive Digital Commerce with Content Marketing', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://vimeo.com/374961815/040fe06be7">Gutenberg for Enterprise↗</a></li>
+<li><a href="https://vimeo.com/374961815/040fe06be7"><?php _e( 'Gutenberg for Enterprise', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://vimeo.com/425968597/80d24a1bf4">Lead a Successful Digital Transformation↗</a></li>
+<li><a href="https://vimeo.com/425968597/80d24a1bf4"><?php _e( 'Lead a Successful Digital Transformation', 'wporg' ); ?>↗</a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -11,8 +11,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","right":"0","left":"0"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90);padding-right:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" /></figure>
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"id":15559,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" class="wp-image-15559" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":1,"className":"wp-block-heading screen-reader-text"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -6,23 +6,24 @@
  */
 
 ?>
+<!-- wp:wporg/global-header /-->
 
 <!-- wp:group {"align":"full","backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" width="100%" height="100%"/></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
+<!-- wp:heading {"level":1,"className":"wp-block-heading screen-reader-text"} -->
 <h1 class="wp-block-heading screen-reader-text"><?php _e( 'WordPress Enterprise', 'wporg' ); ?></h1>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","bottom":"var:preset|spacing|40","top":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:45%"><!-- wp:group {"className":"wporg-enterprise-intro","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
-<div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"Content…","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
-<p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7"><?php _e( 'WordPress content management system has grown to become a dominant market leader. Discover how today\'s biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.', 'wporg' ); ?></p>
+<div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"\u003c?php _e( 'Content…', 'wporg' ); ?\u003e","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
+<p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7"><?php _e( 'WordPress content management system has grown to become a dominant market leader. Discover how today&#039;s biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -30,64 +31,59 @@
 
 <!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
-<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-
-<!-- wp:image {"align":"center","width":190,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/NYP-1.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" width="190" height="24"/></figure>
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"width":190,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/NYP-1.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" width="190" height="24" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":76,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/Sun-1.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" width="76" height="24"/></figure>
+<!-- wp:image {"width":76,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Sun-1.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" width="76" height="24" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":81,"height":32,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/People-1.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" width="81" height="32"/></figure>
+<!-- wp:image {"width":81,"height":32,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/People-1.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" width="81" height="32" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":196,"height":27,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/RD-1.png" alt="<?php _e( 'Reader\'s Digest logo', 'wporg' ); ?>" width="196" height="27"/></figure>
+<!-- wp:image {"width":196,"height":27,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/RD-1.png" alt="<?php _e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" width="196" height="27" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":88,"height":26,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/WWD-1.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" width="88" height="26"/></figure>
+<!-- wp:image {"width":88,"height":26,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/WWD-1.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" width="88" height="26" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":104,"height":29,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/Variety-1.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" width="104" height="29"/></figure>
+<!-- wp:image {"width":104,"height":29,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Variety-1.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" width="104" height="29" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":114,"height":36,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/Spotify-1.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" width="114" height="36"/></figure>
+<!-- wp:image {"width":114,"height":36,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Spotify-1.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" width="114" height="36" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":69,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/TED-1.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" width="69" height="25"/></figure>
+<!-- wp:image {"width":69,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/TED-1.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" width="69" height="25" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":129,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/facebook-1.png" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" width="129" height="25"/></figure>
+<!-- wp:image {"width":129,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/facebook-1.png" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" width="129" height="25" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":141,"height":30,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/microsoft-1.png" alt="<?php _e( 'Microsoft Logo', 'wporg' ); ?>" width="141" height="30"/></figure>
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/microsoft-1.png" alt="<?php _e( 'Microsoft Logo', 'wporg' ); ?>" width="141" height="30" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"align":"center","width":72,"height":34,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wordpress.org/files/2022/12/CNN-1.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" width="72" height="34"/></figure>
+<!-- wp:image {"width":72,"height":34,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/CNN-1.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" width="72" height="34" /></figure>
 <!-- /wp:image --></div>
-
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":"top","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"width":"33%","className":"wporg-hidden-mobile"} -->
-<div class="wp-block-column wporg-hidden-mobile" style="flex-basis:33%">
-<!-- wp:image {"width":402,"height":588,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" width="402" height="588"/></figure>
-<!-- /wp:image -->
-</div>
+<div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":null,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"verticalAlignment":"bottom","width":"33%","className":"wporg-hidden-mobile"} -->
+<div class="wp-block-column is-vertically-aligned-bottom wporg-hidden-mobile" style="flex-basis:33%"><!-- wp:image {"width":402,"height":588,"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" width="402" height="588" /></figure>
+<!-- /wp:image --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"67%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
@@ -96,7 +92,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
-<p style="padding-bottom:var(--wp--preset--spacing--60)"><?php _e( 'Whether as a primary or secondary content management system (CMS), you\'ll find WordPress being used by enterprises at scale wherever there\'s a requirement for flexible, cost-effective, and secure creation and distribution of content. Explore some of the platform\'s most popular use cases for enterprises:', 'wporg' ); ?></p>
+<p style="padding-bottom:var(--wp--preset--spacing--60)"><?php _e( 'Whether as a primary or secondary content management system (CMS), you&#039;ll find WordPress being used by enterprises at scale wherever there&#039;s a requirement for flexible, cost-effective, and secure creation and distribution of content. Explore some of the platform&#039;s most popular use cases for enterprises:', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
@@ -128,7 +124,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><?php _e( 'WordPress will help you get your brand\'s story in front of your potential customers quickly and easily.', 'wporg' ); ?></p>
+<p class="has-small-font-size"><?php _e( 'WordPress will help you get your brand&#039;s story in front of your potential customers quickly and easily.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
@@ -149,9 +145,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
 <div class="wp-block-columns alignfull wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
-<!-- wp:image {"id":13887,"width":58,"height":60,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="58" height="60"/></figure>
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13887,"width":58,"height":60,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="58" height="60" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
@@ -164,9 +159,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
-<!-- wp:image {"id":13886,"width":50,"height":61,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="50" height="61"/></figure>
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13886,"width":50,"height":61,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="50" height="61" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
@@ -179,9 +173,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
-<!-- wp:image {"id":13885,"width":63,"height":59,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="63" height="59"/></figure>
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13885,"width":63,"height":59,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="63" height="59" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
@@ -195,10 +188,10 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"full","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
-<h2 class="wp-block-heading alignfull is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/download/"><?php _e( 'Try WordPress', 'wporg' ); ?></a></h2>
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"full","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-5px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+<h2 class="alignfull wp-block-heading is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-5px"><?php _e( '<a href="https://wordpress.org/download/">Try WordPress</a>', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"full","style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|70"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}}} -->
@@ -209,15 +202,15 @@
 
 <!-- wp:list {"className":"is-style-default","fontSize":"small"} -->
 <ul class="is-style-default has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf"><?php _e( 'Abril (PDF)', 'wporg' ); ?>↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf"><?php _e( 'Abril (PDF)↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf"><?php _e( 'KFF (PDF)', 'wporg' ); ?>↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf"><?php _e( 'KFF (PDF)↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf"><?php _e( 'NewsCorp Australia (PDF)', 'wporg' ); ?>↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf"><?php _e( 'NewsCorp Australia (PDF)↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column -->
@@ -229,15 +222,15 @@
 
 <!-- wp:list {"fontSize":"small"} -->
 <ul class="has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf"><?php _e( 'IDC Report (PDF)', 'wporg' ); ?>↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf"><?php _e( 'IDC Report (PDF)↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf"><?php _e( 'WP as a Content Hub (PDF)', 'wporg' ); ?>↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf"><?php _e( 'WP as a Content Hub (PDF)↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf"><?php _e( 'Personalization (PDF)', 'wporg' ); ?>↗</a></li>
+<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf"><?php _e( 'Personalization (PDF)↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column -->
@@ -249,18 +242,20 @@
 
 <!-- wp:list {"fontSize":"small"} -->
 <ul class="has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://vimeo.com/443114625/c2f798174f"><?php _e( 'Drive Digital Commerce with Content Marketing', 'wporg' ); ?>↗</a></li>
+<li><a href="https://vimeo.com/443114625/c2f798174f"><?php _e( 'Drive Digital Commerce with Content Marketing↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://vimeo.com/374961815/040fe06be7"><?php _e( 'Gutenberg for Enterprise', 'wporg' ); ?>↗</a></li>
+<li><a href="https://vimeo.com/374961815/040fe06be7"><?php _e( 'Gutenberg for Enterprise↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://vimeo.com/425968597/80d24a1bf4"><?php _e( 'Lead a Successful Digital Transformation', 'wporg' ); ?>↗</a></li>
+<li><a href="https://vimeo.com/425968597/80d24a1bf4"><?php _e( 'Lead a Successful Digital Transformation↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
+
+<!-- wp:wporg/global-footer /-->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -9,8 +9,8 @@
 <!-- wp:wporg/global-header /-->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","right":"0","left":"0"},"blockGap":{"left":"0"}}}} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90);padding-right:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
+<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","right":"0","left":"0"},"blockGap":{"left":"0"}}},"className":"wporg-enterprise-header"} -->
+<div class="wp-block-columns alignfull are-vertically-aligned-center wporg-enterprise-header" style="padding-top:var(--wp--preset--spacing--90);padding-right:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"id":15559,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" class="wp-image-15559" /></figure>
 <!-- /wp:image -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>"/></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" width="100%" height="100%"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
@@ -149,8 +149,9 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="margin-top:0"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
 <div class="wp-block-columns alignfull wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13887,"width":55,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="55"/></figure>
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+<!-- wp:image {"id":13887,"width":58,"height":60,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="58" height="60"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
@@ -163,8 +164,9 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13886,"width":47,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="47"/></figure>
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+<!-- wp:image {"id":13886,"width":50,"height":61,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="50" height="61"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
@@ -177,8 +179,9 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13885,"width":62,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="62"/></figure>
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+<!-- wp:image {"id":13885,"width":63,"height":59,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="63" height="59"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wp-block-heading"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -9,7 +9,7 @@
 <!-- wp:wporg/global-header /-->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","right":"0","left":"0"}}}} -->
+<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","right":"0","left":"0"},"blockGap":{"left":"0"}}}} -->
 <div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90);padding-right:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"id":15559,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" class="wp-image-15559" /></figure>
@@ -21,7 +21,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);flex-basis:45%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);flex-basis:45%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","orientation":"horizontal"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center","placeholder":"\u003c?php _e( 'Content…', 'wporg' ); ?\u003e","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
 <p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7"><?php _e( 'WordPress content management system has grown to become a dominant market leader. Discover how today&#039;s biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Title: Enterprise
+ * Slug: wporg-main-2022/enterprise
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:cover {"overlayColor":"charcoal-2","minHeightUnit":"px","align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<div class="wp-block-cover alignfull" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+	<span aria-hidden="true" class="wp-block-cover__background has-charcoal-2-background-color has-background-dim-100 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+
+	<!-- wp:media-text {"mediaId":13919,"mediaType":"image","mediaWidth":52,"verticalAlignment":"center","imageFill":false,"style":{"spacing":{"padding":{"top":"var:preset|spacing|90","bottom":"var:preset|spacing|40","left":"var:preset|spacing|10"}}}} -->
+	<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--10);grid-template-columns:52% auto">
+
+	<figure class="wp-block-media-text__media"><img src="https://wordpress.org/files/2022/11/wordpress-enterprise-header-1024x313.png" alt="WordPress Enterprise Heading" class="wp-image-13919 size-full"/></figure><div class="wp-block-media-text__content">
+
+	<!-- wp:group {"className":"wporg-enterprise-intro","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+	<div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"Content…","style":{"typography":{"lineHeight":1.7},"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"className":"is-style-default","fontSize":"small"} -->
+	<p class="has-text-align-center is-style-default has-small-font-size" style="margin-top:var(--wp--preset--spacing--50);line-height:1.7">WordPress content management system has grown to become a dominant market leader. Discover how today's biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
+
+	</div>
+	</div>
+	<!-- /wp:media-text -->
+	</div>
+</div>
+<!-- /wp:cover -->
+
+<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","textColor":"white","className":"is-style-default","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-default has-white-color has-charcoal-2-background-color has-text-color has-background"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:image {"align":"center","id":14621,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/NYP.png" alt="New York Post logo" class="wp-image-14621"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14622,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Sun.png" alt="The Sun logo" class="wp-image-14622"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14623,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/People.png" alt="People logo" class="wp-image-14623"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14624,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/RD.png" alt="Reader's Digest logo" class="wp-image-14624"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14625,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/WWD.png" alt="WWD logo" class="wp-image-14625"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14626,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Variety.png" alt="Variety logo" class="wp-image-14626"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14627,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/Spotify.png" alt="Spotify logo" class="wp-image-14627"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14628,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/TED.png" alt="TED logo" class="wp-image-14628"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14629,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/facebook.png" alt="Facebook logo" class="wp-image-14629"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14630,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/microsoft.png" alt="Microsoft logo" class="wp-image-14630"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":14631,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="https://wordpress.org/files/2022/12/CNN.png" alt="CNN logo" class="wp-image-14631"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":"top","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
+<div class="wp-block-columns alignfull are-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"width":"37%","className":"wporg-hidden-mobile"} -->
+<div class="wp-block-column wporg-hidden-mobile" style="flex-basis:37%"><!-- wp:image {"id":14095,"sizeSlug":"full"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2022/12/enterprise-use-cases-full.png" alt="Enterprise Use Cases Image" class="wp-image-14095"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"63%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:63%"><!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading"} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Enterprise use cases</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
+<p style="padding-bottom:var(--wp--preset--spacing--60)">Whether as a primary or secondary content management system (CMS), you'll find WordPress being used by enterprises at scale wherever there's a requirement for flexible, cost-effective, and secure creation and distribution of content. Explore some of the platform's most popular use cases for enterprises:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","bottom":"var:preset|spacing|50"},"blockGap":"0"}}} -->
+<div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading is-style-default","fontSize":"large","fontFamily":"inter"} -->
+<h2 class="wp-block-heading is-style-default has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Media and publishing</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10)">WordPress powers the sites people visit multiple times every day for news, information, and entertainment.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"var:preset|spacing|50","left":"0"},"blockGap":"0"}}} -->
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">E-commerce</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10"}}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10)">Organizations around the world choose WordPress as their e-commerce solution of choice.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","top":"0","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column" style="padding-top:0;padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;font-style:normal;font-weight:600">Content marketing</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size">WordPress will help you get your brand's story in front of your potential customers quickly and easily.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0","padding":{"bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"className":"wp-block-heading","fontSize":"large","fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:600">Higher education</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","right":"0","bottom":"0","left":"0"}}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="padding-top:var(--wp--preset--spacing--10);padding-right:0;padding-bottom:0;padding-left:0">Educational institutions use WordPress to power everything, from a departmental blog to an entire university system.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
+<div class="wp-block-columns alignfull wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13887,"width":55,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="Extensibility icon" class="wp-image-13887" width="55"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
+<h3 class="wp-block-heading">Extensibility</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Enterprise-level extensions for WordPress span a broad range of functionality, from enhanced search and advanced on-page SEO, to AI-driven content augmentation and developer power tools.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13886,"width":47,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="Security icon" class="wp-image-13886" width="47"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
+<h3 class="wp-block-heading">Security</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>WordPress has strict security standards that make it a popular CMS for enterprise companies around the world. While its popularity might make it a target, it has proven itself as a secure platform.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
+<div class="wp-block-column" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:image {"id":13885,"width":62,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="Open Source Icon" class="wp-image-13885" width="62"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
+<h3 class="wp-block-heading">Open source</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>WordPress is open source software. This means the source code is made freely available and may be distributed and modified subject to the GPL license.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}},"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull has-charcoal-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<div class="wp-block-group alignwide has-link-color" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:heading {"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"wp-block-heading is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+<h2 class="alignwide wp-block-heading is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/download/">Try WordPress</a></h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|70"}}}} -->
+<div class="wp-block-columns" style="border-radius:0px;padding-top:var(--wp--preset--spacing--70)"><!-- wp:column {"className":"wp-block-navigation"} -->
+<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
+<h5 class="wp-block-heading">Case studies</h5>
+<!-- /wp:heading -->
+
+<!-- wp:list {"className":"is-style-default","fontSize":"small"} -->
+<ul class="is-style-default has-small-font-size"><!-- wp:list-item -->
+<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf">Abril (PDF)↗</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf">KFF (PDF)↗</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf">NewsCorp Australia (PDF)↗</a></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"className":"wp-block-navigation"} -->
+<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
+<h5 class="wp-block-heading">White paper references</h5>
+<!-- /wp:heading -->
+
+<!-- wp:list {"fontSize":"small"} -->
+<ul class="has-small-font-size"><!-- wp:list-item -->
+<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf">IDC Report (PDF)↗</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf">WP as a Content Hub (PDF)↗</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf">Personalization (PDF)↗</a></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"className":"wp-block-navigation"} -->
+<div class="wp-block-column wp-block-navigation"><!-- wp:heading {"level":5,"className":"wp-block-heading"} -->
+<h5 class="wp-block-heading">Tutorials</h5>
+<!-- /wp:heading -->
+
+<!-- wp:list {"fontSize":"small"} -->
+<ul class="has-small-font-size"><!-- wp:list-item -->
+<li><a href="https://vimeo.com/443114625/c2f798174f">Drive Digital Commerce with Content Marketing↗</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://vimeo.com/374961815/040fe06be7">Gutenberg for Enterprise</a>↗</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://vimeo.com/425968597/80d24a1bf4">Lead a Successful Digital Transformation↗</a></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -145,9 +145,11 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;margin-top:0"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"bottom":"0","top":"0"},"blockGap":{"top":"0","left":"0"}},"border":{"radius":"0px","width":"0px","style":"none"}},"className":"wporg-enterprise-features"} -->
 <div class="wp-block-columns alignwide wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"width":"0px","style":"none"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"id":13887,"width":58,"height":60,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="58" height="60" /></figure>
-<!-- /wp:image -->
+<div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":15893,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"56px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-15893" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
 
 <!-- wp:heading {"className":"wp-block-heading","fontSize":"heading-4"} -->
 <h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Extensibility', 'wporg' ); ?></h2>
@@ -159,9 +161,11 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"width":"0px","style":"none"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
-<div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"id":13886,"width":50,"height":61,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="50" height="61" /></figure>
-<!-- /wp:image -->
+<div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":15899,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"48px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-15899" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
 
 <!-- wp:heading {"className":"wp-block-heading","fontSize":"heading-4"} -->
 <h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Security', 'wporg' ); ?></h2>
@@ -173,9 +177,11 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"width":"0px","style":"none"}}} -->
-<div class="wp-block-column" style="border-style:none;border-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"id":13885,"width":63,"height":59,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="63" height="59" /></figure>
-<!-- /wp:image -->
+<div class="wp-block-column" style="border-style:none;border-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":15901,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"63px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Open_Source.png" alt="<?php _e( 'Open Source icon', 'wporg' ); ?>" class="wp-image-15901" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
 
 <!-- wp:heading {"className":"wp-block-heading","fontSize":"heading-4"} -->
 <h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Open source', 'wporg' ); ?></h2>

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -242,15 +242,15 @@
 
 <!-- wp:list {"fontSize":"small"} -->
 <ul class="has-small-font-size"><!-- wp:list-item {"className":"external-link"} -->
-<li class="external-link"><a href="https://vimeo.com/443114625/c2f798174f"><?php _e( 'Drive Digital Commerce with Content Marketing', 'wporg' ); ?></a></li>
+<li class="external-link"><a href="https://vimeo.com/443114625/c2f798174f" target="_blank" rel="noreferrer noopener"><?php _e( 'Drive Digital Commerce with Content Marketing', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item {"className":"external-link"} -->
-<li class="external-link"><a href="https://vimeo.com/374961815/040fe06be7"><?php _e( 'Gutenberg for Enterprise', 'wporg' ); ?></a></li>
+<li class="external-link"><a href="https://vimeo.com/374961815/040fe06be7" target="_blank" rel="noreferrer noopener"><?php _e( 'Gutenberg for Enterprise', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item {"className":"external-link"} -->
-<li class="external-link"><a href="https://vimeo.com/425968597/80d24a1bf4"><?php _e( 'Lead a Successful Digital Transformation', 'wporg' ); ?></a></li>
+<li class="external-link"><a href="https://vimeo.com/425968597/80d24a1bf4" target="_blank" rel="noreferrer noopener"><?php _e( 'Lead a Successful Digital Transformation', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -8,9 +8,9 @@
 ?>
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90"}}}} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90)"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|90","right":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignfull are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--90);padding-right:0;padding-left:0"><!-- wp:column {"verticalAlignment":"center","width":"55%","style":{"spacing":{"padding":{"left":"var:preset|spacing|10","right":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--10);flex-basis:55%"><!-- wp:image {"sizeSlug":"large"} -->
 <figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2022/12/WordPress-Enterprise.png" alt="<?php _e( 'WordPress Enterprise', 'wporg' ); ?>" /></figure>
 <!-- /wp:image -->
@@ -20,9 +20,9 @@
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","bottom":"var:preset|spacing|40","top":"var:preset|spacing|60"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:45%"><!-- wp:group {"className":"wporg-enterprise-intro","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
-<div class="wp-block-group wporg-enterprise-intro"><!-- wp:paragraph {"align":"center","placeholder":"\u003c?php _e( 'Content…', 'wporg' ); ?\u003e","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
+<!-- wp:column {"verticalAlignment":"center","width":"45%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--60);flex-basis:45%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"align":"center","placeholder":"\u003c?php _e( 'Content…', 'wporg' ); ?\u003e","style":{"typography":{"lineHeight":1.7}},"textColor":"white","className":"is-style-default","fontSize":"small"} -->
 <p class="has-text-align-center is-style-default has-white-color has-text-color has-small-font-size" style="line-height:1.7"><?php _e( 'WordPress content management system has grown to become a dominant market leader. Discover how today&#039;s biggest brands use WordPress, the features that make it so appealing and how you can make WordPress work for your enterprise.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
@@ -79,7 +79,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":null,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
+<div class="wp-block-group alignfull"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
 <div class="wp-block-columns alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"verticalAlignment":"bottom","width":"33%","className":"wporg-hidden-mobile"} -->
 <div class="wp-block-column is-vertically-aligned-bottom wporg-hidden-mobile" style="flex-basis:33%"><!-- wp:image {"width":402,"height":588,"sizeSlug":"large"} -->
 <figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" width="402" height="588" /></figure>
@@ -202,15 +202,15 @@
 
 <!-- wp:list {"className":"is-style-default","fontSize":"small"} -->
 <ul class="is-style-default has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf"><?php _e( 'Abril (PDF)↗', 'wporg' ); ?></a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-grupo-abril.pdf"><?php _e( 'Abril (PDF)', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf"><?php _e( 'KFF (PDF)↗', 'wporg' ); ?></a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-kff.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-kff.pdf"><?php _e( 'KFF (PDF)', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf"><?php _e( 'NewsCorp Australia (PDF)↗', 'wporg' ); ?></a></li>
+<li><a href="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/case-studies-newscorp-australia.pdf"><?php _e( 'NewsCorp Australia (PDF)', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column -->
@@ -222,15 +222,15 @@
 
 <!-- wp:list {"fontSize":"small"} -->
 <ul class="has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf"><?php _e( 'IDC Report (PDF)↗', 'wporg' ); ?></a></li>
+<li><a href="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/IDC-Report-Choosing-a-CMS-to-Meet-Todays-Digital-Experience-Challenges.pdf"><?php _e( 'IDC Report (PDF)', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf"><?php _e( 'WP as a Content Hub (PDF)↗', 'wporg' ); ?></a></li>
+<li><a href="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/wordpress-as-a-content-hub-whitepaper.pdf"><?php _e( 'WP as a Content Hub (PDF)', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf"><?php _e( 'Personalization (PDF)↗', 'wporg' ); ?></a></li>
+<li><a href="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf" data-type="URL" data-id="https://wordpress.org/files/2020/11/Personalization-whitepaper.pdf"><?php _e( 'Personalization (PDF)', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column -->
@@ -241,16 +241,16 @@
 <!-- /wp:heading -->
 
 <!-- wp:list {"fontSize":"small"} -->
-<ul class="has-small-font-size"><!-- wp:list-item -->
-<li><a href="https://vimeo.com/443114625/c2f798174f"><?php _e( 'Drive Digital Commerce with Content Marketing↗', 'wporg' ); ?></a></li>
+<ul class="has-small-font-size"><!-- wp:list-item {"className":"external-link"} -->
+<li class="external-link"><a href="https://vimeo.com/443114625/c2f798174f"><?php _e( 'Drive Digital Commerce with Content Marketing', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
-<!-- wp:list-item -->
-<li><a href="https://vimeo.com/374961815/040fe06be7"><?php _e( 'Gutenberg for Enterprise↗', 'wporg' ); ?></a></li>
+<!-- wp:list-item {"className":"external-link"} -->
+<li class="external-link"><a href="https://vimeo.com/374961815/040fe06be7"><?php _e( 'Gutenberg for Enterprise', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
-<!-- wp:list-item -->
-<li><a href="https://vimeo.com/425968597/80d24a1bf4"><?php _e( 'Lead a Successful Digital Transformation↗', 'wporg' ); ?></a></li>
+<!-- wp:list-item {"className":"external-link"} -->
+<li class="external-link"><a href="https://vimeo.com/425968597/80d24a1bf4"><?php _e( 'Lead a Successful Digital Transformation', 'wporg' ); ?></a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -149,8 +149,8 @@
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-13887" width="58" height="60" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
-<h4 class="wp-block-heading"><?php _e( 'Extensibility', 'wporg' ); ?></h4>
+<!-- wp:heading {"className":"wp-block-heading","fontSize":"heading-4"} -->
+<h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Extensibility', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -163,8 +163,8 @@
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-13886" width="50" height="61" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
-<h4 class="wp-block-heading"><?php _e( 'Security', 'wporg' ); ?></h4>
+<!-- wp:heading {"className":"wp-block-heading","fontSize":"heading-4"} -->
+<h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Security', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -177,8 +177,8 @@
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/11/icon-open-source.png" alt="<?php _e( 'Open Source Icon', 'wporg' ); ?>" class="wp-image-13885" width="63" height="59" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:heading {"level":4,"className":"wp-block-heading"} -->
-<h4 class="wp-block-heading"><?php _e( 'Open source', 'wporg' ); ?></h4>
+<!-- wp:heading {"className":"wp-block-heading","fontSize":"heading-4"} -->
+<h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Open source', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -31,48 +31,48 @@
 
 <!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
-<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"id":14917,"width":190,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/NYP-1.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" class="wp-image-14917" width="190" height="24" /></figure>
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"id":15765,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"190px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/NYP.webp" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" class="wp-image-15765" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14916,"width":76,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/Sun-1.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" class="wp-image-14916" width="76" height="24" /></figure>
+<!-- wp:image {"id":15777,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"76px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Sun.webp" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" class="wp-image-15777" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14915,"width":81,"height":32,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/People-1.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" class="wp-image-14915" width="81" height="32" /></figure>
+<!-- wp:image {"id":15768,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"81px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/People.webp" alt="<?php _e( 'People logo', 'wporg' ); ?>" class="wp-image-15768" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14914,"width":196,"height":27,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/RD-1.png" alt="<?php _e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" class="wp-image-14914" width="196" height="27" /></figure>
+<!-- wp:image {"id":15780,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"196px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/RD.webp" alt="<?php _e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" class="wp-image-15780" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14913,"width":88,"height":26,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/WWD-1.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" class="wp-image-14913" width="88" height="26" /></figure>
+<!-- wp:image {"id":15783,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"88px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/WWD.webp" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" class="wp-image-15783" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14912,"width":104,"height":29,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/Variety-1.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" class="wp-image-14912" width="104" height="29" /></figure>
+<!-- wp:image {"id":15786,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"104px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Variety.webp" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" class="wp-image-15786" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14911,"width":114,"height":36,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/Spotify-1.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" class="wp-image-14911" width="114" height="36" /></figure>
+<!-- wp:image {"id":15789,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"114px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Spotify.webp" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" class="wp-image-15789" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14918,"width":69,"height":25,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/TED-1.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" class="wp-image-14918" width="69" height="25" /></figure>
+<!-- wp:image {"id":15792,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"69px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/TED.webp" alt="<?php _e( 'TED logo', 'wporg' ); ?>" class="wp-image-15792" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14909,"width":129,"height":25,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/facebook-1.png" alt="<?php _e( 'facebook logo', 'wporg' ); ?>" class="wp-image-14909" width="129" height="25" /></figure>
+<!-- wp:image {"id":15794,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"129px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/facebook.webp" alt="<?php _e( 'facebook logo', 'wporg' ); ?>" class="wp-image-15794" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14908,"width":141,"height":30,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/microsoft-1.png" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-14908" width="141" height="30" /></figure>
+<!-- wp:image {"id":15796,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"141px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Microsoft.webp" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-15796" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"id":14907,"width":72,"height":34,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/CNN-1.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" class="wp-image-14907" width="72" height="34" /></figure>
+<!-- wp:image {"id":15799,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"72px"}}} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/CNN.webp" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" class="wp-image-15799" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -82,14 +82,16 @@
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull"><!-- wp:columns {"verticalAlignment":"top","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","left":"0"}}}} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"width":"37%","className":"wporg-hidden-mobile"} -->
-<div class="wp-block-column wporg-hidden-mobile" style="flex-basis:37%"><!-- wp:image {"id":14095,"sizeSlug":"full"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2022/12/enterprise-use-cases-full.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" class="wp-image-14095"/></figure>
-<!-- /wp:image --></div>
+<div class="wp-block-columns alignfull are-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:column {"width":"33%","className":"wporg-hidden-mobile"} -->
+<div class="wp-block-column wporg-hidden-mobile" style="flex-basis:33%">
+<!-- wp:image {"width":402,"height":588,"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Enterprise-Use-Cases.png" alt="<?php _e( 'Enterprise Use Cases Image', 'wporg' ); ?>" width="402" height="588"/></figure>
+<!-- /wp:image -->
+</div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"63%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:63%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"heading-3"} -->
+<!-- wp:column {"width":"67%","style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"0","top":"0","bottom":"0"}}}} -->
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--60);flex-basis:67%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"wp-block-heading","fontSize":"heading-3"} -->
 <h2 class="wp-block-heading has-heading-3-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><?php _e( 'Enterprise use cases', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -30,49 +30,49 @@
 <!-- /wp:columns -->
 
 <!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
-<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"width":190,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/NYP-1.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" width="190" height="24" /></figure>
+<div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"id":14917,"width":190,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/NYP-1.png" alt="<?php _e( 'New York Post logo', 'wporg' ); ?>" class="wp-image-14917" width="190" height="24" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":76,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Sun-1.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" width="76" height="24" /></figure>
+<!-- wp:image {"id":14916,"width":76,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/Sun-1.png" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" class="wp-image-14916" width="76" height="24" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":81,"height":32,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/People-1.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" width="81" height="32" /></figure>
+<!-- wp:image {"id":14915,"width":81,"height":32,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/People-1.png" alt="<?php _e( 'People logo', 'wporg' ); ?>" class="wp-image-14915" width="81" height="32" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":196,"height":27,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/RD-1.png" alt="<?php _e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" width="196" height="27" /></figure>
+<!-- wp:image {"id":14914,"width":196,"height":27,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/RD-1.png" alt="<?php _e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" class="wp-image-14914" width="196" height="27" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":88,"height":26,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/WWD-1.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" width="88" height="26" /></figure>
+<!-- wp:image {"id":14913,"width":88,"height":26,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/WWD-1.png" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" class="wp-image-14913" width="88" height="26" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":104,"height":29,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Variety-1.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" width="104" height="29" /></figure>
+<!-- wp:image {"id":14912,"width":104,"height":29,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/Variety-1.png" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" class="wp-image-14912" width="104" height="29" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":114,"height":36,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/Spotify-1.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" width="114" height="36" /></figure>
+<!-- wp:image {"id":14911,"width":114,"height":36,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/Spotify-1.png" alt="<?php _e( 'Spotify logo', 'wporg' ); ?>" class="wp-image-14911" width="114" height="36" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":69,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/TED-1.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" width="69" height="25" /></figure>
+<!-- wp:image {"id":14918,"width":69,"height":25,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/TED-1.png" alt="<?php _e( 'TED logo', 'wporg' ); ?>" class="wp-image-14918" width="69" height="25" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":129,"height":25,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/facebook-1.png" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" width="129" height="25" /></figure>
+<!-- wp:image {"id":14909,"width":129,"height":25,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/facebook-1.png" alt="<?php _e( 'facebook logo', 'wporg' ); ?>" class="wp-image-14909" width="129" height="25" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":141,"height":30,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/microsoft-1.png" alt="<?php _e( 'Microsoft Logo', 'wporg' ); ?>" width="141" height="30" /></figure>
+<!-- wp:image {"id":14908,"width":141,"height":30,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/microsoft-1.png" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-14908" width="141" height="30" /></figure>
 <!-- /wp:image -->
 
-<!-- wp:image {"width":72,"height":34,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2022/12/CNN-1.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" width="72" height="34" /></figure>
+<!-- wp:image {"id":14907,"width":72,"height":34,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/12/CNN-1.png" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" class="wp-image-14907" width="72" height="34" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -72,6 +72,13 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	&-logos {
 		row-gap: var(--wp--preset--spacing--40) !important;
 	}
+
+	&-use-cases .wp-block-cover__image-background {
+		object-fit: contain;
+		max-width: 31%;
+		max-height: 85%;
+		top: unset;
+	}
 }
 
 /*
@@ -120,9 +127,6 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 }
 
 @media (max-width: 781px) {
-	.wporg-hidden-mobile {
-		display: none;
-	}
 
 	/* Update the columns gap when it switches to single-column */
 	#benefits .is-layout-flex,
@@ -151,9 +155,17 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		padding-right: 0 !important;
 	}
 
-	.wporg-enterprise-features {
-		.wp-block-column {
+	.wporg-enterprise {
+		&-features .wp-block-column {
 			border-right: none;
+
+			&:not(:first-child) {
+				border-top: 1px solid var(--wp--preset--color--light-grey-1) !important;
+			}
+		}
+
+		&-use-cases .wp-block-cover__image-background {
+			display: none;
 		}
 	}
 }
@@ -174,25 +186,31 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		width: 100% !important;
 	}
 
-	.wporg-enterprise-logos {
-		display: grid !important;
-		grid-template-rows: 1fr 1fr;
-		row-gap: var(--wp--preset--spacing--30) !important;
-		padding-top: 0 !important;
-
-		.wp-block-image {
-			display: flex;
-			justify-content: center;
-
-			&:last-child {
-				grid-column-start: 1;
-				grid-column-end: 3;
+	.wporg-enterprise {
+		&-logos {
+			display: grid !important;
+			grid-template-rows: 1fr 1fr;
+			row-gap: var(--wp--preset--spacing--30) !important;
+			padding-top: 0 !important;
+	
+			.wp-block-image {
+				display: flex;
+				justify-content: center;
+	
+				&:last-child {
+					grid-column-start: 1;
+					grid-column-end: 3;
+				}
+	
+				> img {
+					max-height: 20px;
+					width: auto;
+				}
 			}
+		}
 
-			> img {
-				max-height: 20px;
-				width: auto;
-			}
+		&-try-wordpress .wp-block-heading.is-style-with-arrow {
+			font-size: 52px !important;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -64,17 +64,15 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
  * Enterprise page
  */
 
-.wporg-enterprise {
-	&-logos {
-		row-gap: var(--wp--preset--spacing--40) !important;
-	}
+.wporg-enterprise-logos {
+	row-gap: var(--wp--preset--spacing--40) !important;
+}
 
-	&-use-cases .wp-block-cover__image-background {
-		object-fit: contain;
-		max-width: 31%;
-		max-height: 85%;
-		top: unset;
-	}
+.wporg-enterprise-use-cases .wp-block-cover__image-background {
+	object-fit: contain;
+	max-width: 31%;
+	max-height: 85%;
+	top: unset;
 }
 
 /*
@@ -151,18 +149,16 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		padding-right: 0 !important;
 	}
 
-	.wporg-enterprise {
-		&-features .wp-block-column {
-			border-right: none;
+	.wporg-enterprise-features .wp-block-column {
+		border-right: none;
 
-			&:not(:first-child) {
-				border-top: 1px solid var(--wp--preset--color--light-grey-1) !important;
-			}
+		&:not(:first-child) {
+			border-top: 1px solid var(--wp--preset--color--light-grey-1) !important;
 		}
+	}
 
-		&-use-cases .wp-block-cover__image-background {
-			display: none;
-		}
+	.wporg-enterprise-use-cases .wp-block-cover__image-background {
+		display: none;
 	}
 }
 
@@ -182,33 +178,32 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		width: 100% !important;
 	}
 
-	.wporg-enterprise {
-		&-logos {
-			display: grid !important;
-			grid-template-rows: 1fr 1fr;
-			row-gap: var(--wp--preset--spacing--30) !important;
-			padding-top: 0 !important;
+	.wporg-enterprise-logos {
+		display: grid !important;
+		grid-template-rows: 1fr 1fr;
+		row-gap: var(--wp--preset--spacing--30) !important;
+		padding-top: 0 !important;
 
-			.wp-block-image {
-				display: flex;
-				justify-content: center;
+		.wp-block-image {
+			display: flex;
+			justify-content: center;
 
-				&:last-child {
-					grid-column-start: 1;
-					grid-column-end: 3;
-				}
+			&:last-child {
+				grid-column-start: 1;
+				grid-column-end: 3;
+			}
 
-				> img {
-					max-height: 20px;
-					width: auto;
-				}
+			> img {
+				max-height: 20px;
+				width: auto;
 			}
 		}
-
-		&-try-wordpress .wp-block-heading.is-style-with-arrow {
-			font-size: 52px !important;
-		}
 	}
+
+	.wporg-enterprise-try-wordpress .wp-block-heading.is-style-with-arrow {
+		font-size: 52px !important;
+	}
+	
 }
 
 

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -187,7 +187,7 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		.wp-block-image {
 			display: flex;
 			justify-content: center;
-			
+
 			&:last-child {
 				display: flex;
 				justify-content: center;

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -65,10 +65,6 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
  */
 
 .wporg-enterprise {
-	&-header .wp-block-columns {
-		gap: 0;
-	}
-
 	&-logos {
 		row-gap: var(--wp--preset--spacing--40) !important;
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -65,6 +65,10 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
  */
 
 .wporg-enterprise {
+	&-header .wp-block-columns {
+		gap: 0;
+	}
+
 	&-intro > p {
 		max-width: 30rem;
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -66,6 +66,14 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 
 .wporg-enterprise-logos {
 	row-gap: var(--wp--preset--spacing--40) !important;
+
+	.wp-block-image {
+		line-height: 1;
+
+		> img {
+			vertical-align: middle;
+		}
+	}
 }
 
 .wporg-enterprise-use-cases .wp-block-cover__image-background {
@@ -203,7 +211,6 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	.wporg-enterprise-try-wordpress .wp-block-heading.is-style-with-arrow {
 		font-size: 52px !important;
 	}
-	
 }
 
 

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -181,10 +181,13 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	.wporg-enterprise-logos {
 		display: grid !important;
 		grid-template-rows: 1fr 1fr;
-		row-gap: var(--wp--preset--spacing--20) !important;
+		row-gap: var(--wp--preset--spacing--30) !important;
 		padding-top: 0 !important;
 
 		.wp-block-image {
+			display: flex;
+			justify-content: center;
+			
 			&:last-child {
 				display: flex;
 				justify-content: center;
@@ -192,8 +195,9 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 				grid-column-end: 3;
 			}
 
-			[class^="wp-image-"] {
+			> img {
 				max-height: 20px;
+				width: auto;
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -69,10 +69,6 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		gap: 0;
 	}
 
-	&-intro > p {
-		max-width: 30rem;
-	}
-
 	&-logos {
 		row-gap: var(--wp--preset--spacing--40) !important;
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -64,6 +64,10 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
  * Enterprise page
  */
 
+.wporg-enterprise-header {
+	--wp--preset--spacing--90: clamp(140px, calc(100vw / 7), 160px);
+}
+
 .wporg-enterprise-logos {
 	row-gap: var(--wp--preset--spacing--40) !important;
 
@@ -81,6 +85,10 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	max-width: 31%;
 	max-height: 85%;
 	top: unset;
+}
+
+.wporg-enterprise-features {
+	--wp--preset--spacing--60: clamp(40px, calc(100vw / 18), 80px);
 }
 
 /*

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -192,16 +192,16 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 			grid-template-rows: 1fr 1fr;
 			row-gap: var(--wp--preset--spacing--30) !important;
 			padding-top: 0 !important;
-	
+
 			.wp-block-image {
 				display: flex;
 				justify-content: center;
-	
+
 				&:last-child {
 					grid-column-start: 1;
 					grid-column-end: 3;
 				}
-	
+
 				> img {
 					max-height: 20px;
 					width: auto;

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -189,8 +189,6 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 			justify-content: center;
 
 			&:last-child {
-				display: flex;
-				justify-content: center;
 				grid-column-start: 1;
 				grid-column-end: 3;
 			}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -60,6 +60,20 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	background-color: var(--wp--preset--color--charcoal-1);
 }
 
+/**
+ * Enterprise page
+ */
+
+.wporg-enterprise {
+	&-intro > p {
+		max-width: 30rem;
+	}
+
+	&-logos {
+		row-gap: var(--wp--preset--spacing--40) !important;
+	}
+}
+
 /*
  * Spacing for small screens.
  */
@@ -106,6 +120,9 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 }
 
 @media (max-width: 781px) {
+	.wporg-hidden-mobile {
+		display: none;
+	}
 
 	/* Update the columns gap when it switches to single-column */
 	#benefits .is-layout-flex,
@@ -133,6 +150,12 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	#features .wp-block-columns > .wp-block-column:first-child {
 		padding-right: 0 !important;
 	}
+
+	.wporg-enterprise-features {
+		.wp-block-column {
+			border-right: none;
+		}
+	}
 }
 
 @media (max-width: 599px) {
@@ -149,6 +172,26 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 	.wp-block-buttons .wp-block-button,
 	.wp-block-buttons .wp-block-button .wp-block-button__link {
 		width: 100% !important;
+	}
+
+	.wporg-enterprise-logos {
+		display: grid !important;
+		grid-template-rows: 1fr 1fr;
+		row-gap: var(--wp--preset--spacing--20) !important;
+		padding-top: 0 !important;
+
+		.wp-block-image {
+			&:last-child {
+				display: flex;
+				justify-content: center;
+				grid-column-start: 1;
+				grid-column-end: 3;
+			}
+
+			[class^="wp-image-"] {
+				max-height: 20px;
+			}
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-main-2022/templates/page-enterprise.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-enterprise.html
@@ -1,0 +1,9 @@
+<!-- wp:wporg/global-header /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/enterprise"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"style":"white-on-black"} /-->


### PR DESCRIPTION
Closes #150 

Adds a template and pattern for the Enterprise page. Some custom styles have had to be added, mostly for the logo grid which changes layout significantly on mobile.

Remaining tasks:
- [x] Prod quality images
- [x] Escaping
- [x] Arrow styling for last section
- [x] Heading hierarchy
- [x] A11y
- [x] Lighthouse Perf and a11y tests

Props @bengreeley

### Screenshots

| Desktop | Tablet | Mobile |
|--------|-------|-------|
| ![localhost_8888_enterprise_](https://user-images.githubusercontent.com/1017872/207766564-9a567888-fcd3-4104-871f-3e0997496732.png) | ![localhost_8888_enterprise_(iPad)](https://user-images.githubusercontent.com/1017872/207766625-83aeff84-0b74-483b-aeea-f534613153f7.png) | ![localhost_8888_enterprise_(Samsung Galaxy S20 Ultra)](https://user-images.githubusercontent.com/1017872/207766671-3bd62c64-bba1-444f-8b5b-02f9141a1e3e.png) |

### How to test the changes in this Pull Request:

1. Add an 'Enterprise' page with slug `enterprise` (an existing page may need to be deprecated in your site)
2. Rebuild the styles `yarn workspace wporg-main-2022-theme build`
3. Test the responsive layout