### PR TITLE
Try new design for search results page

### DIFF
--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -37,6 +37,11 @@ function should_use_new_theme() {
 		return true;
 	}
 
+	// Use the new theme on all search results.
+	if ( str_starts_with( $request_uri, '/search/' ) ) {
+		return true;
+	}
+
 	// Check if the page being requested isn't supported by the new theme, it should fall-back to the old theme if so.
 	$new_theme_pages = array(
 		'/',

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/inc/capabilities.php';
 
 // Block files
 require_once __DIR__ . '/src/download-counter/index.php';
+require_once __DIR__ . '/src/google-search-embed/index.php';
 require_once __DIR__ . '/src/random-heading/index.php';
 require_once __DIR__ . '/src/release-tables/index.php';
 

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/block.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/google-search-embed",
+	"version": "0.1.0",
+	"title": "Google Search Embed",
+	"category": "design",
+	"icon": "",
+	"description": "Display the Google Search embed for WordPress.org.",
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"align": true,
+		"html": false,
+		"multiple": false,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": false,
+			"blockGap": false
+		}
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
+}

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+function Edit() {
+	return <div { ...useBlockProps() }>Google Search</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Block Name: Google Search Embed
+ * Description: Display the Google Search embed for WordPress.org.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Main_2022\Google_Search_Embed;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/google-search-embed',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! empty( $block->block_type->view_script ) ) {
+		wp_enqueue_script( $block->block_type->view_script );
+		// Move to footer.
+		wp_script_add_data( $block->block_type->view_script, 'group', 1 );
+	}
+
+	$terms = urldecode( wp_unslash( $_GET['s'] ?? '' ) ); // phpcs:ignore
+	$terms = htmlspecialchars_decode( $terms );
+	$terms = explode( '?', $terms )[0];
+	$terms = trim( $terms, "/ \r\n\t" );
+
+	$search_config = array(
+		'div'        => 'gsce-search',
+		'gname'      => 'wordpressorg-search',
+		'attributes' => array(
+			'queryParameterName' => 'search',
+			'linkTarget'         => '_parent',
+			'enableHistory'      => false,
+			'enableOrderBy'      => true,
+		),
+	);
+
+	$refinement = isset( $_REQUEST['in'] ) ? sanitize_title( wp_unslash( $_REQUEST['in'] ) ) : ''; // phpcs:ignore
+	if ( in_array( $refinement, [ 'support_forums', 'support_docs', 'developer_documentation' ], true ) ) {
+		$search_config['attributes']['defaultToRefinement'] = $refinement;
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %1$s id="gsce-search" data-config="%2$s" data-terms="%3$s"></div>',
+		$wrapper_attributes,
+		esc_js( wp_json_encode( $search_config, true ) ),
+		esc_js( wp_json_encode( $terms ) )
+	);
+}

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
@@ -40,6 +40,11 @@ function render( $attributes, $content, $block ) {
 		wp_enqueue_script( $block->block_type->view_script );
 		// Move to footer.
 		wp_script_add_data( $block->block_type->view_script, 'group', 1 );
+
+		// If jQuery is not enqueued, add it.
+		if ( ! wp_script_is( 'jquery', 'enqueued' ) ) {
+			wp_enqueue_script( 'jquery' );
+		}
 	}
 
 	$terms = urldecode( wp_unslash( $_GET['s'] ?? '' ) ); // phpcs:ignore

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/style.scss
@@ -1,0 +1,10 @@
+.wp-block-wporg-google-search-embed {
+	.gsc-search-button-v2 {
+		padding: 13px 27px;
+	}
+
+	.gs-web-image-box,
+	.gs-promotion-image-box {
+		margin-right: 8px;
+	}
+}

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/view.js
@@ -1,0 +1,91 @@
+/* global google, jQuery */
+
+function wporg_search_update_url( term, refinement_obj = false ) {
+	let refinement = 'all';
+	if ( refinement_obj && refinement_obj.length ) {
+		refinement = refinement_obj
+			.text()
+			.trim()
+			.toLowerCase()
+			.replace( /[^a-z]/g, '_' );
+	}
+	if ( 'all' === refinement ) {
+		refinement = '';
+	}
+
+	const state = {
+		search: term,
+		refinement: refinement,
+	};
+
+	if (
+		! window.history.state ||
+		window.history.state.search !== state.search ||
+		window.history.state.refinement !== state.refinement
+	) {
+		wporg_record_search( term, refinement );
+	}
+
+	window.history.replaceState(
+		state,
+		document.title,
+		'/search/' +
+			encodeURIComponent( term ).replace( /%20/g, '+' ) +
+			'/' +
+			( refinement ? '?in=' + refinement : '' )
+	);
+}
+
+function wporg_record_search( term, refinement ) {
+	jQuery.post( 'https://api.wordpress.org/search/1.0/', {
+		term: term,
+		in: refinement, // eslint-disable-line id-length
+	} );
+}
+
+window.__gcse = {
+	parsetags: 'explicit',
+	callback: function () {
+		const executeSearch = function () {
+			const container = document.getElementById( 'gsce-search' );
+			container.innerHTML = '';
+			google.search.cse.element.render( JSON.parse( container.dataset.config ) );
+			google.search.cse.element
+				.getElement( 'wordpressorg-search' )
+				.execute( JSON.parse( container.dataset.terms ) );
+		};
+
+		if ( document.readyState === 'complete' ) {
+			executeSearch();
+		} else {
+			google.setOnLoadCallback( function () {
+				executeSearch();
+			}, true );
+		}
+	},
+	searchCallbacks: {
+		web: {
+			starting: ( gname, searchTerm ) => {
+				wporg_search_update_url( searchTerm, jQuery( '.gsc-refinementBlock .gsc-tabhActive' ) );
+			},
+			rendered: ( gname, searchTerm ) => {
+				jQuery( '.gsc-refinementBlock .gsc-tabHeader' )
+					.off( 'click.refinement, keypress.refinement' )
+					.on( 'click.refinement, keypress.refinement', function () {
+						wporg_search_update_url( searchTerm, jQuery( this ) );
+					} );
+			},
+		},
+	},
+};
+
+( function () {
+	const cx = '012566942813864066925:bnbfebp99hs'; // eslint-disable-line id-length
+	const gcseElement = document.createElement( 'script' );
+	gcseElement.type = 'text/javascript';
+	gcseElement.async = true;
+	gcseElement.src = 'https://cse.google.com/cse.js?cx=' + cx;
+
+	const firstScriptTag = document.getElementsByTagName( 'script' )[ 0 ];
+	firstScriptTag.parentNode.insertBefore( gcseElement, firstScriptTag );
+} )();

--- a/source/wp-content/themes/wporg-main-2022/templates/page-search.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-search.html
@@ -1,0 +1,27 @@
+<!-- wp:wporg/global-header /-->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:cover {"overlayColor":"blueberry-1","minHeight":300,"align":"full"} -->
+	<div class="wp-block-cover alignfull" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"heading-cta"} -->
+	<h1 class="wp-block-heading has-text-align-center has-heading-cta-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Search</h1>
+	<!-- /wp:heading -->
+	
+	<!-- wp:paragraph {"align":"center","className":"is-style-short-text"} -->
+	<p class="has-text-align-center is-style-short-text">Search the WordPress.org website for plugins, themes, and support.</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group --></div></div>
+	<!-- /wp:cover -->
+	
+	<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull"><!-- wp:wporg/google-search-embed {"align":"wide"} /--></div>
+	<!-- /wp:group -->
+
+	<!-- wp:spacer {"height":"40px"} -->
+	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"style":"white-on-black"} /-->


### PR DESCRIPTION
This PR adds a new block for the Google Search embed & a new template for the Search page which uses that new block. The block itself is a very simple port of the code currently in [wporg-main/page-search.php](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-main/page-search.php).

This is a very shallow update of the page, really just changing the header font & colors. The search embed is provided by Google, so we probably can't style it very much - I don't think we can be guaranteed that the markup will stay consistent, so less customization is better.

See https://github.com/WordPress/wporg-documentation-2022/issues/30

### Screenshots

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/541093/211420602-dd78ecee-cea4-4dec-832b-8a180772de75.png) | ![after](https://user-images.githubusercontent.com/541093/211420488-53c142e1-0815-406b-b49c-a165342e4682.png) |

### How to test the changes in this Pull Request:

1. View the `/search/` page
2. Try different search terms with this format `/search/block+editor`, or by typing in the search box on the page.
3. Try clicking the different tabs.
4. There should be no functional differences between production & this branch, only styles.

You can test this locally, kind of — it will only render the search box. It's best to push this up to a sandbox and test there.
