### PR TITLE
Enterprise go live: switch to final URLs

### DIFF
--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -8,7 +8,7 @@
 		"template": "page-download.html"
 	},
 	{
-		"slug": "enterprise-2",
+		"slug": "enterprise",
 		"pattern": "enterprise.php",
 		"template": "page-enterprise.html"
 	},

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -51,7 +51,7 @@ function should_use_new_theme() {
 		'/download/releases/',
 		'/download/source/',
 		'/mobile/',
-		'/enterprise-2/',
+		'/enterprise/',
 	);
 	if ( ! in_array( $request_uri, $new_theme_pages ) ) {
 		return false;


### PR DESCRIPTION
Closes #160 

Updates the page manifest and theme switcher for Enterprise to use the final slug.