### PR TITLE
Fix searches for plugin support forums

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
@@ -72,7 +72,7 @@ function render( $attributes, $content, $block ) {
 	return sprintf(
 		'<div %1$s id="gsce-search" data-config="%2$s" data-terms="%3$s"></div>',
 		$wrapper_attributes,
-		esc_js( wp_json_encode( $search_config, true ) ),
-		esc_js( wp_json_encode( $terms ) )
+		esc_attr( wp_json_encode( $search_config, true ) ),
+		esc_attr( wp_json_encode( $terms ) )
 	);
 }

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/index.php
@@ -49,7 +49,6 @@ function render( $attributes, $content, $block ) {
 
 	$terms = urldecode( wp_unslash( $_GET['s'] ?? '' ) ); // phpcs:ignore
 	$terms = htmlspecialchars_decode( $terms );
-	$terms = explode( '?', $terms )[0];
 	$terms = trim( $terms, "/ \r\n\t" );
 
 	$search_config = array(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes https://meta.trac.wordpress.org/ticket/6679

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1.  Search from https://wordpress.org/support/plugin/redirection/ with a question mark included, or without..
2. Notice it doesn't quite work right, but looks like it does
3. Apply patch.
4. Perform search again, notice the `?` is kept, and that `intext:...` is included.

<!-- If you can, add the appropriate [Component] label(s). -->
