### PR TITLE
Fix layout of Enterprise logos when number of logos is even

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -31,9 +31,7 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"charcoal-2","className":"wporg-enterprise-header","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-default"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
-<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-
-<!-- wp:image {"id":15777,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"76px"}}} -->
+<div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"id":15777,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"76px"}}} -->
 <figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Sun.webp" alt="<?php _e( 'The Sun logo', 'wporg' ); ?>" class="wp-image-15777" /></figure>
 <!-- /wp:image -->
 

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -196,17 +196,12 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 
 	.wporg-enterprise-logos {
 		display: grid !important;
-		grid-template-rows: 1fr 1fr;
+		grid-template-columns: 1fr 1fr;
 		row-gap: var(--wp--preset--spacing--30) !important;
 
 		.wp-block-image {
 			display: flex;
 			justify-content: center;
-
-			&:last-child {
-				grid-column-start: 1;
-				grid-column-end: 3;
-			}
 
 			> img {
 				max-height: 20px;


### PR DESCRIPTION
Fixes #173 

### Screenshots

| Before | After |
|--------|-------|
| 
![Screen Shot 2023-01-23 at 8 45 17 AM](https://user-images.githubusercontent.com/1017872/213940318-c7860954-c8f5-4a46-a8a8-056bbe77d1f0.jpg)
 | image |

### How to test the changes in this Pull Request:

1. Open https://wordpress.org/enterprise
2. Resize browser window to < 600px wide or open on mobile
3. Check that logos are laid out in 2 columns