### PR TITLE
Add Courier Prime font option

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2274,12 +2274,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "7d2ffaabca7d6c90c74190b09c23b76aa70ece58"
+                "reference": "2097028ce55d25b166ca8a234b0058359456ed7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/7d2ffaabca7d6c90c74190b09c23b76aa70ece58",
-                "reference": "7d2ffaabca7d6c90c74190b09c23b76aa70ece58",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/2097028ce55d25b166ca8a234b0058359456ed7b",
+                "reference": "2097028ce55d25b166ca8a234b0058359456ed7b",
                 "shasum": ""
             },
             "require-dev": {
@@ -2317,7 +2317,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2023-01-25T23:19:09+00:00"
+            "time": "2023-02-01T02:41:04+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",

--- a/source/wp-content/themes/wporg-main-2022/theme.json
+++ b/source/wp-content/themes/wporg-main-2022/theme.json
@@ -1,7 +1,32 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"settings": {},
+	"settings": {
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Courier Prime', serif",
+					"slug": "courier prime",
+					"name": "Courier Prime"
+				},
+				{
+					"fontFamily": "'EB Garamond', serif",
+					"slug": "eb-garamond",
+					"name": "EB Garamond"
+				},
+				{
+					"fontFamily": "'Inter', sans-serif",
+					"slug": "inter",
+					"name": "Inter"
+				},
+				{
+					"fontFamily": "'IBM Plex Mono', monospace",
+					"slug": "monospace",
+					"name": "Monospace"
+				}
+			]
+		}
+	},
 	"styles": {
 		"blocks": {
 			"wporg/download-counter": {


### PR DESCRIPTION
Closes #184 

### Screenshots

| Editor | Frontend |
|--------|-------|
| ![Screen Shot 2023-02-01 at 4 25 25 PM](https://user-images.githubusercontent.com/1017872/215937852-56924945-719a-43c5-beb0-6309d7d59ee2.jpg) | ![Screen Shot 2023-02-01 at 4 19 09 PM](https://user-images.githubusercontent.com/1017872/215937871-f7ded82c-a8b4-4f7d-a776-4353f3b96a71.jpg) |

### How to test the changes in this Pull Request:

1. In the editor, edit a page using the new theme (main, download, etc) 
2. Select some text and Courier Prime should be available as a font option in the dropdown
3. Choose Courier Prime, update and preview the page
4. Courier Prime should be used on the frontend
5. Try changing the text to bold (italic is not supported)