### PR TITLE
Update About sub pages

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/features.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/features.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<!-- wp:group {"layout":{"type":"constrained"},"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky"} -->
+<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"},"align":"full"} -->
 <div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
 <p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
@@ -16,8 +16,8 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} -->
+<!-- wp:group {"layout":{"type":"constrained"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"className":"wp-block-heading","fontSize":"heading-2"} -->
 <h1 class="wp-block-heading has-heading-2-font-size" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Features', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
@@ -33,8 +33,8 @@
 <p><?php _e( 'Here are some of the features that we think that you’ll love.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
+<!-- wp:list {"className":"is-style-list-long-items"} -->
+<ul class="is-style-list-long-items"><!-- wp:list-item -->
 <li><?php _e( '<strong>Simplicity</strong><br>Simplicity makes it possible for you to get online and get publishing, quickly. Nothing should get in the way of you getting your website up and your content out there. WordPress is built to make that happen.', 'wporg' ); ?></li>
 <!-- /wp:list-item -->
 
@@ -107,7 +107,7 @@
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
-<!-- wp:heading -->
+<!-- wp:heading {"className":"wp-block-heading"} -->
 <h2 class="wp-block-heading"><?php _e( 'Developer Features', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
@@ -115,8 +115,8 @@
 <p><?php _e( 'For developers, we’ve got lots of goodies packed under the hood that you can use to extend WordPress in whatever direction takes your fancy.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
+<!-- wp:list {"className":"is-style-list-long-items"} -->
+<ul class="is-style-list-long-items"><!-- wp:list-item -->
 <li><?php _e( '<strong>Plugin System</strong><br>The <a href="https://developer.wordpress.org/">WordPress APIs</a> make it possible for you to create plugins to extend WordPress. WordPress’s extensibility lies in the thousands of hooks at your disposal. Once you’ve created your plugin, we’ve even got a <a href="https://wordpress.org/plugins/">plugin repository</a> for you to host it on.', 'wporg' ); ?></li>
 <!-- /wp:list-item -->
 

--- a/source/wp-content/themes/wporg-main-2022/patterns/security.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/security.php
@@ -123,8 +123,8 @@
 <p><?php _e( 'A release cycle follows the following pattern<sup id="ref2"><a href="#footnote2">2</a></sup>:', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
+<!-- wp:list {"className":"is-style-list-long-items"} -->
+<ul class="is-style-list-long-items"><!-- wp:list-item -->
 <li><?php _e( 'Phase 1: Planning and securing team leads. This is done in the #core chat room on Slack. The release lead discusses features for the next release of WordPress. WordPress contributors get involved with that discussion. The release lead will identify team leads for each of the features.', 'wporg' ); ?></li>
 <!-- /wp:list-item -->
 

--- a/source/wp-content/themes/wporg-main-2022/patterns/security.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/security.php
@@ -25,10 +25,6 @@
 <p><?php _e( 'Learn more about WordPress core software security in this free white paper. You can also download it in&nbsp;<a href="https://github.com/WordPress/Security-White-Paper/blob/master/WordPressSecurityWhitePaper.pdf?raw=true">PDF format</a>.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"align":"center","sizeSlug":"large"} -->
-<figure class="wp-block-image aligncenter size-large"><img src="https://s.w.org/about/images/logos/wordpress-logo-stacked-rgb.png" alt="" /></figure>
-<!-- /wp:image -->
-
 <!-- wp:heading -->
 <h2 class="wp-block-heading"><?php _e( 'Overview', 'wporg' ); ?></h2>
 <!-- /wp:heading -->


### PR DESCRIPTION
Fixes #189 

List items with long content have more space between, and the old logo is removed from About/Security

### Screenshots

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/1017872/216447914-a2aba366-3aad-4f8c-ac98-44a43ecc7287.png) | ![Screen Shot 2023-02-03 at 9 57 01 AM](https://user-images.githubusercontent.com/1017872/216447984-002b5d0d-d279-4449-9353-a8e969d81b08.jpg) |