### PR TITLE
Add convenience scripts for running yarn workspace commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
 		"lighthouse": "lighthouse-ci http://localhost:8888/ --accessibility=100 --best-practices=100 --seo=100",
 		"lighthouse:desktop": "lighthouse http://localhost:8888/ --view --preset=desktop --output-path=lighthouse.html",
 		"lighthouse:mobile": "lighthouse http://localhost:8888/ --view --screenEmulation.mobile --output-path=lighthouse.html",
-		"build:patterns": "./env/build-patterns.sh"
+		"build:patterns": "./env/build-patterns.sh",
+		"build:theme": "yarn workspace wporg-main-2022-theme build",
+		"lint:frontend": "yarn workspace wporg-main-2022-theme lint:css && yarn workspace wporg-main-2022-theme lint:js",
+		"lint:php": "composer run lint source/wp-content/themes/wporg-main-2022 && composer run lint source/wp-content/mu-plugins/theme-switcher.php && composer run lint env",
+		"start:theme": "yarn workspace wporg-main-2022-theme start"
 	},
 	"workspaces": [
 		"source/wp-content/themes/wporg-main-2022"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"build:patterns": "./env/build-patterns.sh",
 		"build:theme": "yarn workspace wporg-main-2022-theme build",
 		"lint:frontend": "yarn workspace wporg-main-2022-theme lint:css && yarn workspace wporg-main-2022-theme lint:js",
-		"lint:php": "composer run lint source/wp-content/themes/wporg-main-2022 && composer run lint source/wp-content/mu-plugins/theme-switcher.php && composer run lint env",
+		"lint:php": "composer run lint source/wp-content/themes/wporg-main-2022 source/wp-content/mu-plugins/theme-switcher.php env",
 		"start:theme": "yarn workspace wporg-main-2022-theme start"
 	},
 	"workspaces": [


### PR DESCRIPTION
I find it really useful to have the yarn workspace commands in the root package.json for typical workflows, ie. build, start and lint.

### How to test the changes in this Pull Request:

1. Run each of the commands added; `build:theme`, `lint:frontend`, `lint:php`, `start:theme`, and ensure they do what they say
2. Try adding things which should fail lint