### PR TITLE
Align About page section headings with adjacent body copy

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -235,7 +235,9 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 @media (min-width: 782px) {
 	.wporg-about-section-heading {
 		// move the section heading up to align with the top of the right column
-		margin-block-start: -10px !important;
+		// fluid margin-block-start based on screen width, margin reduces as screen gets wider:
+		// clamp(-10px above 1920px wide, preferred value, 4px below 600px wide)
+		margin-block-start: clamp(-0.625rem, -1.06vw + 0.65rem, 0.25rem) !important;
 	}
 
 	[class*="wporg-about-section-freedom-"] {


### PR DESCRIPTION
The section headings in the About page need to align with the top of the adjacent body copy column

<img width="1712" alt="screen-shot-2023-02-09-at-14 39 25" src="https://user-images.githubusercontent.com/1017872/217987983-24e4c5bb-6abe-4384-88fc-e0256bb32b9f.png">

The font size of these headings is fluid so the margin adjustment to align the elements needs to be too.

Fixes #188 

### Screenshots

| Monitor | Desktop | Tablet landscape |
|--------|-------|-------|
| ![localhost_8888_about-2_(Monitor)](https://user-images.githubusercontent.com/1017872/217988882-304baf85-866c-4d51-a5e9-728ea64d489b.png) | ![localhost_8888_about-2_(Desktop)](https://user-images.githubusercontent.com/1017872/217988911-67a2105f-7172-4f18-8909-98f891424d18.png) | ![localhost_8888_about-2_(iPad) (6)](https://user-images.githubusercontent.com/1017872/217988931-a16a68f3-f5d6-4946-a5bd-e828cde34e36.png) |

### How to test the changes in this Pull Request:

1. Ensure you have a page at `about-2` and set the template to `page-about`
2. View the page and check the alignment of the section headings at various screen sizes (design has desktop width at 1320px and monitor at 1920px). Below 782px the layout switches to stacked columns, so there should be no margin set below that.