### PR TITLE
Link directly from About page to Mercantile

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/about.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about.php
@@ -255,7 +255,7 @@
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><a href="https://wordpress.org/about/swag/"><?php _e( 'Swag ↗', 'wporg' ); ?></a></li>
+<li><a href="https://mercantile.wordpress.org/"><?php _e( 'Swag ↗', 'wporg' ); ?></a></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->


### PR DESCRIPTION
See #208

Changes the link in the about page from https://wordpress.org/about/swag/ to https://mercantile.wordpress.org/