### PR TITLE
Fix broken Download Modal layout

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/download/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/download/style.scss
@@ -35,16 +35,17 @@
 
 .components-modal__header {
 	display: flex;
+
+	.components-modal__header-heading {
+		font-size: var(--wp--preset--font-size--heading-2);
+		font-weight: var(--wp--custom--heading--typography--font-weight);
+		line-height: var(--wp--custom--heading--level-2--typography--line-height);
+		margin: 0 0 0.5em;
+	}
 }
 
 .components-modal__header-heading-container {
 	flex: 1;
-}
-
-.components-modal__header-heading {
-	font-size: var(--wp--preset--font-size--heading-2);
-	line-height: var(--wp--custom--heading--level-2--typography--line-height);
-	margin: 0 0 0.5em;
 }
 
 .components-modal__header .components-button {
@@ -72,6 +73,14 @@
 
 .wporg__download-modal .components-modal__header {
 	padding-bottom: 0;
+	position: unset;
+	height: unset;
+	align-items: unset;
+}
+
+.wporg__download-modal .components-modal__content {
+	margin-top: 0;
+	padding: 0;
 }
 
 .wporg__download-modal-sub-header {

--- a/source/wp-content/themes/wporg-main-2022/src/download/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/download/style.scss
@@ -21,20 +21,54 @@
 	max-width: 568px;
 }
 
-.components-modal__header,
-.wporg__download-modal-sub-header,
-.wporg__download-modal-content {
-	padding: 41px 46px;
-}
 
-.components-modal__header,
-.wporg__download-modal-sub-header {
-	background: var(--wp--preset--color--blueberry-1);
-	color: var(--wp--preset--color--white);
-}
+.wporg__download-modal {
+	.components-modal__header,
+	.wporg__download-modal-sub-header,
+	.wporg__download-modal-content {
+		padding: 41px 46px;
+	}
 
-.components-modal__header {
-	display: flex;
+	.components-modal__header,
+	.wporg__download-modal-sub-header {
+		background: var(--wp--preset--color--blueberry-1);
+		color: var(--wp--preset--color--white);
+	}
+
+	.components-modal__header {
+		display: flex;
+		padding-bottom: 0;
+		position: unset;
+		height: unset;
+		align-items: unset;
+
+		.components-button {
+			--components-modal__close-button-size: 40px;
+			--components-modal__close-button-position: calc(var(--components-modal__close-button-size) / -2);
+			width: var(--components-modal__close-button-size);
+			height: var(--components-modal__close-button-size);
+			margin-right: var(--components-modal__close-button-position);
+			margin-top: var(--components-modal__close-button-position);
+			background: transparent;
+			border: none;
+			cursor: pointer;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+
+			svg {
+				fill: var(--wp--preset--color--white);
+			}
+
+			.components-tooltip {
+				color: var(--wp--preset--color--white);
+			}
+		}
+	}
+
+	.components-modal__header-heading-container {
+		flex: 1;
+	}
 
 	.components-modal__header-heading {
 		font-size: var(--wp--preset--font-size--heading-2);
@@ -42,58 +76,26 @@
 		line-height: var(--wp--custom--heading--level-2--typography--line-height);
 		margin: 0 0 0.5em;
 	}
-}
 
-.components-modal__header-heading-container {
-	flex: 1;
-}
+	.wporg__download-modal-sub-header {
+		margin: 0;
+		padding-top: 0;
+	}
 
-.components-modal__header .components-button {
-	--components-modal__close-button-size: 40px;
-	--components-modal__close-button-position: calc(var(--components-modal__close-button-size) / -2);
-	width: var(--components-modal__close-button-size);
-	height: var(--components-modal__close-button-size);
-	margin-right: var(--components-modal__close-button-position);
-	margin-top: var(--components-modal__close-button-position);
-	background: transparent;
-	border: none;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
+	.components-modal__content {
+		margin-top: 0;
+		padding: 0;
+	}
 
-.components-modal__header .components-button svg {
-	fill: var(--wp--preset--color--white);
-}
+	.wporg__download-modal-content {
+		p:first-child {
+			margin-top: 0;
+		}
 
-.components-modal__header .components-button .components-tooltip {
-	color: var(--wp--preset--color--white);
-}
-
-.wporg__download-modal .components-modal__header {
-	padding-bottom: 0;
-	position: unset;
-	height: unset;
-	align-items: unset;
-}
-
-.wporg__download-modal .components-modal__content {
-	margin-top: 0;
-	padding: 0;
-}
-
-.wporg__download-modal-sub-header {
-	margin: 0;
-	padding-top: 0;
-}
-
-.wporg__download-modal-content p:first-child {
-	margin-top: 0;
-}
-
-.wporg__download-modal-content ul {
-	list-style: none;
-	padding-left: 0;
-	margin-bottom: 0;
+		ul {
+			list-style: none;
+			padding-left: 0;
+			margin-bottom: 0;
+		}
+	}
 }


### PR DESCRIPTION
The regression is caused by new Modal styles introduced in the @wordpress/components package. 

This PR adds style overrides which are compatible with both the local dev env (WP 6.1.1, Gutenberg 15.4.0) and prod (WP 6.3-alpha-55582, Gutenberg 15.1.0)

It also adds a `.wporg__download-modal` scope to all the custom layout styles, as they have diverged quite a long way from the default styles, and could negatively affect any other modals we add.

Fixes #219

## Screenshots

### Sandbox (prod versions)

| Desktop | iPad | Mobile |
|--------|-------|-|
| ![wordpress org_download_(Desktop)](https://user-images.githubusercontent.com/1017872/227390264-ef06f320-8bd3-4e90-98cd-7a10212d0976.png) | ![wordpress org_download_(iPad)](https://user-images.githubusercontent.com/1017872/227390289-a5d7ac61-2232-4691-a285-3ad5fc27d968.png) | ![wordpress org_download_(Samsung Galaxy S20 Ultra)](https://user-images.githubusercontent.com/1017872/227390316-e6e20618-5f64-4fff-8001-77bf251062f7.png) |

### Local

| Desktop | iPad | Mobile |
|--------|-------|-|
| ![localhost_8888_download_(Desktop) (1)](https://user-images.githubusercontent.com/1017872/227390423-19bf21e2-1a80-42a2-8abd-c95824ac87c2.png) | ![localhost_8888_download_(iPad)](https://user-images.githubusercontent.com/1017872/227390479-a6e67dd4-ebf4-4080-abb9-3bdba4e7d409.png) | ![localhost_8888_download_(Samsung Galaxy S20 Ultra)](https://user-images.githubusercontent.com/1017872/227390463-e338649a-dcb7-4359-847b-b1d0b190ac24.png) |

### How to test the changes in this Pull Request:

Test locally or in sandbox

1. Navigate to /download
2. Click the 'Get WordPress...' button
3. Dismiss the download
4. View the modal and check the layout, including different screens sizes
