### PR TITLE
Fix deployment of styles of Download modal without other block changes

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -63,7 +63,7 @@ function enqueue_assets() {
 			'wporg-main-2022-download-style',
 			get_stylesheet_directory_uri() . '/build/download/style-index.css',
 			array(),
-			$script_info['version']
+			filemtime( __DIR__ . '/build/download/style-index.css' )
 		);
 		wp_style_add_data( 'wporg-main-2022-download-style', 'rtl', 'replace' );
 	}


### PR DESCRIPTION
Change version of Download Modal style to the filemtime of that file.

If it's set to the time of the index.asset.php file and that file hasn't changed, the old version is loaded

Fixes the deployment of #219

Tested in sandbox, where the new version number is `1679876118`. Updating the CSS request in prod with the same version loads the new CSS:

![Screen Shot 2023-03-27 at 1 38 09 PM](https://user-images.githubusercontent.com/1017872/227815433-25326823-f79c-4585-b79d-96f77694ad6b.jpg)
