### PR TITLE
Search: Update search page styles

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/search.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/search.php
@@ -6,20 +6,16 @@
  */
 
 ?>
-<!-- wp:cover {"overlayColor":"blueberry-1","minHeight":300,"align":"full"} -->
-<div class="wp-block-cover alignfull" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"heading-cta"} -->
-<h1 class="wp-block-heading has-text-align-center has-heading-cta-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0"><?php _e( 'Search', 'wporg' ); ?></h1>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"align":"center","className":"is-style-short-text"} -->
-<p class="has-text-align-center is-style-short-text"><?php _e( 'Search the WordPress.org website for plugins, themes, and support.', 'wporg' ); ?></p>
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Search', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:group --></div></div>
-<!-- /wp:cover -->
+<!-- /wp:group --></div>
+<!-- /wp:group -->
 
-<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull"><!-- wp:wporg/google-search-embed {"align":"wide"} /--></div>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50)"><!-- wp:wporg/google-search-embed {"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":"40px"} -->

--- a/source/wp-content/themes/wporg-main-2022/src/google-search-embed/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/google-search-embed/style.scss
@@ -1,6 +1,27 @@
 .wp-block-wporg-google-search-embed {
+	.gsc-control-cse {
+		font-family: var(--wp--preset--font-family--inter) !important;
+
+		* {
+			font-family: inherit !important;
+		}
+	}
+
+	form.gsc-search-box {
+		margin-bottom: var(--wp--preset--spacing--40);
+	}
+
+	.gsc-result-info,
+	.gsc-orderby-label {
+		color: var(--wp--preset--color--charcoal-4);
+	}
+
 	.gsc-search-button-v2 {
 		padding: 13px 27px;
+
+		svg {
+			transform: scaleX(-1);
+		}
 	}
 
 	.gs-web-image-box,


### PR DESCRIPTION
In this PR, I've updated the page content to use the local nav style for the "Search" header, and added some CSS. It should flip the search icon, though I didn't go as far as overwriting it in case the embed code changes one day; update the light grey color of the results count to be `charcoal-4` and force everything to use the theme's body font (Inter).

I tried updating the style provided by Google on the search form & results to use our color palette - I could only change some things (text colors, the basic button colors, and the search box's border), but I think it helped increase the contrast on the page. These changes to the embed are published to production already.

Fixes #216

### Screenshots

| Before | After |
|--------|-------|
| <img  alt="" src="https://user-images.githubusercontent.com/1204802/226575611-8c33d485-6801-4420-b590-ce0a4c87aa3e.png"> | ![](https://user-images.githubusercontent.com/541093/229922981-ff37d0ed-6cd1-4e50-adb4-bd46a625358e.png) |

### How to test the changes in this Pull Request:

1. Go to the search page `/search/`
2. Search for something
3. The results should look like the after screenshot
