### PR TITLE
Download page: Update download button styles on small screens

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -427,6 +427,42 @@ html[dir="rtl"] :where([style*="border-right-color"]) {
 		width: 100% !important;
 	}
 
+	#download-install .wp-block-button:nth-child(1) a {
+		padding: 0;
+		background-color: transparent;
+		color: var(--wp--custom--link--color--text);
+		font-weight: 400;
+		text-align: revert;
+		display: inline;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration: underline;
+		}
+	}
+
+	#download-install .wp-block-button:nth-child(2) a {
+		--wp--custom--button--outline--color--background: var(--wp--preset--color--blueberry-1);
+		--wp--custom--button--outline--color--text: var(--wp--preset--color--white);
+		--wp--custom--button--outline--hover--color--background: var(--wp--preset--color--deep-blueberry);
+		--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--white);
+		--wp--custom--button--outline--active--color--background: var(--wp--preset--color--charcoal-1);
+		--wp--custom--button--outline--active--color--text: var(--wp--preset--color--white);
+		border: none;
+		background-color: var(--wp--custom--button--outline--color--background);
+
+		&:hover,
+		&:focus {
+			background-color: var(--wp--custom--button--outline--hover--color--background);
+			color: var(--wp--custom--button--outline--hover--color--text);
+		}
+
+		&:active {
+			background-color: var(--wp--custom--button--outline--active--color--background);
+			color: var(--wp--custom--button--outline--active--color--text);
+		}
+	}
+
 	.wporg-enterprise-logos {
 		display: grid !important;
 		grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
Fixes #249 — Update the style of the "Download" and "Installation guide" links when viewing from a small screen. The cutoff for "small" is 600px.

### Screenshots

| Before | After |
|--------|-------|
| ![trunk](https://user-images.githubusercontent.com/541093/231000911-879ac002-6370-4125-851b-a5625eb79844.png) | ![branch](https://user-images.githubusercontent.com/541093/231000907-4d159121-37ef-420f-a30d-245b62cac7cc.png) |

### How to test the changes in this Pull Request:

1. Check out this branch & build the CSS
2. View the download page
3. On larger (600+) screens, the Download button is primary
4. On smaller screens, the Installation guide button is primary
