### PR TITLE
Try new Local Navigation block

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -21,6 +21,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
 add_filter( 'wp_img_tag_add_loading_attr', __NAMESPACE__ . '\override_lazy_loading', 10, 2 );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\update_site_breadcrumbs' );
+add_filter( 'render_block_core/site-title', __NAMESPACE__ . '\use_parent_page_title', 10, 3 );
 
 /**
  * Enqueue scripts and styles.
@@ -117,7 +118,7 @@ function override_lazy_loading( $value, $image ) {
 }
 
 /**
- * In the subpages, update first breadcrumb to be the parent page, rather than site home.
+ * Use the page heirarchy to display breadcrumbs.
  */
 function update_site_breadcrumbs( $breadcrumbs ) {
 	$parent = get_post_parent();
@@ -125,21 +126,51 @@ function update_site_breadcrumbs( $breadcrumbs ) {
 		return $breadcrumbs;
 	}
 
-	if ( 'about' === $parent->post_name ) {
-		$top_level_page = array(
-			'url'   => home_url( '/about/' ),
-			'title' => __( 'About', 'wporg' ),
+	$breadcrumbs = array();
+	$breadcrumbs[] = array(
+		'url' => false,
+		'title' => get_the_title(),
+	);
+
+	while ( $parent ) {
+		$breadcrumbs[] = array(
+			'url' => get_permalink( $parent->ID ),
+			'title' => $parent->post_title,
 		);
-		$breadcrumbs[0] = $top_level_page;
-	} else if ( 'download' === $parent->post_name ) {
-		$top_level_page = array(
-			'url'   => home_url( '/download/' ),
-			'title' => __( 'Download', 'wporg' ),
-		);
-		$breadcrumbs[0] = $top_level_page;
+		$parent = get_post_parent( $parent );
 	}
 
-	return $breadcrumbs;
+	return array_reverse( $breadcrumbs );
+}
+
+/**
+ * Replace the site title & link with the parent page title.
+ *
+ * The About and Download sections are pseudo-individual sites, so when site title
+ * is used there, it should reference the parent page.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ */
+function use_parent_page_title( $block_content, $block, $instance ) {
+	$parent = get_post_parent();
+	if ( ! $parent ) {
+		return $block_content;
+	}
+
+	// Loop up to the first child page, this is the section title.
+	while ( $parent ) {
+		$url = get_permalink( $parent->ID );
+		$title = $parent->post_title;
+		$parent = get_post_parent( $parent );
+	}
+
+	return str_replace(
+		array( home_url(), get_bloginfo( 'name' ) ),
+		array( $url, $title ),
+		$block_content
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/src/release-tables/index.php';
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
 add_filter( 'wp_img_tag_add_loading_attr', __NAMESPACE__ . '\override_lazy_loading', 10, 2 );
+add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\update_site_breadcrumbs' );
 
 /**
  * Enqueue scripts and styles.
@@ -113,6 +114,32 @@ function override_lazy_loading( $value, $image ) {
 		return false;
 	}
 	return $value;
+}
+
+/**
+ * In the subpages, update first breadcrumb to be the parent page, rather than site home.
+ */
+function update_site_breadcrumbs( $breadcrumbs ) {
+	$parent = get_post_parent();
+	if ( ! $parent ) {
+		return $breadcrumbs;
+	}
+
+	if ( 'about' === $parent->post_name ) {
+		$top_level_page = array(
+			'url'   => home_url( '/about/' ),
+			'title' => __( 'About', 'wporg' ),
+		);
+		$breadcrumbs[0] = $top_level_page;
+	} else if ( 'download' === $parent->post_name ) {
+		$top_level_page = array(
+			'url'   => home_url( '/download/' ),
+			'title' => __( 'Download', 'wporg' ),
+		);
+		$breadcrumbs[0] = $top_level_page;
+	}
+
+	return $breadcrumbs;
 }
 
 /**

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Section Nav (About - Details)
+ * Slug: wporg-main-2022/nav-about-details
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
@@ -7,12 +7,12 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
+<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
@@ -7,12 +7,8 @@
  */
 
 ?>
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
 <!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
-<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Section Nav (About - People)
+ * Slug: wporg-main-2022/nav-about-people
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
@@ -7,12 +7,8 @@
  */
 
 ?>
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
 <!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
-<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
@@ -7,12 +7,12 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
+<!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Section Nav (About - Technology)
+ * Slug: wporg-main-2022/nav-about-technology
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
@@ -7,12 +7,12 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
+<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
@@ -7,12 +7,8 @@
  */
 
 ?>
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
 <!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
-<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
@@ -7,12 +7,12 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:wporg/local-navigation-bar {"className":"is-style-brush-stroke","style":{"position":{"type":"sticky"}},"fontSize":"small"} -->
+<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"ref":11576,"backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
+<!-- wp:navigation {"ref":11576,"hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"32px","bottom":"16px"}}},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-small-font-size" style="padding-top:32px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Section Nav (Download)
+ * Slug: wporg-main-2022/nav-download
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:navigation {"ref":11576,"backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
@@ -12,7 +12,3 @@
 
 <!-- wp:navigation {"ref":11576,"hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"32px","bottom":"16px"}}},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-small-font-size" style="padding-top:32px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs /--></div>
-<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-accessibility.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-accessibility.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Accessibility', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-domains.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-domains.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Domains', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-etiquette.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-etiquette.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Etiquette', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-features.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-features.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"className":"wp-block-heading"} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Features', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-history.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-history.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1} -->
 <h1 class="wp-block-heading"><?php _e( 'History', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-license.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-license.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'GNU Public License', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-logos.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-logos.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Graphics &amp; Logos', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-philosophy.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-philosophy.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":17028,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Philosophy', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-privacy.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-privacy.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Privacy policy', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Requirements', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-roadmap.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-roadmap.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1} -->
 <h1 class="wp-block-heading"><?php _e( 'Roadmap', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-security.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-security.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16421,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Security', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-stats.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-stats.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'About', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":16892,"textColor":"blueberry-1","backgroundColor":"white","align":"wide","className":"is-style-dropdown-on-mobile","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
 <h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Statistics', 'wporg' ); ?></h1>

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-beta-nightly.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-beta-nightly.php
@@ -10,13 +10,13 @@
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}} -->
 <div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:column {"width":"33.33%"} -->
 <div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"level":1,"style":{"spacing":{"padding":{"right":"var:preset|spacing|60"}}},"fontSize":"heading-2"} -->
-<h1 class="has-heading-2-font-size" style="padding-right:var(--wp--preset--spacing--60)"><?php _e( 'Beta/Nightly', 'wporg' ); ?></h1>
+<h1 class="wp-block-heading has-heading-2-font-size" style="padding-right:var(--wp--preset--spacing--60)"><?php _e( 'Beta/Nightly', 'wporg' ); ?></h1>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"66.66%"} -->
 <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:heading {"fontSize":"heading-3"} -->
-<h2 class="has-heading-3-font-size"><?php _e( 'Unstable Beta Versions', 'wporg' ); ?></h2>
+<h2 class="wp-block-heading has-heading-3-font-size"><?php _e( 'Unstable Beta Versions', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -32,7 +32,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"fontSize":"heading-3"} -->
-<h2 class="has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--30)"><?php _e( 'Nightly Builds', 'wporg' ); ?></h2>
+<h2 class="wp-block-heading has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--30)"><?php _e( 'Nightly Builds', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-beta-nightly.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-beta-nightly.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":11576,"backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}} -->
 <div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:column {"width":"33.33%"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-counter.php
@@ -9,7 +9,7 @@
 <!-- wp:cover {"overlayColor":"charcoal-2","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
 <div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-2-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"italic"}},"fontSize":"heading-5"} -->
-<h1 class="has-text-align-center has-heading-5-font-size" style="font-style:italic"><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></h1>
+<h1 class="wp-block-heading has-text-align-center has-heading-5-font-size" style="font-style:italic"><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:wporg/download-counter {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"}},"typography":{"fontWeight":"200"}},"textColor":"blueberry-2"} /--></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-counter.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|charcoal-1","width":"1px"},"bottom":{"width":"0px","style":"none"}}},"backgroundColor":"charcoal-2","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--charcoal-1);border-top-width:1px;border-bottom-style:none;border-bottom-width:0px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":11576,"textColor":"blueberry-2","backgroundColor":"charcoal-2","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:cover {"overlayColor":"charcoal-2","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
 <div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-2-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"italic"}},"fontSize":"heading-5"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-releases.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-releases.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":11576,"backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}} -->
 <div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:column {"width":"33.33%"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-source.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-source.php
@@ -6,16 +6,6 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Download', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:navigation {"ref":11576,"backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}} -->
 <div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:column {"width":"33.33%"} -->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-accessibility.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-accessibility.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-details"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/accessibility"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-beta-nightly.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-beta-nightly.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-download"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/beta-nightly"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-counter.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-counter.html
@@ -1,12 +1,10 @@
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|charcoal-1","width":"1px"},"bottom":{"width":"0px","style":"none"}}},"backgroundColor":"charcoal-2","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--charcoal-1);border-top-width:1px;border-bottom-style:none;border-bottom-width:0px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}},"border":{"top":{"color":"var:preset|color|charcoal-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|charcoal-1","style":"solid","width":"1px"},"left":{}}},"textColor":"white","fontSize":"small"} -->
+<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"ref":11576,"textColor":"blueberry-2","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
+<!-- wp:navigation {"ref":11576,"textColor":"blueberry-2","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">

--- a/source/wp-content/themes/wporg-main-2022/templates/page-counter.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-counter.html
@@ -1,5 +1,13 @@
 <!-- wp:wporg/global-header /-->
 
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"}},"border":{"top":{"color":"var:preset|color|charcoal-1","width":"1px"},"bottom":{"width":"0px","style":"none"}}},"backgroundColor":"charcoal-2","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-brush-stroke is-sticky has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="border-top-color:var(--wp--preset--color--charcoal-1);border-top-width:1px;border-bottom-style:none;border-bottom-width:0px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
+
+<!-- wp:navigation {"ref":11576,"textColor":"blueberry-2","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/counter"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-domains.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-domains.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-details"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/domains"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-etiquette.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-etiquette.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-people"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/etiquette"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-features.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-features.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-technology"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/features"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-history.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-history.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-technology"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/history"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-license.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-license.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-details"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/license"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-logos.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-logos.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-people"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/logos"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-philosophy.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-philosophy.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-people"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/philosophy"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-privacy.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-privacy.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-details"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/privacy"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-releases.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-releases.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-download"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/releases"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-requirements.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-requirements.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-technology"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/requirements"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-roadmap.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-roadmap.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-technology"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/roadmap"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-security.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-security.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-technology"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/security"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-source.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-source.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-download"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/source"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-stats.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-stats.html
@@ -1,5 +1,7 @@
 <!-- wp:wporg/global-header {"style":"black-on-white"} /-->
 
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-about-details"} /-->
+
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:pattern {"slug":"wporg-main-2022/stats"} /-->


### PR DESCRIPTION
This is a companion PR to https://github.com/WordPress/wporg-mu-plugins/pull/404, which introduces a new Local Navigation container to hold the section title & section menu. This PR extracts out the local header from the synced post content, and creates new reusable pattern-partials which handle the header content on each subpage. The new patterns use the Local Navigation container block.

The changes here also bring these headers in line with the generic section header mocked up. @WordPress/meta-design As I understood it, this pattern is complete, but if that's not the case let me know.

![Section Header L2](https://github.com/WordPress/wporg-main-2022/assets/541093/f8638edf-41a4-4f00-922b-2cf4957f780a)

❗ If we decide not to merge the Local Nav block, I still think we should merge https://github.com/WordPress/wporg-main-2022/commit/e1e42a3e60411e69d1f81841cb1ef0b61f31691c to DRY up the About pages. That won't change any visuals.

Additionally, once this is merged, I'll need to go in and update each of the subpages to remove the banner, so that the content sync doesn't overwrite these changes.

See WordPress/wporg-mu-plugins#465

### Screenshots

1. The Stats page, a general About subpage. I added borders to the header as this was mocked up at some point, but I don't know if that's still the preference.
2. The Requirements page, scrolled down— the top banner sticks under the global header, but the breadcrumbs scroll. Is that the expected behavior?
3. The Beta/Nightly page— I kept the brush stroke style on the download subpages, but that + the breadcrumbs is a little strange.
4. The download counter— unlike the other download subpages, this does not have the breadcrumbs, and uses the black+borders style for the banner. So we can still have unique features on individual pages.

| Before | After |
|--------|-------|
| ![before-about-stats](https://github.com/WordPress/wporg-main-2022/assets/541093/82ae7057-f513-4b95-ac90-83d6f2e4bab7) | ![after-about-stats](https://github.com/WordPress/wporg-main-2022/assets/541093/d8ecd2c8-242b-4135-9690-3448d79c2640) |
| ![before-about-reqs-scroll](https://github.com/WordPress/wporg-main-2022/assets/541093/0fc0077d-4125-4027-a1e7-b37206c3828b) | ![after-about-reqs-scroll](https://github.com/WordPress/wporg-main-2022/assets/541093/b31df9d1-6443-4c7b-b2fe-91b477494270) |
| ![before-download-nightly](https://github.com/WordPress/wporg-main-2022/assets/541093/1983fcfb-f6d4-4fae-8b20-668e8a8fcca3) | ![after-download-nightly](https://github.com/WordPress/wporg-main-2022/assets/541093/f068f201-a06c-444c-a9ef-db998f530fe5) |
| ![before-download-counter](https://github.com/WordPress/wporg-main-2022/assets/541093/6578d80a-b373-41c6-9c0c-8a830be09319) | ![after-download-counter](https://github.com/WordPress/wporg-main-2022/assets/541093/a1b7563a-1878-4fbf-80ac-3f3dd75e4997) |

### How to test the changes in this Pull Request:

1. Make sure you have https://github.com/WordPress/wporg-mu-plugins/pull/404 applied on wporg-mu-plugins
2. Check out this branch
3. View the About and Download subpages
