### PR TITLE
Add a local navigation banner to archives & single posts

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-main-2022/parts/header.html
@@ -1,1 +1,3 @@
 <!-- wp:wporg/global-header /-->
+
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-index"} /-->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-index.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-index.php
@@ -1,0 +1,16 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Section Nav (Index (all posts))
+ * Slug: wporg-main-2022/nav-index
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"16px","bottom":"16px"}}},"backgroundColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-sticky has-white-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:700"><?php _e( 'News', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->


### PR DESCRIPTION
This adds a new pattern (based off the work in #269) which is a "News" local header. It has no subnavigation. It's called by the `header.html` template part, which is only used on the index, archive, and single templates provided by the parent theme (so it only shows on single posts, and lists of posts). These are not used on the main (English) site, but they are used on the Rosetta sites.

See https://github.com/WordPress/wporg-main-2022/issues/266, https://github.com/WordPress/wporg-parent-2021/pull/88

### Screenshots

![Screen Shot 2023-06-15 at 18 24 01](https://github.com/WordPress/wporg-main-2022/assets/541093/cc659daa-4178-4ba2-af60-f3756fe7361e)

See more screenshots on https://github.com/WordPress/wporg-parent-2021/pull/88

### How to test the changes in this Pull Request:

See the test instructions on https://github.com/WordPress/wporg-parent-2021/pull/88
