### PR TITLE
Bump the recommended MariaDB version to 10.4

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -47,7 +47,7 @@ add_shortcode(
 add_shortcode(
 	'recommended_mariadb',
 	function() {
-		return '10.3';
+		return '10.4';
 	}
 );
 


### PR DESCRIPTION
Matches the version number in the WordPress readme and Site Health.

https://core.trac.wordpress.org/ticket/58158
https://meta.trac.wordpress.org/ticket/7099