### PR TITLE
Try using workflow from wporg-repo-tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,46 +1,39 @@
 name: Build and push to build branch.
 
 on:
-    push:
-        branches: [trunk]
+  push:
+    branches: [trunk]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: trunk
 
-            - name: Install NodeJS
-              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
-              with:
-                  node-version-file: '.nvmrc'
-                  cache: 'yarn'
+      - name: Setup
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Install all dependencies
-              run: |
-                  composer install
-                  yarn
+      - name: Trim the repo down to just the theme
+        run: |
+          rm -rf source/wp-content/themes/wporg-main-2022/node_modules
+          mv source/wp-content/themes/wporg-main-2022 $RUNNER_TEMP
+          git rm -rfq .
+          rm -rf *
+          mv $RUNNER_TEMP/wporg-main-2022/* .
 
-            - name: Build
-              run: yarn workspaces run build
+      - name: Add all the theme files
+        run: |
+          git add * --force
 
-            - name: Trim the repo down to just the theme
-              run: |
-                  rm -rf source/wp-content/themes/wporg-main-2022/node_modules
-                  mv source/wp-content/themes/wporg-main-2022 $RUNNER_TEMP
-                  git rm -rfq .
-                  rm -rf *
-                  mv $RUNNER_TEMP/wporg-main-2022/* .
-
-            - name: Add all the theme files
-              run: |
-                  git add * --force
-
-            - name: Commit and push
-              uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  branch: build
-                  force: true
-                  message: 'Build: ${{ github.sha }}'
+      - name: Commit and push
+        uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: build
+          force: true
+          message: 'Build: ${{ github.sha }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           ref: trunk
 
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,40 +2,23 @@ name: Static Analysis (Linting)
 
 # This workflow is triggered on pushes to trunk, and any PRs.
 on:
-    push:
-        branches: [trunk]
-    pull_request:
+  push:
+    branches: [trunk]
+  pull_request:
 
 jobs:
-    check:
-        name: Lint everything
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: trunk
 
-        runs-on: ubuntu-latest
+      - name: Setup
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-
-            - name: Install NodeJS
-              uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.3.0
-              with:
-                  node-version-file: '.nvmrc'
-                  cache: yarn
-
-            - name: Install dependencies & setup configs
-              run: |
-                  yarn setup:tools
-
-            - name: Lint CSS
-              run: |
-                  yarn workspace wporg-main-2022-theme lint:css
-
-            - name: Lint JS
-              run: |
-                  yarn workspace wporg-main-2022-theme lint:js
-
-            - name: Lint PHP
-              run: |
-                  composer run lint source/wp-content/themes/wporg-main-2022
-                  composer run lint source/wp-content/mu-plugins/theme-switcher.php
-                  composer run lint env
+      - name: Lint
+        uses: WordPress/wporg-repo-tools/.github/actions/lint@try/reusable-workflows

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        with:
-          ref: trunk
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        uses: WordPress/wporg-repo-tools/.github/actions/lint@try/reusable-workflows
+        uses: WordPress/wporg-repo-tools/.github/actions/lint@trunk

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,33 +2,26 @@ name: PHP Unit Tests
 
 # This workflow is triggered on pushes to trunk, and any PRs.
 on:
-    push:
-        branches: [trunk]
-    pull_request:
+  push:
+    branches: [trunk]
+  pull_request:
 
 jobs:
-    check:
-        name: Test PHP
+  check:
+    name: Test PHP
 
-        runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: trunk
 
-            - name: Install NodeJS
-              uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.3.0
-              with:
-                  node-version-file: '.nvmrc'
-                  cache: yarn
+      - name: Setup
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Install dependencies & setup configs
-              run: |
-                  yarn setup:tools
-
-            - name: Install WordPress
-              run: |
-                  yarn wp-env start
-
-            - name: Running PHP unit tests
-              run: yarn test:php
+      - name: Test
+        uses: WordPress/wporg-repo-tools/.github/actions/test-php@try/reusable-workflows

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
-        uses: WordPress/wporg-repo-tools/.github/actions/test-php@try/reusable-workflows
+        uses: WordPress/wporg-repo-tools/.github/actions/test-php@trunk

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        with:
-          ref: trunk
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@try/reusable-workflows

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
 		"wporg/wporg-repo-tools": "dev-trunk",
 		"wporg/wporg-mu-plugins": "dev-build",
 		"wporg/wporg-parent-2021": "dev-build",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^1.1"
 	},
 	"scripts": {
 		"format": "phpcbf -p",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "652c9baa4366ca13314c13344b96f9cc",
+    "content-hash": "7094cbd956d0c4edb539768c7a0dd30c",
     "packages": [],
     "packages-dev": [
         {
@@ -2372,15 +2372,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "16.4.0",
+            "version": "16.5.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/16.4.0"
+                "reference": "tags/16.5.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.16.4.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.16.5.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -2390,15 +2390,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "12.4",
+            "version": "12.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/12.4"
+                "reference": "tags/12.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.12.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.12.5.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -2430,12 +2430,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "22bd36cc52d800b61a6e9f103c735e3cd8b96af3"
+                "reference": "6f64e1f11713a45fe0d1cafa7866918dc383a3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/22bd36cc52d800b61a6e9f103c735e3cd8b96af3",
-                "reference": "22bd36cc52d800b61a6e9f103c735e3cd8b96af3",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/6f64e1f11713a45fe0d1cafa7866918dc383a3d0",
+                "reference": "6f64e1f11713a45fe0d1cafa7866918dc383a3d0",
                 "shasum": ""
             },
             "require": {
@@ -2449,7 +2449,7 @@
                 "wp-coding-standards/wpcs": "2.*",
                 "wp-phpunit/wp-phpunit": "~6.0",
                 "wporg/wporg-repo-tools": "dev-trunk",
-                "yoast/phpunit-polyfills": "^1.0"
+                "yoast/phpunit-polyfills": "^1.1"
             },
             "type": "wordpress-muplugin",
             "extra": {
@@ -2476,7 +2476,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2023-08-09T00:17:46+00:00"
+            "time": "2023-08-23T04:54:39+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",
@@ -2484,12 +2484,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "e5b02d6e73198fb8ebb02acc63ce0eb609852b28"
+                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/e5b02d6e73198fb8ebb02acc63ce0eb609852b28",
-                "reference": "e5b02d6e73198fb8ebb02acc63ce0eb609852b28",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
+                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
                 "shasum": ""
             },
             "type": "wordpress-theme",
@@ -2497,7 +2497,7 @@
                 "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
                 "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
             },
-            "time": "2023-08-16T19:52:41+00:00"
+            "time": "2023-08-22T15:22:31+00:00"
         },
         {
             "name": "wporg/wporg-repo-tools",
@@ -2531,16 +2531,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2587,7 +2587,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"lighthouse-ci": "^1.13.1"
 	},
 	"scripts": {
-		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs",
+		"setup:tools": "TEXTDOMAIN=wporg composer exec update-configs",
 		"setup:wp": "wp-env run cli \"bash env/setup.sh\" && ./env/refresh.sh",
 		"setup:refresh": "./env/refresh.sh",
 		"update:tools": "composer update && TEXTDOMAIN=wporg composer exec update-configs",

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ Once set up, this environment will contain some shared plugins (Jetpack, Gutenbe
 1. Set up repo dependencies.
 
     ```bash
+    yarn
+    composer install
     yarn setup:tools
     ```
 

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.js
@@ -23,6 +23,6 @@ function Edit( { attributes, name } ) {
 }
 
 registerBlockType( metadata.name, {
-	edit: Edit,	
+	edit: Edit,
 	save: () => null,
 } );

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.js
@@ -23,6 +23,6 @@ function Edit( { attributes, name } ) {
 }
 
 registerBlockType( metadata.name, {
-	edit: Edit,
+	edit: Edit,	
 	save: () => null,
 } );


### PR DESCRIPTION
See https://github.com/WordPress/wporg-repo-tools/issues/26 — this demonstrates updating the actions to use the shared composite actions.

This is still a draft because if https://github.com/WordPress/wporg-repo-tools/pull/29 merges, we'll need to update the action paths to remove the branch name.