### PR TITLE
Parser: Add a note for translators when a string contains a shortcode 

### DIFF
--- a/env/export-content/includes/parser.php
+++ b/env/export-content/includes/parser.php
@@ -236,11 +236,25 @@ function replace_with_i18n( string $content, string $textdomain = 'wporg' ) : st
 
 	$i18n_strings = [];
 	foreach ( $strings as $string ) {
-		$i18n_strings[ $string ] = sprintf(
-			"<?php _e( '%s', '%s' ); ?>",
-			str_replace( "'", '&#039;', $string ),
-			$textdomain
-		);
+		if ( preg_match_all( '#\[[a-z_-]{5,}\]#', $string, $matches ) ) {
+			if ( count( $matches[0] ) > 1 ) {
+				$translator_comment = sprintf( '/* translators: %s are shortcodes and should not be translated. */', implode( ', ', $matches[0] ) );
+			} else {
+				$translator_comment = sprintf( '/* translators: %s is a shortcode and should not be translated. */', implode( ', ', $matches[0] ) );
+			}
+			$i18n_strings[ $string ] = sprintf(
+				"<?php\n%s\n_e( '%s', '%s' );\n?>",
+				$translator_comment,
+				str_replace( "'", '&#039;', $string ),
+				$textdomain
+			);
+		} else {
+			$i18n_strings[ $string ] = sprintf(
+				"<?php _e( '%s', '%s' ); ?>",
+				str_replace( "'", '&#039;', $string ),
+				$textdomain
+			);
+		}
 	}
 
 	return $parser->replace_strings( $i18n_strings );

--- a/env/export-content/tests/block-parser-test.php
+++ b/env/export-content/tests/block-parser-test.php
@@ -147,4 +147,32 @@ class BlockParser_Test extends WP_UnitTestCase {
 		$content_with_i18n = replace_with_i18n( $block_content );
 		$this->assertSame( $expected, $content_with_i18n );
 	}
+
+	/**
+	 * Data provider for valid block content and the i18n-ized results.
+	 *
+	 * @return array
+	 */
+	public function data_block_content_i18n_with_shortcode() {
+		return [
+			[
+				"<!-- wp:paragraph -->\n<p>Recommend PHP [recommended_php] or greater and MySQL [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.</p>\n<!-- /wp:paragraph -->",
+				"<!-- wp:paragraph -->\n<p><?php\n/* translators: [recommended_php], [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */\n_e( 'Recommend PHP [recommended_php] or greater and MySQL [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.', 'wporg' );\n?></p>\n<!-- /wp:paragraph -->",
+			],
+			[
+				"<!-- wp:list-item -->\n<li>Recommend PHP [recommended_php] or greater.</li>\n<!-- /wp:list-item -->",
+				"<!-- wp:list-item -->\n<li><?php\n/* translators: [recommended_php] is a shortcode and should not be translated. */\n_e( 'Recommend PHP [recommended_php] or greater.', 'wporg' );\n?></li>\n<!-- /wp:list-item -->",
+			],
+		];
+	}
+
+	/**
+	 * Test the i18n replacement.
+	 *
+	 * @dataProvider data_block_content_i18n_with_shortcode
+	 */
+	public function test_i18n_replacement_with_shortcode( $block_content, $expected ) {
+		$content_with_i18n = replace_with_i18n( $block_content );
+		$this->assertSame( $expected, $content_with_i18n );
+	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,14 @@
         <exclude-pattern>source/wp-content/themes/wporg-main-2022/patterns/*</exclude-pattern>
     </rule>
 
+    <!-- Allow php tags to be on same line as HTML. -->
+    <rule ref="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen">
+        <exclude-pattern>source/wp-content/themes/wporg-main-2022/patterns/*</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.PHP.EmbeddedPhp.ContentAfterEnd">
+        <exclude-pattern>source/wp-content/themes/wporg-main-2022/patterns/*</exclude-pattern>
+    </rule>
+
     <!-- Don't enforce commenting on forked files. -->
     <rule ref="Squiz.Commenting.ClassComment.WrongStyle">
         <exclude-pattern>env/export-content/includes/parser.php</exclude-pattern>

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-features.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-features.php
@@ -12,7 +12,10 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'WordPress powers more than [market_share] of the web — a figure that rises every day. Everything from simple websites, to blogs, to complex portals and enterprise websites, and even applications, are built with WordPress.', 'wporg' ); ?></p>
+<p><?php
+/* translators: [market_share] is a shortcode and should not be translated. */
+_e( 'WordPress powers more than [market_share] of the web — a figure that rises every day. Everything from simple websites, to blogs, to complex portals and enterprise websites, and even applications, are built with WordPress.', 'wporg' );
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
@@ -17,11 +17,17 @@
 
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
-<li><?php _e( '<a href="https://www.php.net/">PHP</a> version [recommended_php] or greater.', 'wporg' ); ?></li>
+<li><?php
+/* translators: [recommended_php] is a shortcode and should not be translated. */
+_e( '<a href="https://www.php.net/">PHP</a> version [recommended_php] or greater.', 'wporg' );
+?></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><?php _e( '<a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] or greater OR <a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater.', 'wporg' ); ?></li>
+<li><?php
+/* translators: [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */
+_e( '<a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] or greater OR <a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater.', 'wporg' );
+?></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
@@ -56,11 +62,17 @@
 
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
-<li><?php _e( 'PHP [recommended_php] or greater', 'wporg' ); ?></li>
+<li><?php
+/* translators: [recommended_php] is a shortcode and should not be translated. */
+_e( 'PHP [recommended_php] or greater', 'wporg' );
+?></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><?php _e( 'MySQL [recommended_mysql] or greater OR MariaDB [recommended_mariadb] or greater', 'wporg' ); ?></li>
+<li><?php
+/* translators: [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */
+_e( 'MySQL [recommended_mysql] or greater OR MariaDB [recommended_mariadb] or greater', 'wporg' );
+?></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-counter.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-counter.php
@@ -9,7 +9,10 @@
 <!-- wp:cover {"overlayColor":"charcoal-2","minHeight":70,"minHeightUnit":"vh","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}}} -->
 <div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);min-height:70vh"><span aria-hidden="true" class="wp-block-cover__background has-charcoal-2-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"italic"}},"fontSize":"heading-5"} -->
-<h1 class="wp-block-heading has-text-align-center has-heading-5-font-size" style="font-style:italic"><?php _e( 'Number of WordPress [stable_branch] downloads', 'wporg' ); ?></h1>
+<h1 class="wp-block-heading has-text-align-center has-heading-5-font-size" style="font-style:italic"><?php
+/* translators: [stable_branch] is a shortcode and should not be translated. */
+_e( 'Number of WordPress [stable_branch] downloads', 'wporg' );
+?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:wporg/download-counter {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"}},"typography":{"fontWeight":"200"}},"textColor":"blueberry-2"} /--></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-releases.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-releases.php
@@ -16,7 +16,10 @@
 
 <!-- wp:column {"width":"66.66%"} -->
 <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
-<p><?php _e( 'This is an archive of every release we’ve done that we have a record of.<br>None of these are safe to use, except the <strong>latest</strong> in the [stable_branch] series, which is actively maintained.', 'wporg' ); ?></p>
+<p><?php
+/* translators: [stable_branch] is a shortcode and should not be translated. */
+_e( 'This is an archive of every release we’ve done that we have a record of.<br>None of these are safe to use, except the <strong>latest</strong> in the [stable_branch] series, which is actively maintained.', 'wporg' );
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -16,10 +16,10 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"inherit":true,"type":"constrained"},"anchor":"download-hosting"} -->
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group alignfull" id="download-hosting" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%","style":{"border":{"right":{"color":"var:preset|color|light-grey-1","width":"1px"}}}} -->
-<div class="wp-block-column" style="border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;flex-basis:50%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"80px","right":"var:preset|spacing|60","bottom":"80px","left":"0px"}}},"anchor":"download-install"} -->
+<div class="wp-block-column" style="border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;flex-basis:50%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"80px","right":"var:preset|spacing|60","bottom":"80px","left":"0px"}}}} -->
 <div class="wp-block-group alignwide" id="download-install" style="padding-top:80px;padding-right:var(--wp--preset--spacing--60);padding-bottom:80px;padding-left:0px"><!-- wp:heading {"fontSize":"heading-4"} -->
 <h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Download and install it yourself', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
@@ -30,7 +30,10 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button" id="wporg__download-button"><a class="wp-block-button__link wp-element-button" href="[download_link]"><?php _e( 'Download WordPress [latest_version]', 'wporg' ); ?></a></div>
+<div class="wp-block-button" id="wporg__download-button"><a class="wp-block-button__link wp-element-button" href="[download_link]"><?php
+/* translators: [latest_version] is a shortcode and should not be translated. */
+_e( 'Download WordPress [latest_version]', 'wporg' );
+?></a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"textColor":"blue-1","className":"is-style-outline"} -->
@@ -39,7 +42,10 @@
 <!-- /wp:buttons -->
 
 <!-- wp:paragraph {"textColor":"charcoal-4","className":"is-style-short-text","fontSize":"small"} -->
-<p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size"><?php _e( 'Recommend PHP [recommended_php] or greater and MySQL version [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.', 'wporg' ); ?></p>
+<p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size"><?php
+/* translators: [recommended_php], [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */
+_e( 'Recommend PHP [recommended_php] or greater and MySQL version [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.', 'wporg' );
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:navigation {"textColor":"blueberry-1","overlayMenu":"never","className":"is-style-dots","style":{"spacing":{"blockGap":"0px"}},"fontSize":"small"} -->
@@ -55,7 +61,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"var:preset|spacing|60"}}},"anchor":"hosting"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"80px","left":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-group alignwide" id="hosting" style="padding-top:80px;padding-right:0px;padding-bottom:80px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"fontSize":"heading-4"} -->
 <h2 class="wp-block-heading has-heading-4-font-size"><?php _e( 'Set up with a hosting provider', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
@@ -74,13 +80,13 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"color":null,"style":null,"width":null,"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":[],"bottom":[],"left":[]}},"layout":{"type":"default"},"anchor":""} -->
-<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:paragraph {"align":"center","anchor":"external-link"} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"color":null,"style":null,"width":null,"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":[],"bottom":[],"left":[]}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center" id="external-link"><?php _e( 'Still not sure? Explore the WordPress Playground, a live demo environment right from your browser. <a href="https://developer.wordpress.org/playground/">Try WordPress ↗</a>', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"blueberry-4","layout":{"inherit":true,"type":"constrained"},"anchor":"features"} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"blueberry-4","layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-blueberry-4-background-color has-background" id="features" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|70"}}}} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"0"}}}} -->
 <div class="wp-block-column is-vertically-aligned-center" style="padding-right:0;flex-basis:50%"><!-- wp:list {"className":"is-style-features"} -->
@@ -122,7 +128,7 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"160px","right":"var:preset|spacing|edge-space","bottom":"160px","left":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true,"type":"constrained"},"anchor":"resources"} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"160px","right":"var:preset|spacing|edge-space","bottom":"160px","left":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" id="resources" style="padding-top:160px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:160px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"120px"}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:heading {"fontSize":"heading-2"} -->
@@ -156,7 +162,7 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"120px","right":"var:preset|spacing|edge-space","bottom":"120px","left":"var:preset|spacing|edge-space"}}},"anchor":"mobile"} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"120px","right":"var:preset|spacing|edge-space","bottom":"120px","left":"var:preset|spacing|edge-space"}}}} -->
 <div class="wp-block-group alignfull" id="mobile" style="padding-top:120px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:120px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"textAlign":"center","fontSize":"heading-2"} -->
 <h2 class="wp-block-heading has-text-align-center has-heading-2-font-size"><?php _e( 'Inspiration strikes anywhere', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
@@ -167,11 +173,11 @@
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
-<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php _e( 'Download on the Apple App Store', 'wporg' ); ?>" width="150" height="45" /></a></figure>
+<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php _e( 'Download on the Apple App Store', 'wporg' ); ?>" style="width:150px;height:45px" width="150" height="45" /></a></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
-<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php _e( 'Get it on Google Play', 'wporg' ); ?>" width="150" height="45" /></a></figure>
+<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php _e( 'Get it on Google Play', 'wporg' ); ?>" style="width:150px;height:45px" width="150" height="45" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -297,7 +297,7 @@
 <!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"5rem","right":"var:preset|spacing|edge-space","bottom":"5rem","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"inherit":true,"type":"constrained"},"anchor":"get-started"} -->
 <div class="wp-block-group alignfull has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:5rem;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:5rem;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"60px"}}} -->
 <div class="wp-block-group alignwide"><!-- wp:heading {"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
-<h2 class="wp-block-heading alignwide is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><?php _e( '<a href="https://wordpress.org/download/">Get started</a>', 'wporg' ); ?></h2>
+<h2 class="wp-block-heading alignwide is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><?php _e( '<a href="/download/">Get started</a>', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->


### PR DESCRIPTION
Fixes #284 — This updates the content parser to add a translator comment on strings with shortcodes.

https://github.com/WordPress/wporg-main-2022/blob/7a56dec288104f32a0feb3daec0a01105dd56683/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php#L18-L31

### How to test the changes in this Pull Request:

1. Run the phpunit tests
2. Build the patterns with `yarn build:patterns` (should be no change since this was done in https://github.com/WordPress/wporg-main-2022/commit/e962cc3984b7df09a319eaad0106673237261bce, except for the 6-3 page which is still in progress)
