### PR TITLE
Page Meta: Allow Jetpack to grab the featured image if one exists

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -184,16 +184,6 @@ function use_parent_page_title( $block_content, $block, $instance ) {
 }
 
 /**
- * Prevent Jetpack from looking for a non-existent featured image.
- */
-add_filter(
-	'jetpack_images_pre_get_images',
-	function() {
-		return new \WP_Error();
-	}
-);
-
-/**
  * Register the Rosetta header menu.
  */
 add_action(

--- a/source/wp-content/themes/wporg-main-2022/inc/page-meta-descriptions.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/page-meta-descriptions.php
@@ -71,6 +71,21 @@ add_filter( 'jetpack_open_graph_tags', __NAMESPACE__ . '\custom_open_graph_tags'
 add_filter( 'jetpack_enable_open_graph', '__return_true' );
 
 /**
+ * Prevent Jetpack from looking for a non-existent featured image.
+ */
+add_filter(
+	'jetpack_images_pre_get_images',
+	function( $media, $post_id ) {
+		if ( ! $post_id || ! has_post_thumbnail( $post_id ) ) {
+			return new \WP_Error();
+		}
+		return $media;
+	},
+	10,
+	2
+);
+
+/**
  * Renders site's attributes for the WordPress.org frontpages (including Rosetta).
  *
  * @see https://developers.google.com/search/docs/guides/enhance-site


### PR DESCRIPTION
The 6.3 page has a featured image for use when sharing on social media, but the existing `jetpack_images_pre_get_images` filter short-circuits out of using it. This updates the function to check if there is a thumbnail first.

This function was added to restrict queries on pages without featured images (#62). If you apply this, you should not see queries increase on those pages.

To test:

1. Add a featured image to a page
2. View source, the `og:image` should use the featured image