### PR TITLE
Theme Switcher: Default to using the redesigned theme for pages

### DIFF
--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -20,27 +20,12 @@ function should_use_new_theme() {
 		return false;
 	}
 
-	// Request to resolve a template.
-	if ( isset( $_GET['_wp-find-template'] ) ) {
-		return true;
-	}
-
-	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? explode( '?', esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '/' )[0] : '/';
-
-	// Admin page or an API request.
-	if ( is_admin() || wp_is_json_request() || 0 === strpos( $request_uri, '/wp-json/wp' ) ) {
-		return true;
-	}
-
 	// Preview. Can't call is_preview() this early in the process.
 	if ( isset( $_GET['preview'] ) && isset( $_GET['preview_id'] ) ) {
 		return true;
 	}
 
-	// Use the new theme on all search results.
-	if ( str_starts_with( $request_uri, '/search/' ) ) {
-		return true;
-	}
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? explode( '?', esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '/' )[0] : '/';
 
 	// By default, the new theme is enabled, but there are some exceptions.
 	$old_theme_pages = array(

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -55,7 +55,7 @@ function should_use_new_theme() {
 		'/enterprise/media/',
 		'/hosting/',
 	);
-	if ( in_array( $request_uri, $old_theme_pages ) ) {
+	if ( in_array( strtolower( $request_uri ), $old_theme_pages ) ) {
 		return false;
 	}
 

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -42,36 +42,20 @@ function should_use_new_theme() {
 		return true;
 	}
 
-	// Check if the page being requested isn't supported by the new theme, it should fall-back to the old theme if so.
-	$new_theme_pages = array(
-		'/',
-		'/download/',
-		'/download/beta-nightly/',
-		'/download/counter/',
-		'/download/releases/',
-		'/download/releases/6-3/',
-		'/download/source/',
-		'/mobile/',
-		'/enterprise/',
-		'/about/',
-		'/about/requirements/',
-		'/about/features/',
-		'/about/security/',
-		'/about/roadmap/',
-		'/about/history/',
-		'/about/domains/',
-		'/about/license/',
-		'/about/accessibility/',
-		'/about/privacy/',
-		'/about/stats/',
-		'/about/philosophy/',
-		'/about/etiquette/',
-		'/about/swag/',
-		'/about/logos/',
-		'/blocks/',
-		'/remembers/',
+	// By default, the new theme is enabled, but there are some exceptions.
+	$old_theme_pages = array(
+		'/40-percent-of-web/',
+		'/about/privacy/cookies/',
+		'/about/privacy/data-erasure-request/',
+		'/about/privacy/data-export-request/',
+		'/enterprise/content-marketing/',
+		'/enterprise/ecommerce/',
+		'/enterprise/education/',
+		'/enterprise/integrations/',
+		'/enterprise/media/',
+		'/hosting/',
 	);
-	if ( ! in_array( $request_uri, $new_theme_pages ) ) {
+	if ( in_array( $request_uri, $old_theme_pages ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
This will reverse the logic for loading the redesign theme, so that pages are opted-out of the new theme, rather than opted in. It also makes the page check case-insensitive. This fixes some edge cases where technically-valid page URLs are used, but the theme switcher fails to load the correct template.

For example, the following URLs should now load the correct theme & content. 

- Capitalized slugs: `wordpress.org/About` (or Blocks, as the original issue found, but there's a workaround for that page in place now)
- Slugs with dots: `wordpress.org/download/releases/6.3/` (IIRC this was reported in slack but not followed up on)
- Arbitrary dashes: `wordpress.org/download/beta----nightly/`
- More dots: `wordpress.org/download/beta....nightly/`

Ideally these URLs should redirect to the real canonical URL, but since they are functional links, the theme should at least not be broken. There are core tickets for [the arbitrary dashes](https://core.trac.wordpress.org/ticket/14773) and [dots in permalinks](https://core.trac.wordpress.org/ticket/35437) (which also applies to the 6.3 issue despite seeming related to the post title).

See https://github.com/WordPress/wporg-main-2022/issues/245#issuecomment-1675270164, https://meta.trac.wordpress.org/ticket/7204

### How to test the changes in this Pull Request:

1. Check out the branch, test locally or sync to sandbox (`mu-plugins/main-network/theme-switcher.php`)
2. Try visiting any of the example URLs
3. The page should load the new theme and show the correct content
4. Try other valid pages, they should continue to work
5. Visit `/hosting/` or another "old theme" page
6. It should still use the old theme & content

