### PR TITLE
Use chevron icon for local nav mobile menus

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-details.php
@@ -10,5 +10,5 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"menuSlug":"about-details","textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- wp:navigation {"menuSlug":"about-details","textColor":"blueberry-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-people.php
@@ -10,5 +10,5 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"menuSlug":"about-people","textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- wp:navigation {"menuSlug":"about-people","textColor":"blueberry-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-about-technology.php
@@ -10,5 +10,5 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"menuSlug":"about-technology","textColor":"blueberry-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- wp:navigation {"menuSlug":"about-technology","textColor":"blueberry-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-download.php
@@ -10,5 +10,5 @@
 <!-- wp:wporg/local-navigation-bar {"className":"is-style-brush-stroke","style":{"position":{"type":"sticky"}},"fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"menuSlug":"download","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- wp:navigation {"menuSlug":"download","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-counter.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-counter.html
@@ -3,7 +3,7 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}},"border":{"top":{"color":"var:preset|color|charcoal-1","style":"solid","width":"1px"},"right":{},"bottom":{"color":"var:preset|color|charcoal-1","style":"solid","width":"1px"},"left":{}}},"textColor":"white","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"menuSlug":"download","textColor":"blueberry-2","backgroundColor":"charcoal-2","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- wp:navigation {"menuSlug":"download","textColor":"blueberry-2","backgroundColor":"charcoal-2","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->


### PR DESCRIPTION
Closes #334 
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/480

Changes the local navigation blocks to use the 'menu' (3 bar) icon on mobile, so that in conjunction with https://github.com/WordPress/wporg-mu-plugins/pull/480 the button changes from the word 'Menu' to a chevron icon.

### Screenshots

| Page:State | Before | After |
|--------|-------|-|
| About:Closed | ![localhost_8888_about_domains_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-main-2022/assets/1017872/e5f2dc9b-73b0-496c-a196-c369b16fa560) | ![localhost_8888_about_domains_(Samsung Galaxy S20 Ultra) (2)](https://github.com/WordPress/wporg-main-2022/assets/1017872/2f9512c8-8dbb-4264-9ace-7655541507c3) |
| About:Open | ![localhost_8888_about_domains_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-main-2022/assets/1017872/a9e36d4b-779f-40f4-a508-ac55498f49d0) | ![localhost_8888_about_domains_(Samsung Galaxy S20 Ultra) (3)](https://github.com/WordPress/wporg-main-2022/assets/1017872/da29cf7b-77eb-437f-b221-7a3b27e7ab79) |
| Counter:Closed | ![localhost_8888_download_counter_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-main-2022/assets/1017872/f9c9b0b5-8512-42e1-ae09-c4ba28f2d895) | ![localhost_8888_download_counter_(Samsung Galaxy S20 Ultra) (2)](https://github.com/WordPress/wporg-main-2022/assets/1017872/a34d773b-2689-4f6a-b346-91e71a1dccba) |
| Counter:Open | ![localhost_8888_download_counter_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-main-2022/assets/1017872/8b7c8289-92e9-4617-8019-a3d9e1d1e7b2) | ![localhost_8888_download_counter_(Samsung Galaxy S20 Ultra) (3)](https://github.com/WordPress/wporg-main-2022/assets/1017872/bba9f3e0-4067-49f4-ab3c-acf73c509e0f) |

### How to test the changes in this Pull Request:

1. Unsure your mu-plugins is on https://github.com/WordPress/wporg-mu-plugins/pull/480
2. Open a page from each About sub section, eg. [requirements](http://localhost:8888/about/requirements/), [domains](http://localhost:8888/about/domains/), and [philosophy](http://localhost:8888/about/philosophy/), plus the [download counter](http://localhost:8888/download/counter/)
3. Simulate mobile screen size
4. Check that the icon in the mobile menu button is a chevron
5. Open the menu
6. Check the the chevron icon has been flipper vertically
7. Close the menu