### PR TITLE
Releases Archive: Link releases to microsites

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
@@ -195,6 +195,7 @@ function render_table( $releases ) {
 	return $table;
 }
 
+
 /**
  * Render a release row.
  *
@@ -203,8 +204,20 @@ function render_table( $releases ) {
  * @return string Returns the row markup.
  */
 function render_table_row( $version ) {
+	// Link the version number column to the microsite if it exists.
+	// Microsite URL is expected to be https://wordpress.org/download/releases/{version}/
+	$releases_with_microsites = array( '6.3', '6.4' );
+	$version_number = $version['version'];
+	$maybe_link_to_microsite = in_array( $version_number, $releases_with_microsites )
+		? sprintf(
+			'<a href="/download/releases/%1$s">%2$s</a>',
+			esc_attr( $version_number ),
+			esc_html( $version_number ),
+		)
+		: esc_html( $version_number );
+
 	$row = '<tr>';
-	$row .= '<th class="wp-block-wporg-release-tables__cell-version" scope="row">' . esc_html( $version['version'] ) . '</th>';
+	$row .= '<th class="wp-block-wporg-release-tables__cell-version" scope="row">' . $maybe_link_to_microsite . '</th>';
 	$row .= '<td class="wp-block-wporg-release-tables__cell-date">' . esc_html( date_i18n( get_option( 'date_format' ), $version['builton'] ) ) . '</td>';
 	$row .= sprintf( '<td class="wp-block-wporg-release-tables__cell-zip"><a href="%1$s">zip</a><br /><small>(<a href="%1$s.md5">md5</a> &#183; <a href="%1$s.sha1">sha1</a>)</small></td>', esc_url( $version['zip_url'] ) );
 

--- a/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/release-tables/index.php
@@ -209,6 +209,10 @@ function find_microsite_url_for_version( $version ) {
 	}
 
 	global $post;
+	if ( ! $post ) {
+		return null;
+	}
+
 	$child_pages = get_pages( array( 'child_of' => $post->ID ) );
 	$version_hyphenated = str_replace( '.', '-', $version );
 


### PR DESCRIPTION
See #344 

Adds a link to the version number column to the relevant release microsite if it exists.

![Screenshot 2023-11-08 at 2 21 09 PM](https://github.com/WordPress/wporg-main-2022/assets/1017872/240c83f8-148d-4148-94ea-02de26f1f27b)

Release microsites only exist for 6.3 and 6.4 so far. We'll need to update this array each time a new one is built for a release.

### How to test the changes in this Pull Request:

1. Ensure you have this page locally and navigate to it http://localhost:8888/download/releases/
2. The 6.3 and 6.4 releases should have links on the version number, taking you to the relevant local microsite
3. Other release numbers should not be linked

NOTE: you may need to add local release data in a file at `source/wp-content/mu-plugins/1-sandbox.php`:

```
<?php
namespace WordPressdotorg\Releases;

/**
 * Mock the a release.
 */
function generate_release_array( $version, $timestamp = 0 ) {
	return [
		'version'   => $version,
		'builton'   => $timestamp,
		'zip_url'   => "https://wordpress.org/wordpress-{$version}.zip",
		'targz_url' => "https://wordpress.org/wordpress-{$version}.tar.gz",
		'iis_url'   => "https://wordpress.org/wordpress-{$version}-IIS.zip",
	];
}

/**
 * Mock the release breakdown.
 */
function get_breakdown() {
	return array(
		'betas' => [
			generate_release_array( '6.1-beta3', 1664913600 ),
			generate_release_array( '6.1-beta2', 1664308800 ),
			generate_release_array( '6.1-beta1', 1663790400 ),
			generate_release_array( '6.0.2-RC1', 1661284800 ),
			generate_release_array( '6.0.1-RC1', 1657051200 ),
			generate_release_array( '6.0-RC4', 1653076800 ),
		],
		'branches' => [
			'6.4' => [
				generate_release_array( '6.4', 1661889600 ),
			],
			'6.3' => [
				generate_release_array( '6.3.2', 1664308800 ),
				generate_release_array( '6.3.1', 1663790400 ),
				generate_release_array( '6.3', 1661889600 ),
			],
			'6.0' => [
				generate_release_array( '6.0.2', 1661889600 ),
				generate_release_array( '6.0.1', 1657656000 ),
				generate_release_array( '6.0', 1653422400 ),
			],
			'5.9' => [
				generate_release_array( '5.9.4', 1661889600 ),
				generate_release_array( '5.9.3', 1649188800 ),
				generate_release_array( '5.9.2', 1647032400 ),
				generate_release_array( '5.9.1', 1645563600 ),
				generate_release_array( '5.9', 1643144400 ),
			],
			'5.8' => [
				generate_release_array( '5.8.5', 1661889600 ),
				generate_release_array( '5.8.4', 1647032400 ),
				generate_release_array( '5.8.3', 1641502800 ),
				generate_release_array( '5.8.2', 1636578000 ),
				generate_release_array( '5.8.1', 1631217600 ),
				generate_release_array( '5.8', 1626811200 ),
			],
			'5.7' => [
				generate_release_array( '5.7.7', 1661889600 ),
				generate_release_array( '5.7.6', 1647032400 ),
				generate_release_array( '5.7.5', 1641502800 ),
				generate_release_array( '5.7.4', 1636578000 ),
				generate_release_array( '5.7.3', 1631217600 ),
				generate_release_array( '5.7.2', 1620849600 ),
				generate_release_array( '5.7.1', 1618516800 ),
				generate_release_array( '5.7', 1615323600 ),
			],
		],
		'latest' => generate_release_array( '6.4', 1661889600 ),
		'mu' => [
			[
				'version'   => 'mu-3.1',
				'builton'   => 1299877200,
				'zip_url'   => 'https://wordpress.org/wordpress-mu-3.1.zip',
				'targz_url' => false,
				'iis_url'   => false,
			],
		],
	);
}
```