### PR TITLE
Add Anton font

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/theme.json
+++ b/source/wp-content/themes/wporg-main-2022/theme.json
@@ -8,6 +8,11 @@
 					"fontFamily": "'Courier Prime', serif",
 					"slug": "courier-prime",
 					"name": "Courier Prime"
+				},
+				{
+					"fontFamily": "'Anton', serif",
+					"slug": "anton",
+					"name": "Anton"
 				}
 			]
 		}


### PR DESCRIPTION
Anton font is required for the SoTW page.
See https://github.com/WordPress/wporg-mu-plugins/pull/502 for more details and screenshots.