### PR TITLE
Add Newsreader font

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/theme.json
+++ b/source/wp-content/themes/wporg-main-2022/theme.json
@@ -13,6 +13,11 @@
 					"fontFamily": "'Anton', serif",
 					"slug": "anton",
 					"name": "Anton"
+				},
+				{
+					"fontFamily": "'Newsreader', serif",
+					"slug": "newsreader",
+					"name": "Newsreader"
 				}
 			]
 		}


### PR DESCRIPTION
Newsreader font is required for the SoTW page.
See https://github.com/WordPress/wporg-mu-plugins/pull/503 for more details and screenshots.