### PR TITLE
Add trailing slash to `remembers-list` profile URLs

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/remembers-list/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/remembers-list/index.php
@@ -61,7 +61,7 @@ function render( $attributes, $content, $block ) {
 			$block_content .= '<!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"var:preset|spacing|default","bottom":"var:preset|spacing|40","left":"var:preset|spacing|default"}}},"fontSize":"extra-large"} -->';
 			$block_content .= '<h2 class="wp-block-heading has-text-align-center has-extra-large-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-right:var(--wp--preset--spacing--default);margin-bottom:var(--wp--preset--spacing--40);margin-left:var(--wp--preset--spacing--default)">';
 			$block_content .= '<em>';
-			$block_content .= '<a href="' . esc_url( 'https://profiles.wordpress.org/' . $profile->user_nicename ) . '">' . esc_html( $profile->display_name ) . '</a>';
+			$block_content .= '<a href="' . esc_url( sprintf( 'https://profiles.wordpress.org/%s/', $profile->user_nicename ) ) . '">' . esc_html( $profile->display_name ) . '</a>';
 			$block_content .= '</em>';
 			$block_content .= '</h2>';
 			$block_content .= '<!-- /wp:heading -->';


### PR DESCRIPTION
The profile page links emitted by the `remembers-list` block don't have a trailing slash, yielding e.g. `https://profiles.wordpress.org/viper007bond`.

In order to mitigate a redirect when accessing the profile, this PR adds a trailing slash, e.g. `https://profiles.wordpress.org/viper007bond/`. The URL is composed with `sprintf` for readability to see where the profile name substitution occurs.

### How to test the changes in this Pull Request:

1. Load the `/remembers/` page.
2. Observe the profile link HREFs for each name. They should each have a trailing slash after the username.
