### PR TITLE
Add 2023 SotW banner

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -6,6 +6,28 @@
  */
 
 ?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"black","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-black-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"},"blockGap":{"left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:image {"id":24157,"sizeSlug":"full","linkDestination":"media","className":"is-resized"} -->
+<figure class="wp-block-image size-full is-resized"><a href="https://wordpress.org/files/2023/12/sotw-dotorg-drawer.png"><img src="https://wordpress.org/files/2023/12/sotw-dotorg-drawer.png" alt="" class="wp-image-24157" /></a></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"style":{"spacing":{"blockGap":"16px","padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><!-- wp:paragraph {"style":{"typography":{"lineHeight":1.6}},"textColor":"white","fontSize":"small"} -->
+<p class="has-white-color has-text-color has-small-font-size" style="line-height:1.6"><?php _e( 'Watch State of the Word, the annual keynote address delivered by the WordPress project&#039;s co-founder, Matt Mullenweg, on Dec. 11, live from Madrid at 15:00 UTC.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"textColor":"white","fontSize":"small"} -->
+<p class="has-white-color has-text-color has-link-color has-small-font-size"><?php _e( '<strong>Get the details↗</strong>', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" id="intro" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"120px","right":"0px","bottom":"120px","left":"0px"},"blockGap":"30px"}},"layout":{"inherit":false}} -->
 <div class="wp-block-group alignwide" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px"><!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -21,7 +21,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"textColor":"white","fontSize":"small"} -->
-<p class="has-white-color has-text-color has-link-color has-small-font-size"><?php _e( '<strong>Get the details↗</strong>', 'wporg' ); ?></p>
+<p class="has-white-color has-text-color has-link-color has-small-font-size"><?php _e( '<strong><a href="https://wordpress.org/state-of-the-word/" data-type="page" data-id="23184">Get the details↗</a></strong>', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>


### PR DESCRIPTION
Adds the SotW banner to the top of the homepage.

### Screenshots

| Monitor | Desktop | Tablet | Mobile |
|-|-|-|-|
| ![localhost_8888_(Monitor) (1)](https://github.com/WordPress/wporg-main-2022/assets/1017872/4bb23632-dc9f-424b-9b26-5cbead9b300c) | ![localhost_8888_(Desktop) (12)](https://github.com/WordPress/wporg-main-2022/assets/1017872/b3077176-e88c-4e04-a8e5-7048ace0b227) | ![localhost_8888_(iPad) (2)](https://github.com/WordPress/wporg-main-2022/assets/1017872/fbeb5515-84a6-409e-b350-e20df0e68fa1) | ![localhost_8888_(iPhone 12 Pro)](https://github.com/WordPress/wporg-main-2022/assets/1017872/ef3eb5d2-07e4-4fda-ae7b-03c843462bf0) |
