### PR TITLE
Fix URL in the comments of the import script

### DIFF
--- a/env/import-content.php
+++ b/env/import-content.php
@@ -5,7 +5,7 @@
 namespace WordPress_org\Main_2022\ImportTestContent;
 
 /**
- * CLI script for generating local test content, fetched from the live learn.wordpress.org site.
+ * CLI script for generating local test content, fetched from the live wordpress.org site.
  *
  * This needs to be run in a wp-env, for example:
  *


### PR DESCRIPTION
While trying to build a local environment, I found a typo in the comments of the import script.

My understanding is that this repository does not import content from `learn.wordpress.org`.

### How to test the changes in this Pull Request:

There is no need to test as it is just a comment correction.