### PR TITLE
Data Liberation: Add a data liberation handbook setup

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -15,7 +15,9 @@
 	"plugins": [
 		"./source/wp-content/plugins/gutenberg",
 		"./source/wp-content/plugins/jetpack",
-		"./source/wp-content/plugins/wordpress-importer"
+		"./source/wp-content/plugins/wordpress-importer",
+		"./source/wp-content/plugins/handbook",
+		"./source/wp-content/plugins/wporg-markdown"
 	],
 	"themes": [
 		"./source/wp-content/themes/wporg",

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,26 @@
 						"url": "https://meta.svn.wordpress.org/sites/",
 						"reference": "trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/"
 					}
+				},
+				{
+					"name": "wordpress-meta/handbook",
+					"type": "wordpress-plugin",
+					"version": "1",
+					"source": {
+						"type": "svn",
+						"url": "https://meta.svn.wordpress.org/sites/",
+						"reference": "trunk/wordpress.org/public_html/wp-content/plugins/handbook/"
+					}
+				},
+				{
+					"name": "wordpress-meta/wporg-markdown",
+					"type": "wordpress-plugin",
+					"version": "1",
+					"source": {
+						"type": "svn",
+						"url": "https://meta.svn.wordpress.org/sites/",
+						"reference": "trunk/wordpress.org/public_html/wp-content/plugins/wporg-markdown/"
+					}
 				}
 			]
 		}
@@ -93,6 +113,8 @@
 		"wordpress-meta/pub": "1",
 		"wordpress-meta/wporg": "1",
 		"wordpress-meta/wporg-main": "1",
+		"wordpress-meta/handbook": "1",
+		"wordpress-meta/wporg-markdown": "1",
 		"wp-coding-standards/wpcs": "2.*",
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"wpackagist-plugin/gutenberg": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7094cbd956d0c4edb539768c7a0dd30c",
+    "content-hash": "c2831d49fe0e2b8ab967c2d74caabedc",
     "packages": [],
     "packages-dev": [
         {
@@ -292,16 +292,16 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
                 "shasum": ""
             },
             "require": {
@@ -333,9 +333,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
             },
-            "time": "2023-06-03T09:27:29+00:00"
+            "time": "2023-09-27T20:04:15+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -920,29 +920,29 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.17.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "15873c65b207b07765dbc3c95d20fdf4a320cbe2"
+                "reference": "d4f454f7e1193933f04e6500de3e79191648ed0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/15873c65b207b07765dbc3c95d20fdf4a320cbe2",
-                "reference": "15873c65b207b07765dbc3c95d20fdf4a320cbe2",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d4f454f7e1193933f04e6500de3e79191648ed0c",
+                "reference": "d4f454f7e1193933f04e6500de3e79191648ed0c",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.*",
+                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
+                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpstan/phpstan": "^1.9",
-                "phpunit/phpunit": "^8.0 || ^9.0"
+                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
             },
             "type": "library",
             "extra": {
@@ -975,6 +975,7 @@
             "keywords": [
                 "Double",
                 "Dummy",
+                "dev",
                 "fake",
                 "mock",
                 "spy",
@@ -982,22 +983,22 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.17.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.18.0"
             },
-            "time": "2023-02-02T15:41:36+00:00"
+            "time": "2023-12-07T16:22:33+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.23.1",
+            "version": "1.24.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26"
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/846ae76eef31c6d7790fac9bc399ecee45160b26",
-                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
                 "shasum": ""
             },
             "require": {
@@ -1029,9 +1030,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
             },
-            "time": "2023-08-03T16:32:59+00:00"
+            "time": "2023-12-16T09:33:33+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2078,16 +2079,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
                 "shasum": ""
             },
             "require": {
@@ -2097,7 +2098,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -2116,35 +2117,58 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T12:32:31+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -2173,7 +2197,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -2181,7 +2205,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2242,6 +2266,16 @@
             "time": "2022-06-03T18:03:27+00:00"
         },
         {
+            "name": "wordpress-meta/handbook",
+            "version": "1",
+            "source": {
+                "type": "svn",
+                "url": "https://meta.svn.wordpress.org/sites/",
+                "reference": "trunk/wordpress.org/public_html/wp-content/plugins/handbook/"
+            },
+            "type": "wordpress-plugin"
+        },
+        {
             "name": "wordpress-meta/pub",
             "version": "1",
             "source": {
@@ -2270,6 +2304,16 @@
                 "reference": "trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-main/"
             },
             "type": "wordpress-theme"
+        },
+        {
+            "name": "wordpress-meta/wporg-markdown",
+            "version": "1",
+            "source": {
+                "type": "svn",
+                "url": "https://meta.svn.wordpress.org/sites/",
+                "reference": "trunk/wordpress.org/public_html/wp-content/plugins/wporg-markdown/"
+            },
+            "type": "wordpress-plugin"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2324,7 +2368,7 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.9.7",
+            "version": "5.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
@@ -2372,15 +2416,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "17.1.4",
+            "version": "17.2.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/17.1.4"
+                "reference": "tags/17.2.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.17.1.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.17.2.3.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -2390,15 +2434,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "12.5",
+            "version": "12.9.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/12.5"
+                "reference": "tags/12.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.12.5.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.12.9.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -2430,12 +2474,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "a91aebfe2184f3f032943c541cc65a31f5c3fe88"
+                "reference": "85c367998e9f87ae5cd3cb67dc95383a6da2b4ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/a91aebfe2184f3f032943c541cc65a31f5c3fe88",
-                "reference": "a91aebfe2184f3f032943c541cc65a31f5c3fe88",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/85c367998e9f87ae5cd3cb67dc95383a6da2b4ef",
+                "reference": "85c367998e9f87ae5cd3cb67dc95383a6da2b4ef",
                 "shasum": ""
             },
             "require": {
@@ -2476,7 +2520,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2023-12-04T09:06:05+00:00"
+            "time": "2023-12-14T15:56:26+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",
@@ -2484,12 +2528,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "35ea8e29062c18bd59be80559eeb2410a3211d8e"
+                "reference": "515dd66f2763f55305002cfa1d1bd08709450c4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/35ea8e29062c18bd59be80559eeb2410a3211d8e",
-                "reference": "35ea8e29062c18bd59be80559eeb2410a3211d8e",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/515dd66f2763f55305002cfa1d1bd08709450c4f",
+                "reference": "515dd66f2763f55305002cfa1d1bd08709450c4f",
                 "shasum": ""
             },
             "type": "wordpress-theme",
@@ -2497,7 +2541,7 @@
                 "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
                 "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
             },
-            "time": "2023-11-28T23:22:29+00:00"
+            "time": "2023-12-18T02:18:03+00:00"
         },
         {
             "name": "wporg/wporg-repo-tools",
@@ -2604,5 +2648,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -7,6 +7,7 @@ use function WordPressdotorg\MU_Plugins\Global_Header_Footer\is_rosetta_site;
 require_once __DIR__ . '/inc/page-meta-descriptions.php';
 require_once __DIR__ . '/inc/hreflang.php';
 require_once __DIR__ . '/inc/capabilities.php';
+require_once __DIR__ . '/inc/data-liberation-handbook.php';
 
 // Block files
 require_once __DIR__ . '/src/download-counter/index.php';

--- a/source/wp-content/themes/wporg-main-2022/inc/data-liberation-handbook.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/data-liberation-handbook.php
@@ -15,7 +15,7 @@ function add_data_liberation_handbook( $handbooks ) {
 	$handbooks['and'] = [
 		'label'    => 'Data Liberation Guides',
 		'manifest' => 'https://raw.githubusercontent.com/WordPress/data-liberation/add/manifest/assets/manifest.json', // TODO: See https://github.com/WordPress/data-liberation/pull/46
-		'slug'     => 'and',
+		'slug'     => 'data-liberation/and',
 	];
 
 	return $handbooks;

--- a/source/wp-content/themes/wporg-main-2022/inc/data-liberation-handbook.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/data-liberation-handbook.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WordPressdotorg\Theme\Main_2022;
+
+defined( 'WPINC' ) || die();
+
+add_filter( 'handbooks_config', __NAMESPACE__ . '\add_data_liberation_handbook' );
+
+/**
+ * Configures the Data liberation "handbook" (guides).
+ *
+ * Requires the site to be running the Handbook & WPORG Markdown plugins.
+ */
+function add_data_liberation_handbook( $handbooks ) {
+	$handbooks['and'] = [
+		'label'    => 'Data Liberation Guides',
+		'manifest' => 'https://raw.githubusercontent.com/WordPress/data-liberation/add/manifest/assets/manifest.json', // TODO: See https://github.com/WordPress/data-liberation/pull/46
+		'slug'     => 'and',
+	];
+
+	return $handbooks;
+} );

--- a/source/wp-content/themes/wporg-main-2022/inc/data-liberation-handbook.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/data-liberation-handbook.php
@@ -19,4 +19,4 @@ function add_data_liberation_handbook( $handbooks ) {
 	];
 
 	return $handbooks;
-} );
+}


### PR DESCRIPTION
This PR adds the necessary things to the theme to support the import of the data liberation guides as a handbook.

See https://github.com/WordPress/data-liberation/pull/46 for the manifest it uses.