### PR TITLE
Theme: Add a stylesheet to be used for rosetta site overrides

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -99,6 +99,15 @@ function enqueue_assets() {
 			global_fonts_preload( 'EB Garamond italic', $subsets );
 		}
 	}
+
+	if ( is_rosetta_site() ) {
+		wp_enqueue_style(
+			'wporg-main-2022-rosetta-style',
+			get_stylesheet_directory_uri() . '/build/rosetta/style-index.css',
+			array( 'wporg-main-2022-style' ),
+			filemtime( __DIR__ . '/build/rosetta/style-index.css' )
+		);
+	}
 }
 
 /**

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -87,6 +87,10 @@ function enqueue_assets() {
 	if ( is_callable( 'global_fonts_preload' ) ) {
 		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext. */
 		$subsets = _x( 'latin', 'Heading font subsets, comma separated', 'wporg' );
+		if ( ! in_array( $subsets, [ 'cyrillic', 'cyrillic-ext', 'greek', 'greek-ext', 'vietnamese', 'latin', 'latin-ext' ] ) ) {
+			$subsets = 'latin';
+		}
+
 		// All headings.
 		global_fonts_preload( 'EB Garamond', $subsets );
 

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/block.json
@@ -1,0 +1,3 @@
+{
+	"script": "file:./index.js"
+}

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/index.js
@@ -1,0 +1,2 @@
+// Noop, just imports the CSS for webpack.
+import './style.scss';

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
@@ -1,0 +1,22 @@
+@import "../style/fluid";
+
+$wporg-about-breakpoint-min: 600px;
+$wporg-about-breakpoint-max: 1920px;
+
+[lang="de-DE"],
+[lang="ja"] {
+	.wporg-about-cover-title > span,
+	.wporg-about-section-heading {
+		font-size: #{fluid(40px, 96px, $wporg-about-breakpoint-min, $wporg-about-breakpoint-max)} !important;
+	}
+}
+
+[lang="sq"] {
+	.wporg-about-cover-title > span {
+		font-size: #{fluid(40px, 96px, $wporg-about-breakpoint-min, $wporg-about-breakpoint-max)} !important;
+	}
+
+	.wporg-about-section-heading {
+		font-size: #{fluid(40px,80px, $wporg-about-breakpoint-min, $wporg-about-breakpoint-max)} !important;
+	}
+}

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
@@ -3,7 +3,13 @@
 $wporg-about-breakpoint-min: 600px;
 $wporg-about-breakpoint-max: 1920px;
 
-[lang="de-DE"],
+[lang="de-DE"] {
+	.wporg-about-cover-title > span,
+	.wporg-about-section-heading {
+		font-size: #{fluid(40px, 92px, $wporg-about-breakpoint-min, $wporg-about-breakpoint-max)} !important;
+	}
+}
+
 [lang="ja"] {
 	.wporg-about-cover-title > span,
 	.wporg-about-section-heading {

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
@@ -17,6 +17,6 @@ $wporg-about-breakpoint-max: 1920px;
 	}
 
 	.wporg-about-section-heading {
-		font-size: #{fluid(40px,80px, $wporg-about-breakpoint-min, $wporg-about-breakpoint-max)} !important;
+		font-size: #{fluid(40px, 80px, $wporg-about-breakpoint-min, $wporg-about-breakpoint-max)} !important;
 	}
 }

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
@@ -1,5 +1,8 @@
 @import "../style/fluid";
 
+// This file contains page & section-specific overrides for Rosetta sites.
+// When adding a new locale, try to keep the lang selectors in alphabetical order.
+
 $wporg-about-breakpoint-min: 600px;
 $wporg-about-breakpoint-max: 1920px;
 


### PR DESCRIPTION
This adds a place for polyglots teams to add page & section-specific overrides for their sites. Anything more global should go in the parent theme, see the related PR: https://github.com/WordPress/wporg-parent-2021/pull/120.

Specifically in this PR, I've added some code to shrink the headings on the About page, as they're defined in the CSS, not theme.json settings.

See #266, https://github.com/WordPress/wporg-parent-2021/pull/120.

### Screenshots

| Locale | Before | After |
|-------|--------|-------|
| Albanian | ![about-sq-before](https://github.com/WordPress/wporg-parent-2021/assets/541093/b7f1ed9e-879a-4611-b322-17abbf2cc168) | ![about-sq-after](https://github.com/WordPress/wporg-parent-2021/assets/541093/6c765571-f88e-4fba-b7f1-9327021960e5) |
| Japanese | ![about-ja-before](https://github.com/WordPress/wporg-parent-2021/assets/541093/03328bfd-d690-4236-ae00-de4da01ebf6a) | ![about-ja-after](https://github.com/WordPress/wporg-parent-2021/assets/541093/ef58f043-b013-48fd-9b69-fd6a20ec7a0f) |

### How to test the changes in this Pull Request:

You can test localized sites by [following the instructions on wporg-main-2022](https://github.com/WordPress/wporg-main-2022#working-on-non-english-sites).

- Follow those instructions, then set your site's language to German, Japanese, or Albanian.
- View the About page. The titles should be smaller so they are not cut off.

I also tested this on my sandbox with the [top completed languages](https://translate.wordpress.org/projects/meta/wordpress-org/) for wporg.
