### PR TITLE
SEO: Change separator to pipe.

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/src/remembers-list/index.php';
  */
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'init', __NAMESPACE__ . '\register_shortcodes' );
+add_filter( 'document_title_separator', __NAMESPACE__ . '\document_title_separator' );
 add_filter( 'wp_img_tag_add_loading_attr', __NAMESPACE__ . '\override_lazy_loading', 10, 2 );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\update_site_breadcrumbs' );
 add_filter( 'render_block_core/site-title', __NAMESPACE__ . '\use_parent_page_title', 10, 3 );
@@ -322,4 +323,14 @@ function update_header_template_part_class( $block ) {
 		}
 	}
 	return $block;
+}
+
+/**
+ * Change document title separator
+ *
+ * @param string $title
+ * @return string
+ */
+function document_title_separator( $title ) {
+	return '&#124;';
 }

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -328,9 +328,10 @@ function update_header_template_part_class( $block ) {
 /**
  * Change document title separator
  *
- * @param string $title
+ * @param string $sep
+ *
  * @return string
  */
-function document_title_separator( $title ) {
+function document_title_separator( $sep ) {
 	return '&#124;';
 }


### PR DESCRIPTION
Most of our subsites use a "|" as a separator. This PR updates the main theme to use the "|" separator as well. 

This has come up as a result of working on https://github.com/WordPress/wporg-main-2022/pull/375.

**Example**
| URL | Title |
|--------|--------|
| [/patterns](https://wordpress.org/patterns/) | Block Pattern Directory \| WordPress.org |
| [/showcase](https://wordpress.org/showcase/) | Star-studded sites built with WordPress \| WordPress.org |
| [/plugins](https://wordpress.org/plguins/) | WordPress Plugins \| WordPress.org | 

Currently, the main theme doesn't enforce that pattern and we get the default "-" separator.

