### PR TITLE
Streamline content updates, by automating PRs for content updates

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Run the content update
         run: |
+          sed -i -e "s/image: 'mariadb'/image: 'mariadb:lts'/g" node_modules/@wordpress/env/lib/build-docker-compose-config.js
           yarn wp-env start
           yarn build:patterns
           git status

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  content-update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -34,8 +34,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: source/wp-content/themes/wporg-main-2022/**/*.php
-          title: 'Content updates from Site Editor'
-          commit-message: '[automated] Sync content from Site Editor.'
+          title: 'Content updates from Page Editor'
+          commit-message: '[automated] Sync content from Page Editor.'
           body: |
-            The content has changed in the Site Editor.
+            The content has changed in the Page Editor.
             Please review, merge, and deploy.

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -25,7 +25,6 @@ jobs:
 
       - name: Run the content update
         run: |
-          sed -i -e "s/image: 'mariadb'/image: 'mariadb:lts'/g" node_modules/@wordpress/env/lib/build-docker-compose-config.js
           chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
           yarn wp-env start
           yarn build:patterns

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -1,0 +1,35 @@
+name: Update existing content
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [trunk]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: trunk
+
+      - name: Setup
+        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run the content update
+        run: |
+          yarn wp-env start
+          yarn build:patterns
+          git status
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths	: source/wp-content/themes/wporg-main-2022/**/*.php

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -29,9 +29,13 @@ jobs:
           chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
           yarn wp-env start
           yarn build:patterns
-          git status
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: source/wp-content/themes/wporg-main-2022/**/*.php
+          title: 'Content updates from Site Editor'
+          commit-message: '[automated] Sync content from Site Editor.'
+          body: |
+            The content has changed in the Site Editor.
+            Please review, merge, and deploy.

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Run the content update
         run: |
           sed -i -e "s/image: 'mariadb'/image: 'mariadb:lts'/g" node_modules/@wordpress/env/lib/build-docker-compose-config.js
+          chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
           yarn wp-env start
           yarn build:patterns
           git status
@@ -33,4 +34,4 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          add-paths	: source/wp-content/themes/wporg-main-2022/**/*.php
+          add-paths: source/wp-content/themes/wporg-main-2022/**/*.php

--- a/env/export-content/includes/parser.php
+++ b/env/export-content/includes/parser.php
@@ -21,7 +21,7 @@ class BlockParser {
 		$this->fallback = new Parsers\BasicText();
 		$this->parsers  = [
 			// Blocks that have custom parsers.
-			'core/paragraph'   => new Parsers\HTMLParser( 'p' ),
+			'core/paragraph'   => new Parsers\HTMLParser( 'p', [], 2 /* minimum length of 2 characters. */ ),
 			'core/image'       => new Parsers\HTMLParser( 'figcaption', [ 'alt', 'title' ] ),
 			'core/heading'     => new Parsers\HTMLRegexParser( '/h[1-6]/' ),
 

--- a/env/export-content/includes/parser.php
+++ b/env/export-content/includes/parser.php
@@ -43,8 +43,9 @@ class BlockParser {
 			'core/list'        => new Parsers\Noop(),
 			'core/quote'       => new Parsers\Noop(),
 
-			// Don't translate code content.
-			'core/code' => new Parsers\Noop(),
+			// Don't translate content.
+			'core/code'  => new Parsers\Noop(),
+			'core/embed' => new Parsers\Noop(),
 
 			// Common core blocks that use the default parser.
 			'core/media-text'  => new Parsers\BasicText(),

--- a/env/export-content/includes/parsers/HTMLParser.php
+++ b/env/export-content/includes/parsers/HTMLParser.php
@@ -7,10 +7,12 @@ class HTMLParser implements BlockParser {
 
 	public $tags = [];
 	public $attributes = [];
+	public $min_string_length = 0;
 
-	public function __construct( $tags = array(), $attributes = array() ) {
-		$this->tags       = (array) $tags;
-		$this->attributes = (array) $attributes;
+	public function __construct( $tags = array(), $attributes = array(), $min_string_length = 0 ) {
+		$this->tags              = (array) $tags;
+		$this->attributes        = (array) $attributes;
+		$this->min_string_length = (int) $min_string_length;
 	}
 
 	public function to_strings( array $block ) : array {
@@ -53,6 +55,19 @@ class HTMLParser implements BlockParser {
 			}
 
 			$strings = array_merge( $strings, $found_strings );
+		}
+
+		if ( $this->min_string_length ) {
+			$strings = array_filter(
+				$strings,
+				function( $string ) {
+					if ( function_exists( 'mb_strlen' ) ) {
+						return mb_strlen( $string ) >= $this->min_string_length;
+					}
+
+					return strlen( $string ) >= $this->min_string_length;
+				}
+			);
 		}
 
 		return $strings;


### PR DESCRIPTION
Currently the process for updating an existing page is to..
 - Update the page in the Page Editor
 - Checkout this repo
 - Run build & pattern build
 - Commit changes, PR, Merge
 - Sync & Deploy wordpress.org

This PR reduces the process and removes the requirement for the merger to have a local working environment.

With this change the flow is:
 - Update the page in the Page Editor
 - Run the Workflow (We can automate this, to happen after a page edit, or on a cron schedule)
 - Review & Merge the PR
 - Sync & Deploy wordpress.org

There's a very slight change in the process there, but notably it doesn't require a local environment for basic text-only updates.

This could be improved by..
 - Including screenshot of modified pages
 - Verifying no fatal errors are present in the modified files

For an example of the generated PR, see https://github.com/dd32/wporg-main-2022/pull/1

As this flow is becoming more used, this could be made as a generic action imported from https://github.com/wordpress/wporg-repo-tools/ once confirmed working and acceptable.

**Edit:** Just noting that this includes a fix for the upstream mariadb+wp-env issue; this can be removed before merge, we'll need to separately update the wp-env package or wait for the upstream mariadb docker image to update, before this will work without it.