### PR TITLE
When creating translated patterns/templates, use esc_attr_e() for attributes

### DIFF
--- a/env/export-content/includes/parsers/HTMLParser.php
+++ b/env/export-content/includes/parsers/HTMLParser.php
@@ -69,9 +69,17 @@ class HTMLParser implements BlockParser {
 				continue;
 			}
 
-			// TODO: Potentially this should be more specific for tags/attribute replacements as needed.
-			$regex = '#([>"\'])\s*' . preg_quote( $original, '#' ) . '\s*([\'"<])#s';
-			$html  = preg_replace( $regex, '$1' . addcslashes( $replacements[ $original ], '\\$' ) . '$2', $html );
+			// Replace content in HTML attributes with appropriate escaping.
+			$replacement = $replacements[ $original ];
+			$replacement = str_replace( ' _e(', ' esc_attr_e(', $replacement );
+			$regex       = '#(["\'])\s*' . preg_quote( $original, '#' ) . '\s*\\1#s';
+			$html        = preg_replace( $regex, '$1' . addcslashes( $replacement, '\\$' ) . '$1', $html );
+
+			// Replace content in HTML tags.
+			$replacement = $replacements[ $original ];
+			$regex       = '#(>)\s*' . preg_quote( $original, '#' ) . '\s*(<)#s';
+			$html        = preg_replace( $regex, '$1' . addcslashes( $replacement, '\\$' ) . '$2', $html );
+
 		}
 
 		$block['innerHTML']    = $html;

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-privacy.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-privacy.php
@@ -302,6 +302,6 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"linkDestination":"custom"} -->
-<figure class="wp-block-image"><a href="https://creativecommons.org/licenses/by-sa/4.0/"><img src="https://s.w.org/images/home/ccbysa40.png" alt="<?php _e( 'Creative Commons License', 'wporg' ); ?>" /></a></figure>
+<figure class="wp-block-image"><a href="https://creativecommons.org/licenses/by-sa/4.0/"><img src="https://s.w.org/images/home/ccbysa40.png" alt="<?php esc_attr_e( 'Creative Commons License', 'wporg' ); ?>" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/blocks.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/blocks.php
@@ -22,7 +22,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:image {"align":"wide","id":20995,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image alignwide size-full"><img src="https://wordpress.org/files/2023/08/blocks-header-image.png" alt="<?php _e( 'WordPress editor view showing the outline of three blocks with an inserter icon.', 'wporg' ); ?>" class="wp-image-20995" /></figure>
+<figure class="wp-block-image alignwide size-full"><img src="https://wordpress.org/files/2023/08/blocks-header-image.png" alt="<?php esc_attr_e( 'WordPress editor view showing the outline of three blocks with an inserter icon.', 'wporg' ); ?>" class="wp-image-20995" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
@@ -51,11 +51,11 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline-on-dark"} -->
-<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://developer.wordpress.org/block-editor/getting-started/create-block/', 'wporg' ); ?>"><?php _e( 'Create blocks', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://developer.wordpress.org/block-editor/getting-started/create-block/', 'wporg' ); ?>"><?php _e( 'Create blocks', 'wporg' ); ?></a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"className":"is-style-outline-on-dark"} -->
-<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php _e( '/patterns', 'wporg' ); ?>"><?php _e( 'Browse block patterns', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( '/patterns', 'wporg' ); ?>"><?php _e( 'Browse block patterns', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>
@@ -173,7 +173,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline-on-dark"} -->
-<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://wordpress.org/showcase/', 'wporg' ); ?>"><?php _e( 'Explore the Showcase', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/showcase/', 'wporg' ); ?>"><?php _e( 'Explore the Showcase', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>
@@ -208,7 +208,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
-<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="<?php _e( '/gutenberg', 'wporg' ); ?>"><?php _e( 'Try blocks live', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( '/gutenberg', 'wporg' ); ?>"><?php _e( 'Try blocks live', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>
@@ -253,7 +253,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline-on-dark"} -->
-<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://developer.wordpress.org/block-editor/getting-started/create-block/', 'wporg' ); ?>"><?php _e( 'Create a block', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://developer.wordpress.org/block-editor/getting-started/create-block/', 'wporg' ); ?>"><?php _e( 'Create a block', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/data-liberation.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/data-liberation.php
@@ -128,7 +128,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"layout":{"selfStretch":"fill","flexSize":null}}} -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"has-custom-width is-style-outline-on-dark"} -->
-<div class="wp-block-button has-custom-width is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://github.com/WordPress/move-to-wp/tree/trunk#how-to-contribute', 'wporg' ); ?>"><?php _e( 'Get Started', 'wporg' ); ?></a></div>
+<div class="wp-block-button has-custom-width is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://github.com/WordPress/move-to-wp/tree/trunk#how-to-contribute', 'wporg' ); ?>"><?php _e( 'Get Started', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-beta-nightly.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-beta-nightly.php
@@ -45,7 +45,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://wordpress.org/nightly-builds/wordpress-latest.zip', 'wporg' ); ?>"><?php _e( 'Download the latest nightly release', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/nightly-builds/wordpress-latest.zip', 'wporg' ); ?>"><?php _e( 'Download the latest nightly release', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-releases-6-3.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-releases-6-3.php
@@ -22,7 +22,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://www.youtube.com/watch?v=6JhJcOLySLY', 'wporg' ); ?>" target="_blank" rel="noreferrer noopener"><?php _e( 'Watch the demo', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://www.youtube.com/watch?v=6JhJcOLySLY', 'wporg' ); ?>" target="_blank" rel="noreferrer noopener"><?php _e( 'Watch the demo', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->
@@ -401,7 +401,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":20581,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/08/image-5.png" alt="<?php _e( 'Screenshot of the block editor, with the text, &quot;Hello, WordPress&quot;, and the new Top Toolbar option enabled.', 'wporg' ); ?>" class="wp-image-20581" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/08/image-5.png" alt="<?php esc_attr_e( 'Screenshot of the block editor, with the text, &quot;Hello, WordPress&quot;, and the new Top Toolbar option enabled.', 'wporg' ); ?>" class="wp-image-20581" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -439,7 +439,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":20626,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="https://wordpress.org/files/2023/08/image-12.png"><img src="https://wordpress.org/files/2023/08/image-12-1024x576.png" alt="<?php _e( 'Abstract image showing square boxes denoting aspect ratios, 16;9, 4:3, and 1:1.', 'wporg' ); ?>" class="wp-image-20626" /></a></figure>
+<figure class="wp-block-image size-large"><a href="https://wordpress.org/files/2023/08/image-12.png"><img src="https://wordpress.org/files/2023/08/image-12-1024x576.png" alt="<?php esc_attr_e( 'Abstract image showing square boxes denoting aspect ratios, 16;9, 4:3, and 1:1.', 'wporg' ); ?>" class="wp-image-20626" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -449,7 +449,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":157,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://sixthree.mystagingwebsite.com/wp-content/uploads/2023/07/image-8.png" alt="<?php _e( 'Screenshot showing abstracted menu management with a drag and drop action underway.', 'wporg' ); ?>" class="wp-image-157" /></figure>
+<figure class="wp-block-image size-full"><img src="https://sixthree.mystagingwebsite.com/wp-content/uploads/2023/07/image-8.png" alt="<?php esc_attr_e( 'Screenshot showing abstracted menu management with a drag and drop action underway.', 'wporg' ); ?>" class="wp-image-157" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -461,7 +461,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":20252,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/07/Frame-327.png" alt="<?php _e( 'Cropped screenshot of the block editor, showing a revision history for visual styles.', 'wporg' ); ?>" class="wp-image-20252" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/07/Frame-327.png" alt="<?php esc_attr_e( 'Cropped screenshot of the block editor, showing a revision history for visual styles.', 'wporg' ); ?>" class="wp-image-20252" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -471,7 +471,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":20622,"width":"135px","height":"37px","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/08/image-11.png" alt="<?php _e( 'Screenshot of a &quot;Start typing...&quot; prompt.', 'wporg' ); ?>" class="wp-image-20622" style="width:135px;height:37px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/08/image-11.png" alt="<?php esc_attr_e( 'Screenshot of a &quot;Start typing...&quot; prompt.', 'wporg' ); ?>" class="wp-image-20622" style="width:135px;height:37px" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -483,7 +483,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":20292,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/08/image.png" alt="<?php _e( 'A screenshot of a footnotes block showing the text: 1. WordPress started in 2003 when Mike Little and Matt Mullenweg created a fork of b2/cafelog. The need for an elegant, well-architected personal publishing system was clear even then. Today, WordPress is built on PHP and MySQL, and licensed under the GPLv2. It is also the platform of choice for over 43% of all sites across the web.', 'wporg' ); ?>" class="wp-image-20292" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/08/image.png" alt="<?php esc_attr_e( 'A screenshot of a footnotes block showing the text: 1. WordPress started in 2003 when Mike Little and Matt Mullenweg created a fork of b2/cafelog. The need for an elegant, well-architected personal publishing system was clear even then. Today, WordPress is built on PHP and MySQL, and licensed under the GPLv2. It is also the platform of choice for over 43% of all sites across the web.', 'wporg' ); ?>" class="wp-image-20292" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -493,7 +493,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":20629,"sizeSlug":"full","linkDestination":"media"} -->
-<figure class="wp-block-image size-full"><a href="https://wordpress.org/files/2023/08/image-13.png"><img src="https://wordpress.org/files/2023/08/image-13.png" alt="<?php _e( 'Cropped screenshot of a a block theme, Twenty Twenty-Three, dark text on white background.', 'wporg' ); ?>" class="wp-image-20629" /></a></figure>
+<figure class="wp-block-image size-full"><a href="https://wordpress.org/files/2023/08/image-13.png"><img src="https://wordpress.org/files/2023/08/image-13.png" alt="<?php esc_attr_e( 'Cropped screenshot of a a block theme, Twenty Twenty-Three, dark text on white background.', 'wporg' ); ?>" class="wp-image-20629" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-releases-6-4.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-releases-6-4.php
@@ -22,7 +22,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://wordpress.org/download/', 'wporg' ); ?>"><?php _e( 'Download WordPress 6.4', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/download/', 'wporg' ); ?>"><?php _e( 'Download WordPress 6.4', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>
@@ -33,7 +33,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:image {"align":"full","id":23156,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image alignfull size-full"><img src="https://wordpress.org/files/2023/11/tt4-hero-1-scaled.jpg" alt="<?php _e( 'Cropped screenshots of the Twenty Twenty-Four theme, with the featured one showing an RSVP full-page pattern.', 'wporg' ); ?>" class="wp-image-23156" /></figure>
+<figure class="wp-block-image alignfull size-full"><img src="https://wordpress.org/files/2023/11/tt4-hero-1-scaled.jpg" alt="<?php esc_attr_e( 'Cropped screenshots of the Twenty Twenty-Four theme, with the featured one showing an RSVP full-page pattern.', 'wporg' ); ?>" class="wp-image-23156" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -53,7 +53,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://wordpress.org/themes/twentytwentyfour/', 'wporg' ); ?>"><?php _e( 'Download theme', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/themes/twentytwentyfour/', 'wporg' ); ?>"><?php _e( 'Download theme', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->
@@ -77,7 +77,7 @@
 <!-- wp:column {"verticalAlignment":"bottom","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:50%"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://2024.wordpress.net/index.php/blogger-demo/', 'wporg' ); ?>"><?php _e( 'View demo', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://2024.wordpress.net/index.php/blogger-demo/', 'wporg' ); ?>"><?php _e( 'View demo', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>
@@ -107,7 +107,7 @@
 <!-- wp:column {"verticalAlignment":"bottom","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:50%"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'http://2024.wordpress.net/index.php/photographer-demo/', 'wporg' ); ?>"><?php _e( 'View demo', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'http://2024.wordpress.net/index.php/photographer-demo/', 'wporg' ); ?>"><?php _e( 'View demo', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>
@@ -188,7 +188,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://2024.wordpress.net/index.php/patterns/', 'wporg' ); ?>"><?php _e( 'Explore patterns', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://2024.wordpress.net/index.php/patterns/', 'wporg' ); ?>"><?php _e( 'Explore patterns', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -249,7 +249,7 @@
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"id":23067,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/commandpalette-1.png" alt="<?php _e( 'Screenshot of the refreshed UI of the Command Palette with a decorative background image. It displays a search bar with the words &quot;Search for commands&quot; and a variety of shortcuts listed below, including &quot;Add new page,&quot; &quot;Toggle code editor,&quot; &quot;Editor preferences,&quot; and more.', 'wporg' ); ?>" class="wp-image-23067" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/commandpalette-1.png" alt="<?php esc_attr_e( 'Screenshot of the refreshed UI of the Command Palette with a decorative background image. It displays a search bar with the words &quot;Search for commands&quot; and a variety of shortcuts listed below, including &quot;Add new page,&quot; &quot;Toggle code editor,&quot; &quot;Editor preferences,&quot; and more.', 'wporg' ); ?>" class="wp-image-23067" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
@@ -296,21 +296,21 @@
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"lightbox":{"enabled":true},"id":23209,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/abstract-geometric-art.webp" alt="<?php _e( 'architectural texture on a modern building', 'wporg' ); ?>" class="wp-image-23209" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/abstract-geometric-art.webp" alt="<?php esc_attr_e( 'architectural texture on a modern building', 'wporg' ); ?>" class="wp-image-23209" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"lightbox":{"enabled":true},"id":23211,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2023/11/museum-768x1024.webp" alt="<?php _e( 'modern interior ramp', 'wporg' ); ?>" class="wp-image-23211" /></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2023/11/museum-768x1024.webp" alt="<?php esc_attr_e( 'modern interior ramp', 'wporg' ); ?>" class="wp-image-23211" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"lightbox":{"enabled":true},"id":23210,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/tt4_portfolio_1-scaled-1.jpg" alt="<?php _e( 'interior design showing a table and chairs', 'wporg' ); ?>" class="wp-image-23210" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/tt4_portfolio_1-scaled-1.jpg" alt="<?php esc_attr_e( 'interior design showing a table and chairs', 'wporg' ); ?>" class="wp-image-23210" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"lightbox":{"enabled":true},"id":23212,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2023/11/tt4_portfolio_8-1022x1024.jpg" alt="<?php _e( 'bike in the sun', 'wporg' ); ?>" class="wp-image-23212" /></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/files/2023/11/tt4_portfolio_8-1022x1024.jpg" alt="<?php esc_attr_e( 'bike in the sun', 'wporg' ); ?>" class="wp-image-23212" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -343,7 +343,7 @@
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"id":23016,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/block-hooks.png" alt="<?php _e( 'Cropped screenshot showing a navigation menu with a shopping cart button inserted by Block Hooks.', 'wporg' ); ?>" class="wp-image-23016" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/block-hooks.png" alt="<?php esc_attr_e( 'Cropped screenshot showing a navigation menu with a shopping cart button inserted by Block Hooks.', 'wporg' ); ?>" class="wp-image-23016" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
@@ -356,7 +356,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":23143,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/i7-1.png" alt="<?php _e( 'Featured highlights of WordPress 6.4: Twenty Twenty-Four theme, enable lightbox functionality, background images in Group blocks, categorize custom patterns, enhanced Command Palette, Block Hooks, previews in List View, and more.', 'wporg' ); ?>" class="wp-image-23143" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/11/i7-1.png" alt="<?php esc_attr_e( 'Featured highlights of WordPress 6.4: Twenty Twenty-Four theme, enable lightbox functionality, background images in Group blocks, categorize custom patterns, enhanced Command Palette, Block Hooks, previews in List View, and more.', 'wporg' ); ?>" class="wp-image-23143" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|10"} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -37,7 +37,7 @@ _e( 'Download WordPress [latest_version]', 'wporg' );
 <!-- /wp:button -->
 
 <!-- wp:button {"textColor":"blue-1","className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-blue-1-color has-text-color wp-element-button" href="<?php _e( 'https://wordpress.org/support/article/how-to-install-wordpress/', 'wporg' ); ?>"><?php _e( 'Installation guide', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-blue-1-color has-text-color wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/support/article/how-to-install-wordpress/', 'wporg' ); ?>"><?php _e( 'Installation guide', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 
@@ -64,7 +64,7 @@ _e( 'Recommend PHP [recommended_php] or greater and MySQL version [recommended_m
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://wordpress.org/hosting/', 'wporg' ); ?>"><?php _e( 'See all recommended hosts', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/hosting/', 'wporg' ); ?>"><?php _e( 'See all recommended hosts', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>
@@ -165,11 +165,11 @@ _e( 'Recommend PHP [recommended_php] or greater and MySQL version [recommended_m
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":"150px","height":"45px","linkDestination":"custom"} -->
-<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php _e( 'Download on the Apple App Store', 'wporg' ); ?>" style="width:150px;height:45px" /></a></figure>
+<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php esc_attr_e( 'Download on the Apple App Store', 'wporg' ); ?>" style="width:150px;height:45px" /></a></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":"150px","height":"45px","linkDestination":"custom"} -->
-<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php _e( 'Get it on Google Play', 'wporg' ); ?>" style="width:150px;height:45px" /></a></figure>
+<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php esc_attr_e( 'Get it on Google Play', 'wporg' ); ?>" style="width:150px;height:45px" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/enterprise.php
@@ -30,43 +30,43 @@
 <div class="wp-block-group alignfull wporg-enterprise-header has-charcoal-2-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"},"blockGap":"var:preset|spacing|50"}},"className":"is-style-default","layout":{"type":"constrained","contentSize":"1020px"}} -->
 <div class="wp-block-group alignfull is-style-default" style="padding-top:60px;padding-bottom:60px"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"0","bottom":"0","right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"className":"wporg-enterprise-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group alignwide wporg-enterprise-logos" style="padding-top:0;padding-right:var(--wp--preset--spacing--50);padding-bottom:0;padding-left:var(--wp--preset--spacing--50)"><!-- wp:image {"id":15777,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"76px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Sun.webp" alt="<?php _e( 'Sun logo', 'wporg' ); ?>" class="wp-image-15777" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Sun.webp" alt="<?php esc_attr_e( 'Sun logo', 'wporg' ); ?>" class="wp-image-15777" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15768,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"81px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/People.webp" alt="<?php _e( 'People logo', 'wporg' ); ?>" class="wp-image-15768" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/People.webp" alt="<?php esc_attr_e( 'People logo', 'wporg' ); ?>" class="wp-image-15768" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15780,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"196px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/RD.webp" alt="<?php _e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" class="wp-image-15780" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/RD.webp" alt="<?php esc_attr_e( 'Reader&#039;s Digest logo', 'wporg' ); ?>" class="wp-image-15780" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15783,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"88px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/WWD.webp" alt="<?php _e( 'WWD logo', 'wporg' ); ?>" class="wp-image-15783" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/WWD.webp" alt="<?php esc_attr_e( 'WWD logo', 'wporg' ); ?>" class="wp-image-15783" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15786,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"104px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Variety.webp" alt="<?php _e( 'Variety logo', 'wporg' ); ?>" class="wp-image-15786" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Variety.webp" alt="<?php esc_attr_e( 'Variety logo', 'wporg' ); ?>" class="wp-image-15786" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":24471,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"69px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/12/time-magazine.webp" alt="<?php _e( 'Time Magazine logo', 'wporg' ); ?>" class="wp-image-24471" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/12/time-magazine.webp" alt="<?php esc_attr_e( 'Time Magazine logo', 'wporg' ); ?>" class="wp-image-24471" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15792,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"69px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/TED.webp" alt="<?php _e( 'TED logo', 'wporg' ); ?>" class="wp-image-15792" style="object-fit:cover" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/TED.webp" alt="<?php esc_attr_e( 'TED logo', 'wporg' ); ?>" class="wp-image-15792" style="object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15794,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"129px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/facebook.webp" alt="<?php _e( 'Facebook logo', 'wporg' ); ?>" class="wp-image-15794" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/facebook.webp" alt="<?php esc_attr_e( 'Facebook logo', 'wporg' ); ?>" class="wp-image-15794" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15796,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"141px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Microsoft.webp" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-15796" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Microsoft.webp" alt="<?php esc_attr_e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-15796" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":15799,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"72px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/CNN.webp" alt="<?php _e( 'CNN logo', 'wporg' ); ?>" class="wp-image-15799" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/CNN.webp" alt="<?php esc_attr_e( 'CNN logo', 'wporg' ); ?>" class="wp-image-15799" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
@@ -133,7 +133,7 @@
 <div class="wp-block-columns alignwide wporg-enterprise-features" style="border-style:none;border-width:0px;border-radius:0px;padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"width":"0px","style":"none"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
 <div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"id":15893,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"56px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Extensibility.png" alt="<?php _e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-15893" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Extensibility.png" alt="<?php esc_attr_e( 'Extensibility icon', 'wporg' ); ?>" class="wp-image-15893" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -149,7 +149,7 @@
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}},"border":{"top":{"width":"0px","style":"none"},"right":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}}} -->
 <div class="wp-block-column" style="border-top-style:none;border-top-width:0px;border-right-color:var(--wp--preset--color--light-grey-1);border-right-width:1px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"id":15899,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"48px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Security.png" alt="<?php _e( 'Security icon', 'wporg' ); ?>" class="wp-image-15899" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Security.png" alt="<?php esc_attr_e( 'Security icon', 'wporg' ); ?>" class="wp-image-15899" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -165,7 +165,7 @@
 <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"id":15901,"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"63px"}}} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Open_Source.png" alt="<?php _e( 'Open Source icon', 'wporg' ); ?>" class="wp-image-15901" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2023/01/Open_Source.png" alt="<?php esc_attr_e( 'Open Source icon', 'wporg' ); ?>" class="wp-image-15901" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -305,5 +305,5 @@
 <!-- /wp:group -->
 
 <!-- wp:image {"align":"full","id":22532,"sizeSlug":"full","linkDestination":"custom"} -->
-<figure class="wp-block-image alignfull size-full"><a href="https://soewp.com/"><img src="https://wordpress.org/files/2023/10/270319241-c2f85fca-c6a3-4eb4-9e02-5b02ba8212c0.png" alt="<?php _e( 'View the 2023 State of Enterprise WordPress survey results', 'wporg' ); ?>" class="wp-image-22532" /></a></figure>
+<figure class="wp-block-image alignfull size-full"><a href="https://soewp.com/"><img src="https://wordpress.org/files/2023/10/270319241-c2f85fca-c6a3-4eb4-9e02-5b02ba8212c0.png" alt="<?php esc_attr_e( 'View the 2023 State of Enterprise WordPress survey results', 'wporg' ); ?>" class="wp-image-22532" /></a></figure>
 <!-- /wp:image -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -46,7 +46,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( '/download/', 'wporg' ); ?>"><?php _e( 'Get WordPress', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( '/download/', 'wporg' ); ?>"><?php _e( 'Get WordPress', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>
@@ -80,7 +80,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:image {"id":11481,"sizeSlug":"full","linkDestination":"custom"} -->
-<figure class="wp-block-image size-full"><a href="https://wordpress.org/themes/"><img src="https://wordpress.org/files/2022/08/theme-styles.png" alt="<?php _e( 'An illustration showing a grid of different type styles and color options, with a cursor arrow making a selection.', 'wporg' ); ?>" class="wp-image-11481" /></a></figure>
+<figure class="wp-block-image size-full"><a href="https://wordpress.org/themes/"><img src="https://wordpress.org/files/2022/08/theme-styles.png" alt="<?php esc_attr_e( 'An illustration showing a grid of different type styles and color options, with a cursor arrow making a selection.', 'wporg' ); ?>" class="wp-image-11481" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -154,33 +154,33 @@
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"className":"wporg-home-showcase-logos","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide wporg-home-showcase-logos" style="margin-top:50px;margin-bottom:50px"><!-- wp:image {"id":24441,"width":"173px","height":"33px","scale":"contain","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/12/rolling-stone.png" alt="<?php _e( 'Rolling Stone logo', 'wporg' ); ?>" class="wp-image-24441" style="object-fit:contain;width:173px;height:33px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/12/rolling-stone.png" alt="<?php esc_attr_e( 'Rolling Stone logo', 'wporg' ); ?>" class="wp-image-24441" style="object-fit:contain;width:173px;height:33px" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":11475,"width":"79px","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Time-Magazine.png" alt="<?php _e( 'Time Magazine logo', 'wporg' ); ?>" class="wp-image-11475" style="width:79px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2022/08/Time-Magazine.png" alt="<?php esc_attr_e( 'Time Magazine logo', 'wporg' ); ?>" class="wp-image-11475" style="width:79px" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":22635,"width":"96px","height":"96px","scale":"contain","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/NASA-1.png" alt="<?php _e( 'NASA logo', 'wporg' ); ?>" class="wp-image-22635" style="object-fit:contain;width:96px;height:96px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/NASA-1.png" alt="<?php esc_attr_e( 'NASA logo', 'wporg' ); ?>" class="wp-image-22635" style="object-fit:contain;width:96px;height:96px" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":22636,"width":"150px","height":"33px","scale":"contain","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/Microsoft.png" alt="<?php _e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-22636" style="object-fit:contain;width:150px;height:33px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/Microsoft.png" alt="<?php esc_attr_e( 'Microsoft logo', 'wporg' ); ?>" class="wp-image-22636" style="object-fit:contain;width:150px;height:33px" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":22637,"width":"64px","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/tech-crunch.png" alt="<?php _e( 'TechCrunch logo', 'wporg' ); ?>" class="wp-image-22637" style="width:64px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/tech-crunch.png" alt="<?php esc_attr_e( 'TechCrunch logo', 'wporg' ); ?>" class="wp-image-22637" style="width:64px" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":22638,"width":"160px","sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/Harvard.png" alt="<?php _e( 'Harvard logo', 'wporg' ); ?>" class="wp-image-22638" style="width:160px" /></figure>
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2023/10/Harvard.png" alt="<?php esc_attr_e( 'Harvard logo', 'wporg' ); ?>" class="wp-image-22638" style="width:160px" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
 <!-- wp:buttons {"align":"wide"} -->
 <div class="wp-block-buttons alignwide"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://wordpress.org/showcase/', 'wporg' ); ?>"><?php _e( 'Explore the Showcase', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://wordpress.org/showcase/', 'wporg' ); ?>"><?php _e( 'Explore the Showcase', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 
@@ -241,7 +241,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"100px","right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}}},"backgroundColor":"light-grey-2","textColor":"blueberry-1","layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-blueberry-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" id="community" style="padding-right:0;padding-bottom:100px;padding-left:0"><!-- wp:cover {"url":"https://wordpress.org/files/2022/10/community-photo-2-q50-unscaled.webp","id":12467,"dimRatio":0,"focalPoint":{"x":0.5,"y":1},"minHeight":500,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"color":[],"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"bottom":"60px"}}}} -->
+<div class="wp-block-group alignfull has-blueberry-1-color has-light-grey-2-background-color has-text-color has-background has-link-color" id="community" style="padding-right:0;padding-bottom:100px;padding-left:0"><!-- wp:cover {"url":"https://wordpress.org/files/2022/10/community-photo-2-q50-unscaled.webp","id":12467,"alt":"A black and white bird’s eye view of the thousands of contributors who attended WordCamp Europe 2022. They are all standing in front of the venue with their hands up in celebration.","dimRatio":0,"focalPoint":{"x":0.5,"y":1},"minHeight":500,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"color":[],"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"bottom":"60px"}}}} -->
 <div class="wp-block-cover alignfull is-light" style="margin-bottom:60px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;min-height:500px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-12467" alt="<?php _e( 'A black and white bird’s eye view of the thousands of contributors who attended WordCamp Europe 2022. They are all standing in front of the venue with their hands up in celebration.', 'wporg' ); ?>" src="https://wordpress.org/files/2022/10/community-photo-2-q50-unscaled.webp" style="object-position:50% 100%" data-object-fit="cover" data-object-position="50% 100%" /><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
@@ -268,7 +268,7 @@
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="<?php _e( 'https://make.wordpress.org/', 'wporg' ); ?>"><?php _e( 'Get involved', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="<?php esc_attr_e( 'https://make.wordpress.org/', 'wporg' ); ?>"><?php _e( 'Get involved', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/mobile.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/mobile.php
@@ -18,11 +18,11 @@
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
-<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php _e( 'Download on the Apple App Store', 'wporg' ); ?>" width="150" height="45" /></a></figure>
+<figure class="wp-block-image is-resized"><a href="https://itunes.apple.com/app/apple-store/id335703880?pt=299112&amp;ct=wordpress.org&amp;mt=8"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-apple.png" alt="<?php esc_attr_e( 'Download on the Apple App Store', 'wporg' ); ?>" width="150" height="45" /></a></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":150,"height":45,"linkDestination":"custom"} -->
-<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php _e( 'Get it on Google Play', 'wporg' ); ?>" width="150" height="45" /></a></figure>
+<figure class="wp-block-image is-resized"><a href="http://play.google.com/store/apps/details?id=org.wordpress.android"><img src="https://wordpress.org/wp-content/themes/pub/wporg-main/images/badge-google-play.png" alt="<?php esc_attr_e( 'Get it on Google Play', 'wporg' ); ?>" width="150" height="45" /></a></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Replaces a TODO in the code with replacing attributes with an escaped variant.

This isn't the cleanest way to achieve the result, but it is the smallest possible code change.

It might look like `href` should have `esc_url( __( .. ) )` but that complicates it with minimal benefit.

Draft as I don't have time to follow up on it completely right now. 
Feel free to take over.

### How to test the changes in this Pull Request:

1. `yarn build:patterns`
2. Test.

<!-- If you can, add the appropriate [Component] label(s). -->
