### PR TITLE
Don't translate relative links

### DIFF
--- a/env/export-content/includes/parsers/HTMLParser.php
+++ b/env/export-content/includes/parsers/HTMLParser.php
@@ -42,12 +42,31 @@ class HTMLParser implements BlockParser {
 				$found_strings = $matches['string'];
 			}
 
-			// Don't translate anchor links, they correspond to other points on the page.
+			// Don't translate certain types of links, they correspond to other points on the page.
 			if ( 'href' === $attr ) {
 				$found_strings = array_filter(
 					$found_strings,
 					function( $value ) {
-						return ! str_starts_with( $value, '#' );
+						// Anchors.
+						if ( str_starts_with( $value, '#' ) ) {
+							return false;
+						}
+
+						// root relative URLs, which are not protocol-relative.
+						if ( str_starts_with( $value, '/' ) && ! str_starts_with( $value, '//' ) ) {
+							return false;
+						}
+
+						// relative to current page urls.
+						if (
+							! str_starts_with( $value, 'https://' ) &&
+							! str_starts_with( $value, 'http://' ) &&
+							! str_starts_with( $value, '//' )
+						) {
+							return false;
+						}
+
+						return true;
 					}
 				);
 			}

--- a/source/wp-content/themes/wporg-main-2022/patterns/blocks.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/blocks.php
@@ -55,7 +55,7 @@
 <!-- /wp:button -->
 
 <!-- wp:button {"className":"is-style-outline-on-dark"} -->
-<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php _e( '/patterns', 'wporg' ); ?>"><?php _e( 'Browse block patterns', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="/patterns"><?php _e( 'Browse block patterns', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>
@@ -208,7 +208,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
-<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="<?php _e( '/gutenberg', 'wporg' ); ?>"><?php _e( 'Try blocks live', 'wporg' ); ?></a></div>
+<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="/gutenberg"><?php _e( 'Try blocks live', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -46,7 +46,7 @@
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php _e( '/download/', 'wporg' ); ?>"><?php _e( 'Get WordPress', 'wporg' ); ?></a></div>
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/download/"><?php _e( 'Get WordPress', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
The parser already excludes anchor links, such as `#main` but includes root-relative and page-relative urls.

These likely don't need to be translated, and probably shouldn't be.
These probably shouldn't usually exist in the source-content, but have benefits, such as being untranslated after this change.

Example changes included.

### How to test the changes in this Pull Request:

1. `yarn build:patterns`
2. Test.

<!-- If you can, add the appropriate [Component] label(s). -->
