### PR TITLE
Requirements page: Bump recommended MySQL version to 8.0

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -47,7 +47,7 @@ add_shortcode(
 add_shortcode(
 	'recommended_mysql',
 	function() {
-		return '5.7';
+		return '8.0';
 	}
 );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See https://core.trac.wordpress.org/ticket/59701#comment:5 where the recommended version in the WordPress readme was updated from 5.7 to 8.0, because version 5.7 reached EOL.

I don't know if this is the right place to make this change for the https://wordpress.org/about/requirements/ page though 🤷 

<!-- List out anyone who helped with this task. -->
Props @SergeyBiryukov 
