### PR TITLE
Admin: Prevent easy access to the Site Editor

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -349,3 +349,23 @@ function update_header_template_part_class( $block ) {
 	}
 	return $block;
 }
+
+/**
+ * Prevent easy access to the Site Editor.
+ *
+ * See https://github.com/WordPress/wporg-main-2022/issues/390.
+ */
+add_action(
+	'admin_menu',
+	function() {
+		remove_submenu_page( 'themes.php', 'site-editor.php' );
+	}
+);
+
+add_action(
+	'admin_bar_menu',
+	function ( $wp_admin_bar ) {
+		$wp_admin_bar->remove_node( 'site-editor' );
+	},
+	499 // Before the wporg-mu-plugins action.
+);


### PR DESCRIPTION
This removes "easy" access by removing the link from the admin bar and admin menu.

Fixes #390.

It's still possible to get to the editor via a few different means, but removing these two links should at least give users pause. These are the other ways, which I think are acceptable:

- The dashboard welcome panel button
- "Customize" button in the theme grid
- Callout button in the customizer
- Directly: `wp-admin/site-editor.php`

### Screenshots

<img width="290" alt="" src="https://github.com/WordPress/wporg-main-2022/assets/541093/e0a5c46e-ada7-44c3-9b6a-bb82bbca7f11">
<img width="359" alt="" src="https://github.com/WordPress/wporg-main-2022/assets/541093/9838e87a-c8d1-4d97-bb72-f43cf241a031">

### How to test the changes in this Pull Request:

When this PR is applied, you should not see the "Site Editor" link in the admin bar or admin menu.
