### PR TITLE
Add Swag page template and pattern

### DIFF
--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -59,6 +59,11 @@
 		"template": "page-stats.html"
 	},
 	{
+		"slug": "swag",
+		"pattern": "about-swag.php",
+		"template": "page-swag.html"
+	},
+	{
 		"slug": "philosophy",
 		"pattern": "about-philosophy.php",
 		"template": "page-philosophy.html"

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-swag.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-swag.php
@@ -7,9 +7,8 @@
 
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"width":"1px","color":"#d9d9d9","radius":"2px"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-border-color" style="border-color:#d9d9d9;border-width:1px;border-radius:2px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-<h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Swag store', 'wporg' ); ?></h1>
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"heading-6","fontFamily":"inter"} -->
+<h1 class="wp-block-heading has-inter-font-family has-heading-6-font-size" style="font-style:normal;font-weight:700"><?php _e( 'Swag store', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -19,5 +18,4 @@
 <!-- wp:paragraph -->
 <p><?php _e( 'Looking for another way to find swag and connect with fellow WordPressers? Check out a&nbsp;<a href="https://events.wordpress.org/">WordPress event</a>&nbsp;near you.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-swag.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-swag.php
@@ -7,11 +7,17 @@
 
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-<h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Swag', 'wporg' ); ?></h1>
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"border":{"width":"1px","color":"#d9d9d9","radius":"2px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-border-color" style="border-color:#d9d9d9;border-width:1px;border-radius:2px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
+<h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Swag store', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'The swag store is currently closed. We don&#039;t have an update on when it will reopen.', 'wporg' ); ?></p>
+<p><?php _e( 'The Mercantile: WordPress Swag Store has closed its doors for now. Thanks for always wearing your love of WordPress for all to see, and for supporting the WordPress Foundation.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Looking for another way to find swag and connect with fellow WordPressers? Check out a&nbsp;<a href="https://events.wordpress.org/">WordPress event</a>&nbsp;near you.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-swag.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-swag.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Title: Swag
+ * Slug: wporg-main-2022/swag
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
+<h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php _e( 'Swag', 'wporg' ); ?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'The swag store is currently closed. We don&#039;t have an update on when it will reopen.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-swag.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-swag.html
@@ -1,0 +1,9 @@
+<!-- wp:wporg/global-header {"textColor":"charcoal-2","backgroundColor":"white","style":{"border":{"bottom":{"color":"var:preset|color|black-opacity-15","style":"solid","width":"1px"}}}} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/swag"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"textColor":"charcoal-2","backgroundColor":"white"} /-->


### PR DESCRIPTION
See [comment](https://github.com/WordPress/wporg-mu-plugins/issues/614#issuecomment-2145655932).

We have a [redirect](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-redirects.php#L47) in place for `/about/swag` to the mercantile store, but now that the store is shut that redirect is being removed and we need a landing page again.

### Screenshots

![localhost_8888_about_swag_(Desktop)](https://github.com/WordPress/wporg-main-2022/assets/1017872/fcf043ae-329b-481b-a567-3f6b4e105006)