### PR TITLE
Filter page titles to enable translations

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,35 @@
+name: Translate Strings
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - update/generate-i18n-strings
+  schedule:
+    - cron: '0 6,18 * * *'
+
+jobs:
+  translation-strings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: i18n
+        uses: WordPress/wporg-repo-tools/.github/actions/i18n@trunk
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --no_taxonomies --post_types=page --url=https://wordpress.org/wp-json/wp/v2/ --textdomain=wporg
+
+      - name: Remove the translation context
+        run: |
+          sed -i "s/, 'page title'//" extra/translation-strings.php
+          sed -i "s/_x(/__(/" extra/translation-strings.php
+
+      - name: Commit and push
+        # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
+        uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: update/generate-i18n-strings
+            message: 'Update translation strings'

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -1,0 +1,52 @@
+<?php
+// phpcs:disable
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the GlotPress translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ */
+
+__( 'Swag', 'wporg' );
+__( 'WordPress 6.5', 'wporg' );
+__( 'Data Liberation', 'wporg' );
+__( 'State of the Word', 'wporg' );
+__( 'WordPress 6.4', 'wporg' );
+__( 'Blocks', 'wporg' );
+__( 'WordPress 6.3', 'wporg' );
+__( 'Remembers', 'wporg' );
+__( 'Graphics &amp; Logos', 'wporg' );
+__( 'Etiquette', 'wporg' );
+__( 'Philosophy', 'wporg' );
+__( 'Stats', 'wporg' );
+__( 'Privacy', 'wporg' );
+__( 'Accessibility', 'wporg' );
+__( 'License', 'wporg' );
+__( 'Domains', 'wporg' );
+__( 'History', 'wporg' );
+__( 'Roadmap', 'wporg' );
+__( 'Security', 'wporg' );
+__( 'Features', 'wporg' );
+__( 'Requirements', 'wporg' );
+__( 'About', 'wporg' );
+__( 'Search', 'wporg' );
+__( 'Mobile', 'wporg' );
+__( 'Hosting', 'wporg' );
+__( 'WordPress and the Journey to 40% of the Web', 'wporg' );
+__( 'Media', 'wporg' );
+__( 'Integrations', 'wporg' );
+__( 'Education', 'wporg' );
+__( 'eCommerce', 'wporg' );
+__( 'Content Marketing', 'wporg' );
+__( 'Enterprise', 'wporg' );
+__( 'Home', 'wporg' );
+__( 'Counter', 'wporg' );
+__( 'Source Code', 'wporg' );
+__( 'Beta/Nightly', 'wporg' );
+__( 'Release Archive', 'wporg' );
+__( 'Download', 'wporg' );
+__( 'Erase Personal Data', 'wporg' );
+__( 'Export Personal Data', 'wporg' );
+__( 'Cookie Policy', 'wporg' );

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -25,6 +25,8 @@ add_filter( 'wp_img_tag_add_loading_attr', __NAMESPACE__ . '\override_lazy_loadi
 add_filter( 'render_block_core/site-title', __NAMESPACE__ . '\use_parent_page_title', 10, 3 );
 add_filter( 'render_block_data', __NAMESPACE__ . '\update_header_template_part_class' );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
+add_filter( 'the_title', __NAMESPACE__ . '\translate_the_title', 1, 2 );
+add_filter( 'single_post_title', __NAMESPACE__ . '\translate_the_title', 1, 2 );
 
 /**
  * Enqueue scripts and styles.
@@ -274,7 +276,7 @@ function use_parent_page_title( $block_content, $block, $instance ) {
 	// Loop up to the first child page, this is the section title.
 	while ( $parent ) {
 		$url = get_permalink( $parent->ID );
-		$title = $parent->post_title;
+		$title = get_the_title( $parent );
 		$parent = get_post_parent( $parent );
 	}
 
@@ -317,6 +319,27 @@ function update_header_template_part_class( $block ) {
 		}
 	}
 	return $block;
+}
+
+/**
+ * Replace the title with the translated page title.
+ *
+ * @param string $title   The current title, ignored.
+ * @param int    $post_id The post_id of the page.
+ *
+ * @return string
+ */
+function translate_the_title( $title, $post_id = null ) {
+	if ( is_admin() ) {
+		return $title;
+	}
+
+	$post = get_post( $post_id );
+	if ( $post && 'page' === $post->post_type ) {
+		$title = translate( $post->post_title, 'wporg' ); // phpcs:ignore
+	}
+
+	return $title;
 }
 
 /**


### PR DESCRIPTION
Fixes #436. This adds the composite i18n action to sync down page titles from the production server, and then filters the page titles to apply the translations.

### Screenshots

| Before | After |
|---|---|
| <img width="263" alt="Screenshot 2024-04-25 at 11 05 16 AM" src="https://github.com/WordPress/wporg-main-2022/assets/541093/2ca3eda5-02f5-4bee-9f45-a9faddf18636"> | <img width="204" alt="Screenshot 2024-06-11 at 7 12 49 PM" src="https://github.com/WordPress/wporg-main-2022/assets/541093/414c0a2d-6b7e-40f9-a3d9-8e3fe6bd4629"> |
| <img width="258" alt="Screenshot 2024-04-25 at 11 05 23 AM" src="https://github.com/WordPress/wporg-main-2022/assets/541093/71c25650-acce-431c-8c83-8e2cbee3e995"> | <img width="277" alt="Screenshot 2024-06-11 at 7 11 39 PM" src="https://github.com/WordPress/wporg-main-2022/assets/541093/31e7c728-1325-4228-b6cc-46667f7cb077"> |
