### PR TITLE
Rosetta styles: Use Noto Serif JP for headings

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -93,12 +93,16 @@ function enqueue_assets() {
 			$subsets = 'latin';
 		}
 
-		// All headings.
-		global_fonts_preload( 'EB Garamond', $subsets );
+		if ( 'ja' === get_locale() ) {
+			global_fonts_preload( 'Noto Serif JP', 'cjk' );
+		} else {
+			// All headings.
+			global_fonts_preload( 'EB Garamond', $subsets );
 
-		if ( is_front_page() ) {
-			// The heading on the front-page has some italic.
-			global_fonts_preload( 'EB Garamond italic', $subsets );
+			if ( is_front_page() ) {
+				// The heading on the front-page has some italic.
+				global_fonts_preload( 'EB Garamond italic', $subsets );
+			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
@@ -27,6 +27,8 @@ $wporg-about-breakpoint-max: 1920px;
 }
 
 [lang="ja"] {
+	--wp--custom--heading--typography--font-family: var(--wp--preset--font-family--noto-serif-jp);
+
 	.wp-block-wporg-random-heading > strong {
 		display: inline-block;
 	}


### PR DESCRIPTION
Noto Serif JP is being added to the available fonts with https://github.com/WordPress/wporg-mu-plugins/pull/630 & https://github.com/WordPress/wporg-parent-2021/pull/144. This PR updates the main site to use Noto Serif JP for headings.

The font preloading is also updated here, so that ja.w.org only preloads Noto Serif, not EB Garamond.

### Screenshots

| Before | After |
|--------|-------|
| ![home-before](https://github.com/WordPress/wporg-main-2022/assets/541093/88ed5411-4a19-4987-9d4f-2766aa7a85a8) | ![home](https://github.com/WordPress/wporg-main-2022/assets/541093/ef7c8d28-8387-48ea-9c3c-1ceddac0d669) |
| ![download-before](https://github.com/WordPress/wporg-main-2022/assets/541093/8c93f46f-94ac-4704-ba62-832685648590) | ![download](https://github.com/WordPress/wporg-main-2022/assets/541093/bdd74a49-cdec-406d-a768-243215d8764b) |
| ![about-page-before](https://github.com/WordPress/wporg-main-2022/assets/541093/f02e0751-17cc-46bd-8f24-f64dfe93990f) | ![about-page](https://github.com/WordPress/wporg-main-2022/assets/541093/8f411325-2827-44bd-a16a-168754b11974) |

### How to test the changes in this Pull Request:

1. Apply all three PRs across wporg-main-2022 (this one), https://github.com/WordPress/wporg-parent-2021/pull/144, and https://github.com/WordPress/wporg-mu-plugins/pull/630 (I know 😩)
2. Follow [the instructions to set up a non-English test instance](https://github.com/WordPress/wporg-main-2022?tab=readme-ov-file#working-on-non-english-sites), use Japanese to test with
3. Once set up, view the frontend of the site
4. All headings should use Noto Serif JP
5. Noto Serif JP should be preloaded in the `head` tags
6. Check on the default (english) site and/or other locales, they should still use EB Garamond

Note that EB Garamond does still load, it's hardcoded in the the global header site title. It might also appear if the font is set at the block level. We could override `--wp--preset--font-family--eb-garamond` with Noto Serif JP if it should be eradicated totally.
