### PR TITLE
Content: Add a pattern that can be used for "pages in progress"

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/_work-in-progress.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_work-in-progress.php
@@ -1,0 +1,28 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Page in progress
+ * Slug: wporg-main-2022/work-in-progress
+ * Inserter: no
+ *
+ * Use this pattern to prevent publicly showing pages that are not ready yet.
+ */
+
+?>
+<!-- wp:group {"metadata":{"name":"Page"},"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull">
+	<!-- wp:cover {"overlayColor":"light-grey-2","isUserOverlayColor":true,"isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
+		<span aria-hidden="true" class="wp-block-cover__background has-light-grey-2-background-color has-background-dim-100 has-background-dim"></span>
+		<div class="wp-block-cover__inner-container">
+			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} -->
+			<h1 class="wp-block-heading has-text-align-center" style="font-style:italic;font-weight:400">Coming soon…</h1>
+			<!-- /wp:heading -->
+			<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+			<p class="has-text-align-center has-large-font-size">WordPress 6.6 is due to be released on the 16th of July.<br>Check back then for all the great new changes!</p>
+			<!-- /wp:paragraph -->
+		</div>
+	</div>
+	<!-- /wp:cover -->
+</div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/_work-in-progress.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_work-in-progress.php
@@ -9,20 +9,34 @@
  */
 
 ?>
-<!-- wp:group {"metadata":{"name":"Page"},"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull">
-	<!-- wp:cover {"overlayColor":"light-grey-2","isUserOverlayColor":true,"isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
-		<span aria-hidden="true" class="wp-block-cover__background has-light-grey-2-background-color has-background-dim-100 has-background-dim"></span>
-		<div class="wp-block-cover__inner-container">
-			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} -->
-			<h1 class="wp-block-heading has-text-align-center" style="font-style:italic;font-weight:400">Coming soon…</h1>
-			<!-- /wp:heading -->
-			<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-			<p class="has-text-align-center has-large-font-size">WordPress 6.6 is due to be released on the 16th of July.<br>Check back then for all the great new changes!</p>
-			<!-- /wp:paragraph -->
-		</div>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"top":{"color":"var:preset|color|black-opacity-15","style":"solid","width":"1px"},"right":{"style":"none","width":"0px"},"bottom":{"style":"none","width":"0px"},"left":{"style":"none","width":"0px"}}},"className":"wporg-page-in-progress","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull wporg-page-in-progress" style="border-top-color:var(--wp--preset--color--black-opacity-15);border-top-style:solid;border-top-width:1px;border-right-style:none;border-right-width:0px;border-bottom-style:none;border-bottom-width:0px;border-left-style:none;border-left-width:0px;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:heading {"level":1,"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} -->
+		<h1 class="wp-block-heading" style="font-style:italic;font-weight:400">You&#8217;re looking for what&#8217;s new in WordPress</h1>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph -->
+		<p>Go right to the source:</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:list -->
+		<ul class="wp-block-list">
+			<!-- wp:list-item -->
+			<li><a href="https://events.wordpress.org/upcoming-events/">Upcoming WordPress events</a></li>
+			<!-- /wp:list-item -->
+
+			<!-- wp:list-item -->
+			<li><a href="https://wordpress.org/news/">WordPress News</a></li>
+			<!-- /wp:list-item -->
+
+			<!-- wp:list-item -->
+			<li><a href="https://developer.wordpress.org/news/">Developer Blog</a></li>
+			<!-- /wp:list-item -->
+		</ul>
+		<!-- /wp:list -->
 	</div>
-	<!-- /wp:cover -->
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -636,6 +636,17 @@ $wporg-about-breakpoint-max: 1920px;
 	}
 }
 
+/**
+ * Page in progress styles
+ */
+
+.wporg-page-in-progress {
+	// Override the workaround below.
+	.is-content-justification-left > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
+		margin-left: 0 !important;
+	}
+}
+
 /*
  * Workaround for Gutenberg CSS4 selectors on older browsers.
  *

--- a/source/wp-content/themes/wporg-main-2022/templates/page-6-6.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-6-6.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
 <main class="wp-block-group entry-content">
-	<!-- wp:pattern {"slug":"wporg-main-2022/6-6"} /-->
+	<!-- wp:pattern {"slug":"wporg-main-2022/work-in-progress"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Some pages shouldn't be fully public (& indexed by search engines) until they're "finished", but we need them published to sync the content to version control + glotpress. Once the page template and pattern are created though, we can swap out the pattern to a placeholder version. This should keep the editor preview working correctly, while not showing the content to regular viewers.

This approach adds a new pattern `wporg-main-2022/work-in-progress`, which can be swapped out on the page template (I resisted the urge to find an under construction gif 😂).

In this case, the content on the pattern references the 6.6 release page, just in case users land on this page from a search engine. Once the 6.6 page is public, we can change out this text with something more generic (cc @thetinyl). Most people will not see this content though.

The content here is not translated, since these strings are only temporary. If we decide to add a more generic message for the future, we can i18n-ize those.

### Screenshots

![](https://github.com/WordPress/wporg-main-2022/assets/541093/37c0d907-d9da-4372-ac2c-4be5748dcaae)

@WordPress/meta-design — again most people won't see this, but let me know if you want to change anything.

### How to test the changes in this Pull Request:

1. View the /download/releases/6-6 page
2. You should not see the real page content
3. You should see a "coming soon" message
