### PR TITLE
Increase the default minimum PHP version shortcode to "7.2"

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -37,7 +37,7 @@ add_shortcode(
 add_shortcode(
 	'minimum_php',
 	function() {
-		return defined( 'MINIMUM_PHP' ) ? MINIMUM_PHP : '7.0';
+		return defined( 'MINIMUM_PHP' ) ? MINIMUM_PHP : '7.2';
 	}
 );
 

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -37,7 +37,7 @@ add_shortcode(
 add_shortcode(
 	'minimum_php',
 	function() {
-		return defined( 'MINIMUM_PHP' ) ? MINIMUM_PHP : '7.2';
+		return defined( 'MINIMUM_PHP' ) ? MINIMUM_PHP : '7.2.24';
 	}
 );
 


### PR DESCRIPTION
WordPress 6.6 changed the minimum supported PHP version to PHP 7.2.
[The requirements page continues to claim 7.0+:](https://wordpress.org/about/requirements/)
WordPress also works with PHP 7.0+ and MySQL 5.5.5+.
[The compatibility page notes that WordPress 6.6 dropped support for versions 7.0 and 7.1.](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)

Fixes https://meta.trac.wordpress.org/ticket/7723

Props pkevan


