### PR TITLE
Update version number for a11y.

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/about-accessibility.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-accessibility.php
@@ -16,7 +16,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'WordPress aims to make the WordPress Admin and bundled themes fully WCAG 2.0 AA compliant where possible.', 'wporg' ); ?></p>
+<p><?php _e( 'WordPress aims to make the WordPress Admin and bundled themes fully WCAG 2.1 AA compliant where possible.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
Fixes: https://github.com/WordPress/wporg-main-2022/issues/494

Updates accessibility version on https://wordpress.org/about/accessibility/ to `WCAG 2.1 AA` to match the version on https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/.

Props: joedolson.