### PR TITLE
fixes documentation link text confusion

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -174,7 +174,7 @@ _e( 'Recommend PHP [recommended_php] or greater and MySQL version [recommended_m
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li><?php _e( '<a href="https://wordpress.org/support/">WordPress support ↗</a>', 'wporg' ); ?></li>
+<li><?php _e( '<a href="https://wordpress.org/documentation/">WordPress documentation ↗</a>', 'wporg' ); ?></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->


### PR DESCRIPTION
There is a link to the documentation and below to support forums. The link to the docs was not updated and is titled with "WordPress support". It's misleading and can confuse translators to link to the forums again.

![Screenshot 2025-02-05 162622](https://github.com/user-attachments/assets/e6f14fb5-58dc-42b3-ab56-10b9216c28cf)