### PR TITLE
Try to fix the 'Update existing content' workflow

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: trunk
+          ref: try/disable-puppeteer-sandbox
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk

--- a/env/screenshot-changes.js
+++ b/env/screenshot-changes.js
@@ -32,7 +32,7 @@ async function getPageDetails( slug ) {
 ( async () => {
 	const browser = await puppeteer.launch( {
 		headless: true,
-		args: [ '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage' ],
+		args: [ '--no-sandbox', '--disable-setuid-sandbox' ],
 	} );
 	const page = await browser.newPage();
 

--- a/env/screenshot-changes.js
+++ b/env/screenshot-changes.js
@@ -30,7 +30,10 @@ async function getPageDetails( slug ) {
 }
 
 ( async () => {
-	const browser = await puppeteer.launch( { headless: true } );
+	const browser = await puppeteer.launch( {
+		headless: true,
+		args: [ '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage' ],
+	} );
 	const page = await browser.newPage();
 
 	await page.setViewport( {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The 'Update existing content' workflow is currently broken; failing because there is 'No usable sandbox' for Puppeteer. I'm not sure what has changed. Various sources suggest disabling the Chrome sandbox for CI, so that's what this PR tries, however running the workflow with this branch doesn't fix the issue.

```
/home/runner/work/wporg-main-2022/wporg-main-2022/node_modules/@puppeteer/browsers/lib/cjs/launch.js:267
                reject(new Error([
                       ^
Error: Failed to launch the browser process!
[9108:9108:0217/011418.032785:FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0217/011418.041514:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0217/011418.041554:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
TROUBLESHOOTING: https://pptr.dev/troubleshooting
    at ChildProcess.onClose (/home/runner/work/wporg-main-2022/wporg-main-2022/node_modules/@puppeteer/browsers/lib/cjs/launch.js:267:24)
    at ChildProcess.emit (node:events:530:35)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
Node.js v20.18.2
```

### How to test the changes in this Pull Request:

1. Save a change to one of the pages in the manifest
2. Run the 'Update existing content' workflow using this branch
![Screenshot 2025-02-17 at 4 17 27 PM](https://github.com/user-attachments/assets/d64ea325-286f-4aa1-af10-ea8409d460fd)

If successful the change would be detected and puppeteer would open a browser to take a screenshot, but it fails.