### PR TITLE
Disable AppArmor to restore Content Update workflow.

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -25,7 +25,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Disable AppArmor
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Run the content update

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: try/disable-apparmor
+          ref: trunk
 
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Disable AppArmor
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       - name: Run the content update
         id: build-patterns
         run: |

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -19,13 +19,13 @@ jobs:
         with:
           ref: try/disable-apparmor
 
+      - name: Disable AppArmor
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Disable AppArmor
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Run the content update
         id: build-patterns

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: trunk
+          ref: try/disable-apparmor
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk


### PR DESCRIPTION
Inspired by https://github.com/puppeteer/puppeteer/commit/39844498e43e19c6eeb8003d132fdbda01f8bd51

Which seems to work: https://github.com/WordPress/wporg-main-2022/actions/runs/13362512118

This should remove the need for #541