### PR TITLE
Download: Add 6.8 Release page

### DIFF
--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -128,6 +128,11 @@
 		"template": "page-6-7.html"
 	},
 	{
+		"slug": "6-8",
+		"pattern": "download-releases-6-8.php",
+		"template": "page-6-8.html"
+	},
+	{
 		"slug": "source",
 		"pattern": "download-source.php",
 		"template": "page-source.html"

--- a/source/wp-content/themes/wporg-main-2022/patterns/download-releases-6-8.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download-releases-6-8.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Title: WordPress 6.8
+ * Slug: wporg-main-2022/6-8
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"metadata":{"name":"Page"},"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained","wideSize":"1200px"}} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"metadata":{"name":"Hero"},"align":"full","style":{"spacing":{"padding":{"bottom":"0","left":"0","right":"0"},"blockGap":"40px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"dimensions":{"minHeight":"720px"},"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}},"background":{"backgroundImage":{"url":"https://wordpress.org/files/2025/04/6.8-hero-large.png","id":46133,"source":"file","title":"6.8-hero-large"},"backgroundSize":"1384px","backgroundPosition":"50% 0","backgroundRepeat":"no-repeat"}},"backgroundColor":"white","textColor":"charcoal-1","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group has-charcoal-1-color has-white-background-color has-text-color has-background has-link-color" style="min-height:720px;padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"450px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"className":"has-mixed-heading-font","style":{"typography":{"lineHeight":"1","letterSpacing":"-2px","fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-4"}}}},"textColor":"charcoal-4","fontSize":"heading-1","fontFamily":"eb-garamond"} -->
+<h1 class="wp-block-heading has-text-align-center has-mixed-heading-font has-charcoal-4-color has-text-color has-link-color has-eb-garamond-font-family has-heading-1-font-size" style="font-style:normal;font-weight:400;letter-spacing:-2px;line-height:1"><?php _e( 'A release polished to a <br><strong><mark class="has-inline-color has-charcoal-0-color">high sheen</mark></strong>', 'wporg' ); ?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php _e( 'WordPress 6.8 polishes and refines the tools you use every day, making your site faster, more secure, and easier to manage.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"textColor":"white","className":"is-style-fill","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} -->
+<div class="wp-block-button is-style-fill"><a class="wp-block-button__link has-white-color has-text-color has-link-color wp-element-button" href="<?php _e( 'https://wordpress.org/download/', 'wporg' ); ?>"><?php _e( 'Get WordPress 6.8', 'wporg' ); ?></a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Main features"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"},"blockGap":"24px"}},"backgroundColor":"white","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"metadata":{"name":"Stylebook"},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0"},"blockGap":"var:preset|spacing|60"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"color":{"background":"#ffd3d9"},"border":{"radius":"16px"},"layout":{"selfStretch":"fixed","flexSize":"1200px"}},"textColor":"charcoal-1","layout":{"type":"default"}} -->
+<div class="wp-block-group has-charcoal-1-color has-text-color has-background has-link-color" style="border-radius:16px;background-color:#ffd3d9;padding-top:0;padding-bottom:0"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:heading {"className":"has-mixed-heading-font","style":{"typography":{"fontSize":"42px"}},"fontFamily":"inter","blockVisibility":{"hideBlock":false}} -->
+<h2 class="wp-block-heading has-mixed-heading-font has-inter-font-family" style="font-size:42px"><?php _e( 'The Style Book gets a cleaner look—and a few new tricks', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"extra-large","fontFamily":"eb-garamond"} -->
+<p class="has-eb-garamond-font-family has-extra-large-font-size"><?php _e( '<em>See your theme come to life before your eyes</em>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"normal"} -->
+<p class="has-normal-font-size"><?php _e( 'The Style Book has a new, structured layout and clearer labels, to make it even easier to edit colors, typography—almost all your site styles—in one place. Plus, now you can see it in Classic themes that have editor-styles or a theme.json file. Find the Style Book under Appearance &gt; Design and use it to preview your theme’s evolution, as you edit CSS or make changes in the Customizer.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"bottom","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:50%"><!-- wp:image {"id":46095,"width":"367px","height":"auto","sizeSlug":"full","linkDestination":"none","align":"center"} -->
+<figure class="wp-block-image aligncenter size-full is-resized"><img src="https://wordpress.org/files/2025/03/feature-011.png" alt="<?php _e( 'An image of the Stylebook showing red colors', 'wporg' ); ?>" class="wp-image-46095" style="width:367px;height:auto" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Zoom out"},"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"blockGap":"var:preset|spacing|70"},"elements":{"link":{"color":{"text":"var:preset|color|black"}}},"border":{"radius":"16px"},"layout":{"selfStretch":"fixed","flexSize":"1200px"},"color":{"background":"#f2fff0"}},"textColor":"black","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide has-black-color has-text-color has-background has-link-color" style="border-radius:16px;background-color:#f2fff0;padding-top:0;padding-bottom:0"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"id":46087,"width":"219px","height":"auto","sizeSlug":"full","linkDestination":"none","align":"center"} -->
+<figure class="wp-block-image aligncenter size-full is-resized"><img src="https://wordpress.org/files/2025/03/feature-04.png" alt="<?php _e( 'Three icons representing filtering and the query block', 'wporg' ); ?>" class="wp-image-46087" style="width:219px;height:auto" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:heading {"style":{"typography":{"fontSize":"42px"}},"fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family" style="font-size:42px"><?php _e( 'Editor improvements', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"extra-large","fontFamily":"eb-garamond"} -->
+<p class="has-eb-garamond-font-family has-extra-large-font-size"><?php _e( '<em>Smoother building with Data Views, the Query Loop and everything you touch</em>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Easier ways to see your options in Data Views, and you can exclude sticky posts from the Query Loop. Plus, you’ll find lots of little improvements in the editor that smooth your way through everything you build.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Bindings"},"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"blockGap":"var:preset|spacing|60"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"color":{"background":"#fffcdf"},"border":{"radius":"16px"},"layout":{"selfStretch":"fixed","flexSize":"1200px"}},"textColor":"charcoal-1","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide has-charcoal-1-color has-text-color has-background has-link-color" style="border-radius:16px;background-color:#fffcdf;padding-top:0;padding-bottom:0"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:heading {"className":"has-mixed-heading-font","style":{"typography":{"fontSize":"42px"}},"fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-mixed-heading-font has-inter-font-family" style="font-size:42px"><?php _e( 'Near-instant page loads, thanks to Speculative Loading', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"extra-large","fontFamily":"eb-garamond"} -->
+<p class="has-eb-garamond-font-family has-extra-large-font-size"><?php _e( '<em>Hover, click, and go. Fast!</em>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'In WordPress 6.8, pages load faster than ever. When you or your user hovers over or clicks a link, WordPress may preload the next page, for a smoother, near-instant experience. The system balances speed and efficiency, and you can control how it works, with a plugin or your own code. This feature only works in modern browsers—older ones will simply ignore it without any impact.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"id":46089,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/03/feature-03-1.png" alt="<?php _e( 'A transparent image is shown behind another to show it loading', 'wporg' ); ?>" class="wp-image-46089" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Font presets"},"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"blockGap":"var:preset|spacing|70"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"border":{"radius":"16px"},"color":{"background":"#fff3ea"},"layout":{"selfStretch":"fixed","flexSize":"1200px"}},"textColor":"charcoal-1","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide has-charcoal-1-color has-text-color has-background has-link-color" style="border-radius:16px;background-color:#fff3ea;padding-top:0;padding-bottom:0"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"id":46091,"width":"250px","height":"auto","sizeSlug":"full","linkDestination":"none","align":"right"} -->
+<figure class="wp-block-image alignright size-full is-resized"><img src="https://wordpress.org/files/2025/03/feature-tt5.png" alt="<?php _e( 'An icon representation of a password input using asterisks', 'wporg' ); ?>" class="wp-image-46091" style="width:250px;height:auto" /></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:50%"><!-- wp:heading {"style":{"typography":{"fontSize":"42px"}},"fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family" style="font-size:42px"><?php _e( 'Stronger password security with bcrypt', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"extra-large","fontFamily":"eb-garamond"} -->
+<p class="has-eb-garamond-font-family has-extra-large-font-size"><?php _e( '<em>Stronger password security means stronger site security</em>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Now passwords are harder to crack with bcrypt hashing, which takes a lot more computing power to break. This strengthens overall security, as do other encryption improvements across WordPress. You don’t need to do anything—everything updates automatically.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Performance \u0026amp; Accessibility"},"align":"full","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}}},"backgroundColor":"white","textColor":"charcoal-1","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-charcoal-1-color has-white-background-color has-text-color has-background has-link-color" style="padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|50","left":"0","right":"0"},"blockGap":{"left":"80px"}},"layout":{"selfStretch":"fixed","flexSize":"1200px"}}} -->
+<div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0"><!-- wp:column {"verticalAlignment":"stretch","width":"50%","style":{"border":{"radius":"16px"},"color":{"background":"#f0ede9"},"spacing":{"padding":{"top":"50px","bottom":"80px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-column is-vertically-aligned-stretch has-background" style="border-radius:16px;background-color:#f0ede9;padding-top:50px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:80px;padding-left:var(--wp--preset--spacing--edge-space);flex-basis:50%"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide"><!-- wp:image {"id":43812,"width":"48px","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2024/11/icon-perf-48.png" alt="<?php _e( 'Performance icon', 'wporg' ); ?>" class="wp-image-43812" style="width:48px" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"fontSize":"heading-4","fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family has-heading-4-font-size"><?php _e( 'Performance', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'WordPress 6.8 packs a wide range of performance fixes and enhancements to speed up everything from editing to browsing. Beyond speculative loading, WordPress 6.8 pays special attention to the block editor, block type registration, and query caching. Plus, imagine never waiting longer than 50 milliseconds—for any interaction. In WordPress 6.8, the Interactivity API takes a first step toward that goal.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"stretch","width":"50%","style":{"border":{"radius":"16px"},"color":{"background":"#f0ede9"},"spacing":{"padding":{"top":"50px","bottom":"80px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"},"blockGap":"80px"}}} -->
+<div class="wp-block-column is-vertically-aligned-stretch has-background" style="border-radius:16px;background-color:#f0ede9;padding-top:50px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:80px;padding-left:var(--wp--preset--spacing--edge-space);flex-basis:50%"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide"><!-- wp:image {"id":43811,"width":"48px","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2024/11/icon-a11y-48.png" alt="<?php _e( 'Accessibility icon', 'wporg' ); ?>" class="wp-image-43811" style="width:48px" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"fontSize":"heading-4","fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family has-heading-4-font-size"><?php _e( 'Accessibility', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( '100+ accessibility fixes and enhancements touch a broad spectrum of the WordPress experience. This release includes fixes to every bundled theme, improvements to the navigation menu management, the customizer, and simplified labeling. The Block Editor has over 70 improvements to blocks, DataViews, and to its overall user experience.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|50","left":"0","right":"0"},"blockGap":{"left":"80px"}},"layout":{"selfStretch":"fixed","flexSize":"1200px"}}} -->
+<div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0"><!-- wp:column {"verticalAlignment":"stretch","width":"100%","style":{"border":{"radius":"16px"},"color":{"background":"#f0ede9"},"spacing":{"padding":{"top":"50px","bottom":"80px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"},"blockGap":"80px"}}} -->
+<div class="wp-block-column is-vertically-aligned-stretch has-background" style="border-radius:16px;background-color:#f0ede9;padding-top:50px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:80px;padding-left:var(--wp--preset--spacing--edge-space);flex-basis:100%"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:image {"id":43812,"width":"48px","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/files/2024/11/icon-perf-48.png" alt="<?php _e( 'Performance icon', 'wporg' ); ?>" class="wp-image-43812" style="width:48px" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"fontSize":"heading-4","fontFamily":"inter"} -->
+<h2 class="wp-block-heading has-inter-font-family has-heading-4-font-size"><?php _e( 'Take a load off the database', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Work continues on optimizing cache key generation in the <code>WP_Query</code> class. The goal is, as ever, to boost your site’s performance, in this case by taking some more of the load off your database. This is especially good if you get a lot of traffic.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Contributors"},"align":"full","style":{"spacing":{"padding":{"top":"120px","right":"var:preset|spacing|edge-space","bottom":"120px","left":"var:preset|spacing|edge-space"}},"color":{"background":"#f0ede9"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-background" style="background-color:#f0ede9;padding-top:120px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:120px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","style":{"layout":{"selfStretch":"fixed","flexSize":"1200px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"70%"} -->
+<div class="wp-block-column" style="flex-basis:70%"><!-- wp:group {"align":"wide","layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group alignwide"><!-- wp:heading {"fontSize":"heading-1"} -->
+<h2 class="wp-block-heading has-heading-1-font-size"><?php _e( 'Thanks to the over <em>750 contributors</em> who made this release', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"16px","selfStretch":"fixed"}}} -->
+<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"className":"is-style-default","backgroundColor":"light-grey-1"} -->
+<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-default" />
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":"0px","style":{"layout":{"flexSize":"16px","selfStretch":"fixed"}}} -->
+<div style="height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:details {"align":"wide","fontSize":"large"} -->
+<details class="wp-block-details alignwide has-large-font-size"><summary><?php _e( 'View All Contributors', 'wporg' ); ?></summary><!-- wp:shortcode -->
+[wpcredits 6.8 class="has-small-font-size"]
+<!-- /wp:shortcode --></details>
+<!-- /wp:details --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":""} -->
+<div class="wp-block-column"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Get started"},"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|60","right":"0","bottom":"var:preset|spacing|60","left":"0"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--60);padding-right:0;padding-bottom:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group alignwide" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"0","left":"0"}},"layout":{"selfStretch":"fixed","flexSize":"1200px"}}} -->
+<div class="wp-block-group alignwide" style="padding-right:0;padding-left:0"><!-- wp:heading {"align":"wide","className":"is-style-with-arrow","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-6px"}},"fontSize":"heading-cta","fontFamily":"inter"} -->
+<h2 class="wp-block-heading alignwide is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-6px"><?php _e( '<a href="https://wordpress.org/download/">Get started</a>', 'wporg' ); ?></h2>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-6-8.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-6-8.html
@@ -1,0 +1,9 @@
+<!-- wp:wporg/global-header {"textColor":"charcoal-2","backgroundColor":"white","style":{"border":{"bottom":{"color":"var:preset|color|black-opacity-15","style":"solid","width":"1px"}}}} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/6-8"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer /-->


### PR DESCRIPTION
See #549 — This adds the 6.8 release page to the manifest, sets up the page template, and adds the initial pattern. ~There may still be string changes, see https://github.com/WordPress/wordpress-develop/pull/8666/files#diff-63578939240eff4d3824eeb6a4681ffeb8f5758545dd2ccc251bd4849c5e04d1~ Sounds like this will probably not happen.

Note that if this is merged, it won't apply to the page itself until the template is switched (IIRC, switching needs to be done via sandbox, I think I put the command in Neso dev docs).

### Screenshots

| Desktop | Mobile |
|--------|-------|
| ![release-page](https://github.com/user-attachments/assets/4dbc9ea6-0480-4ce5-b262-c39ef216cbc9) | ![release-page-small](https://github.com/user-attachments/assets/4fdc18d1-4034-4b70-a858-8f7f724d5b86) |
