### PR TITLE
Download counter: Set a locale to prevent the AJAX request from using the user's locale

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/index.js
@@ -13,9 +13,10 @@ import metadata from './block.json';
 
 function Edit() {
 	const [ count, setCount ] = useState( '1,000,000' );
-	useEffect( async () => {
-		const realCount = await apiFetch( { path: '/wporg/v1/core-downloads/' } );
-		setCount( realCount );
+	useEffect( () => {
+		apiFetch( { path: '/wporg/v1/core-downloads/?_locale=site' } ).then( ( realCount ) => {
+			setCount( realCount );
+		} );
 	}, [] );
 
 	return <div { ...useBlockProps() }>{ count }</div>;

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
@@ -21,7 +21,7 @@ const init = () => {
 
 			setInterval( async () => {
 				try {
-					const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }` } );
+					const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }?_locale=site` } );
 					element.textContent = decodeEntities( count );
 				} catch ( error ) {}
 			}, 5000 );


### PR DESCRIPTION
By default, the API request will try to set the user's language before returning the number, which might be different than the site's language. For example, on the English site, the number initially loads with commas for thousands separators, but if someone with Spanish as their user-level language views the page, the API will use Spanish when formatting the number. 

This is because the `apiFetch` command has a middleware that adds `_locale=user` to requests, telling the API to load the user's locale when running `number_format_i18n`.

The fix here is simple, adding `_locale=site` to prevent [the middleware](https://github.com/WordPress/gutenberg/blob/trunk/packages/api-fetch/src/middlewares/user-locale.js) from adding the user value, and so keeping the request in the site's locale, like it is on the initial render.

Fixes https://meta.trac.wordpress.org/ticket/7959

Props threadi, Otto42.

### How to test the changes in this Pull Request:

1. With your site's language set to English
2. View the download counter page `/download/counter/`
3. Number loads with commas
4. Change your user's language to a language with different thousands separators, for example Spanish, German.
5. Number should still use commas even after new API requests

Optionally switch the site and user languages (Spanish for site, English for user), and ensure that the thousands separators stay consistent.