### PR TITLE
Fonts: Clean up heading preloading call, rosetta styles

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -59,24 +59,6 @@ function enqueue_assets() {
 		);
 	}
 
-	// Preload the heading font(s).
-	if ( is_callable( 'global_fonts_preload' ) ) {
-		if ( 'ja' === get_locale() ) {
-			global_fonts_preload( 'Noto Serif JP', 'cjk' );
-		} else if ( 'ckb' === get_locale() ) {
-			global_fonts_preload( 'Noto Kufi', 'arabic' );
-		} else {
-			/*
-			 * translators: Font subset for your locale. Can be any of cyrillic,
-			 * cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext.
-			 * Do not translate into your own language.
-			 */
-			$subsets = _x( 'latin', 'EB Garamond subsets, comma separated', 'wporg' );
-			// All headings.
-			global_fonts_preload( 'EB Garamond', $subsets );
-		}
-	}
-
 	if ( get_locale() !== 'en_US' ) {
 		wp_enqueue_style(
 			'wporg-main-2022-rosetta-style',

--- a/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/rosetta/style.scss
@@ -28,7 +28,6 @@ $wporg-about-breakpoint-max: 1920px;
 }
 
 [lang="ja"] {
-	--wp--custom--heading--typography--font-family: var(--wp--preset--font-family--noto-serif-jp);
 	--wp--preset--font-size--heading-1: 60px;
 
 	.wp-block-wporg-random-heading > strong {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-parent-2021/pull/173. This PR removes the preloading call, having moved it to the parent theme. The similar calls in other child themes can also be removed.

This also removes the heading override in Japanese, as this is also now done at the parent theme level to cascade to the rest of the localized sites.

This should be merged after https://github.com/WordPress/wporg-parent-2021/pull/173 & https://github.com/WordPress/wporg-mu-plugins/pull/684 to avoid unstyling the Japanese Rosetta site.
