### PR TITLE
Content update: continue on error

### DIFF
--- a/env/export-content/includes/utils.php
+++ b/env/export-content/includes/utils.php
@@ -2,6 +2,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 namespace WordPress_org\Main_2022\ExportToPatterns;
+use Exception;
 
 require __DIR__ . '/parser.php';
 
@@ -23,22 +24,22 @@ function generate_pattern( $url, $output_path ) {
 	$status_code = wp_remote_retrieve_response_code( $response );
 
 	if ( is_wp_error( $response ) ) {
-		die( esc_html( $response->get_error_message() ) );
+		throw new Exception( esc_html( $response->get_error_message() ) );
 	} elseif ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		die( esc_html( "HTTP Error $status_code \n" ) );
+		throw new Exception( esc_html( "HTTP Error $status_code \n" ) );
 	}
 
 	$data = wp_remote_retrieve_body( $response );
 
 	if ( ! $data ) {
-		die( "Unable to fetch {$url}\n" );
+		throw new Exception( "Unable to fetch {$url}\n" );
 	}
 
 	$posts = json_decode( $data );
 	$post = $posts[0] ?? null;
 	if ( ! isset( $post->content_raw ) ) {
 		var_dump( $post );
-		die( "No content_raw available at {$url}\n" );
+		throw new Exception( "No content_raw available at {$url}\n" );
 	}
 
 	$content = replace_with_i18n( $post->content_raw );
@@ -58,7 +59,7 @@ EOF;
 	$bytes = file_put_contents( $output_path, $header . $content . "\n" );
 
 	if ( false === $bytes ) {
-		die( 'Unable to write to ' . $output_path );
+		throw new Exception( 'Unable to write to ' . $output_path );
 	} else {
 		echo 'Wrote ' . size_format( $bytes ) . ' to ' . $output_path . "\n";
 	}

--- a/env/export-content/includes/utils.php
+++ b/env/export-content/includes/utils.php
@@ -2,6 +2,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 namespace WordPress_org\Main_2022\ExportToPatterns;
+
 use Exception;
 
 require __DIR__ . '/parser.php';
@@ -17,6 +18,11 @@ add_action( 'http_api_curl', __NAMESPACE__ . '\filter_curl_options' );
 
 /**
  * Generate the pattern content from a URL.
+ *
+ * @throws Exception If the request fails or writing the file fails.
+ *
+ * @param string $url The REST API endpoint URL for the post.
+ * @param string $output_path The local file path to write the pattern to.
  */
 function generate_pattern( $url, $output_path ) {
 	$response = wp_remote_get( $url );
@@ -67,6 +73,9 @@ EOF;
 
 /**
  * Create a page template to use this pattern.
+ *
+ * @param string $slug The slug of the pattern to include.
+ * @param string $output_path The local file path to write the template to.
  */
 function generate_template( $slug, $output_path ) {
 	$template = <<<EOF

--- a/env/export-content/index.php
+++ b/env/export-content/index.php
@@ -3,6 +3,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 namespace WordPress_org\Main_2022\ExportToPatterns;
+
 use Exception;
 
 require __DIR__ . '/includes/utils.php';

--- a/env/export-content/index.php
+++ b/env/export-content/index.php
@@ -3,6 +3,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 namespace WordPress_org\Main_2022\ExportToPatterns;
+use Exception;
 
 require __DIR__ . '/includes/utils.php';
 
@@ -29,13 +30,13 @@ $pattern_path = $theme_dir . '/patterns/%s';
 $template_path = $theme_dir . '/templates/%s';
 
 if ( ! isset( $args[0] ) || ! file_exists( $args[0] ) ) {
-	die( "No manifest provided.\n" );
+	throw new Exception( "No manifest provided.\n" );
 }
 
 $manifest_data = file_get_contents( $args[0] );
 $manifest_items = json_decode( $manifest_data );
 if ( ! $manifest_data || ! $manifest_items ) {
-	die( "Unable to read manifest from $args[0]\n" );
+	throw new Exception( "Unable to read manifest from $args[0]\n" );
 }
 
 foreach ( $manifest_items as $item ) {

--- a/env/export-content/index.php
+++ b/env/export-content/index.php
@@ -39,12 +39,27 @@ if ( ! $manifest_data || ! $manifest_items ) {
 	throw new Exception( "Unable to read manifest from $args[0]\n" );
 }
 
+$encountered_problems = false;
+
 foreach ( $manifest_items as $item ) {
 	if ( $item->slug ) {
 		$pattern = $item->pattern ?? $item->slug . '.php';
 		$template = $item->template ?? $item->slug . '.html';
 
-		generate_pattern( sprintf( $rest_url, $item->slug ), sprintf( $pattern_path, $pattern ) );
-		generate_template( $item->slug, sprintf( $template_path, $template ) );
+		try {
+			generate_pattern( sprintf( $rest_url, $item->slug ), sprintf( $pattern_path, $pattern ) );
+			generate_template( $item->slug, sprintf( $template_path, $template ) );
+		} catch ( Exception $e ) {
+			echo '!! Error: ' . $e->getMessage() . "\n";
+			echo "\tDoes the page still exist? Has it been unpublished? Update the Manifest or retry.\n\n";
+			$encountered_problems = true;
+		}
 	}
+}
+
+if ( $encountered_problems ) {
+	echo "\nOne or more errors encountered.\n";
+
+	// Signal that this process kinda failed.
+	exit( 1 );
 }

--- a/env/import-content.php
+++ b/env/import-content.php
@@ -3,6 +3,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 namespace WordPress_org\Main_2022\ImportTestContent;
+use Exception;
 
 /**
  * CLI script for generating local test content, fetched from the live wordpress.org site.
@@ -23,11 +24,11 @@ $opts = getopt( '', array( 'url:' ) );
 require dirname( dirname( __FILE__ ) ) . '/wp-load.php';
 
 if ( 'local' !== wp_get_environment_type() ) {
-	die( 'Not safe to run on ' . esc_html( get_site_url() ) );
+	throw new Exception( 'Not safe to run on ' . esc_html( get_site_url() ) );
 }
 
 if ( empty( $opts['url'] ) || esc_url_raw( $opts['url'], [ 'https' ] ) !== $opts['url'] ) {
-	die( 'Invalid url parameter ' . esc_html( $opts['url'] ) );
+	throw new Exception( 'Invalid url parameter ' . esc_html( $opts['url'] ) );
 }
 
 /**
@@ -67,9 +68,9 @@ function import_rest_to_posts( $rest_url ) {
 	$status_code = wp_remote_retrieve_response_code( $response );
 
 	if ( is_wp_error( $response ) ) {
-		die( esc_html( $response->get_error_message() ) );
+		throw new Exception( esc_html( $response->get_error_message() ) );
 	} elseif ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		die( esc_html( "HTTP Error $status_code \n" ) );
+		throw new Exception( esc_html( "HTTP Error $status_code \n" ) );
 	}
 
 	$body = wp_remote_retrieve_body( $response );
@@ -113,7 +114,7 @@ function import_rest_to_posts( $rest_url ) {
 		$new_post_id = wp_insert_post( $new_post, true );
 
 		if ( is_wp_error( $new_post_id ) ) {
-			die( esc_html( $new_post_id->get_error_message() ) );
+			throw new Exception( esc_html( $new_post_id->get_error_message() ) );
 		}
 
 		echo "Inserted $post->type $post->id as $new_post_id\n\n";

--- a/env/import-content.php
+++ b/env/import-content.php
@@ -3,6 +3,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 namespace WordPress_org\Main_2022\ImportTestContent;
+
 use Exception;
 
 /**
@@ -57,6 +58,8 @@ function filter_curl_options( $ch ) {
 
 /**
  * Import posts from a remote REST API to the local test site.
+ *
+ * @throws Exception If the request fails or inserting a post fails.
  *
  * @param string $rest_url The remote REST API endpoint URL.
  */


### PR DESCRIPTION
It was noticed that the content import script isn't fully importing all changes at present.

This appears to be due to a page being unpublished (swag) which terminates the content update script early, but without setting an error return code - So the Github action appears to succeed.. 

https://github.com/WordPress/wporg-main-2022/actions/runs/18328007743/job/52196952233#step:5:270

This PR changes it from `die()` to `throw Exception` (to exit immediately as an error condition) and updates the content export loop to continue on failure (But signify it after the loop).