### PR TITLE
Recommend MariaDB due to MySQL 8.4+ incompatibility

### DIFF
--- a/env/data.xml
+++ b/env/data.xml
@@ -719,7 +719,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>We recommend servers running version [recommended_php] or greater of <a href="https://www.php.net/">PHP</a> and <a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] <em>OR</em> <a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater.<br>We also recommend either <a href="https://httpd.apache.org/">Apache</a> or <a href="https://nginx.org/">Nginx</a> as the most robust options for running WordPress, but neither is required.</p>
+<p>We recommend servers running version [recommended_php] or greater of <a href="https://www.php.net/">PHP</a> and <a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater.<br>We also recommend either <a href="https://httpd.apache.org/">Apache</a> or <a href="https://nginx.org/">Nginx</a> as the most robust options for running WordPress, but neither is required.</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 

--- a/env/export-content/tests/block-parser-test.php
+++ b/env/export-content/tests/block-parser-test.php
@@ -170,8 +170,8 @@ class BlockParser_Test extends WP_UnitTestCase {
 	public function data_block_content_i18n_with_shortcode() {
 		return [
 			[
-				"<!-- wp:paragraph -->\n<p>Recommend PHP [recommended_php] or greater and MySQL [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.</p>\n<!-- /wp:paragraph -->",
-				"<!-- wp:paragraph -->\n<p><?php\n/* translators: [recommended_php], [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */\n_e( 'Recommend PHP [recommended_php] or greater and MySQL [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.', 'wporg' );\n?></p>\n<!-- /wp:paragraph -->",
+				"<!-- wp:paragraph -->\n<p>Recommend PHP [recommended_php] or greater and MariaDB version [recommended_mariadb] or greater.</p>\n<!-- /wp:paragraph -->",
+				"<!-- wp:paragraph -->\n<p><?php\n/* translators: [recommended_php], [recommended_mariadb] are shortcodes and should not be translated. */\n_e( 'Recommend PHP [recommended_php] or greater and MariaDB version [recommended_mariadb] or greater.', 'wporg' );\n?></p>\n<!-- /wp:paragraph -->",
 			],
 			[
 				"<!-- wp:list-item -->\n<li>Recommend PHP [recommended_php] or greater.</li>\n<!-- /wp:list-item -->",

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
@@ -25,8 +25,8 @@ _e( '<a href="https://www.php.net/">PHP</a> version [recommended_php] or greater
 
 <!-- wp:list-item -->
 <li><?php
-/* translators: [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */
-_e( '<a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] or greater OR <a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater.', 'wporg' );
+/* translators: [recommended_mariadb], [recommended_mysql] are shortcodes and should not be translated. */
+_e( '<a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater OR <a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] (version 8.4 or newer are not compatible).', 'wporg' );
 ?></li>
 <!-- /wp:list-item -->
 
@@ -36,7 +36,7 @@ _e( '<a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] or g
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'That’s really it. <a href="https://httpd.apache.org/">Apache</a> or <a href="https://nginx.org/">Nginx</a> is recommended as the most robust and featureful server for running WordPress, but any server that supports PHP and MySQL will do. That said, for the smoothest experience in setting up—and running—your site, <a href="https://wordpress.org/hosting/">each host on the hosting page</a> supports the above and more with no problems.', 'wporg' ); ?></p>
+<p><?php _e( 'That’s really it. <a href="https://httpd.apache.org/">Apache</a> or <a href="https://nginx.org/">Nginx</a> is recommended as the most robust and featureful server for running WordPress, but any server that supports PHP and MariaDB will do. That said, for the smoothest experience in setting up—and running—your site, <a href="https://wordpress.org/hosting/">each host on the hosting page</a> supports the above and more with no problems.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -46,7 +46,7 @@ _e( '<a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] or g
 <!-- wp:paragraph -->
 <p><?php
 /* translators: [minimum_php] is a shortcode and should not be translated. */
-_e( 'Note: If you are in a legacy environment where you only have older PHP or MySQL versions, WordPress also works with PHP [minimum_php]+ and MySQL 5.5.5+. However, these versions have reached their official End Of Life and <strong>may expose your site to security vulnerabilities</strong>.', 'wporg' );
+_e( 'Note: If you are in a legacy environment where you only have older PHP or MariaDB/MySQL versions, WordPress also works with PHP [minimum_php]+ and MariaDB/MySQL 5.5.5+. However, these versions have reached their official End Of Life and <strong>may expose your site to security vulnerabilities</strong>.', 'wporg' );
 ?></p>
 <!-- /wp:paragraph -->
 
@@ -73,8 +73,8 @@ _e( 'PHP [recommended_php] or greater', 'wporg' );
 
 <!-- wp:list-item -->
 <li><?php
-/* translators: [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */
-_e( 'MySQL [recommended_mysql] or greater OR MariaDB [recommended_mariadb] or greater', 'wporg' );
+/* translators: [recommended_mariadb] are shortcodes and should not be translated. */
+_e( 'MariaDB [recommended_mariadb] or greater', 'wporg' );
 ?></li>
 <!-- /wp:list-item -->
 

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -74,8 +74,8 @@
 
 <!-- wp:paragraph {"className":"is-style-short-text","textColor":"charcoal-4","fontSize":"small"} -->
 <p class="is-style-short-text has-charcoal-4-color has-text-color has-small-font-size"><?php
-/* translators: [recommended_php], [recommended_mysql], [recommended_mariadb] are shortcodes and should not be translated. */
-_e( 'Recommend PHP [recommended_php] or greater and MySQL version [recommended_mysql] or MariaDB version [recommended_mariadb] or greater.', 'wporg' );
+/* translators: [recommended_php], [recommended_mariadb] are shortcodes and should not be translated. */
+_e( 'Recommend PHP [recommended_php] or greater and MariaDB version [recommended_mariadb] or greater.', 'wporg' );
 ?></p>
 <!-- /wp:paragraph -->
 


### PR DESCRIPTION
MySQL 8.4 and newer are incompatible with WordPress because they have removed support for `SQL_CALC_FOUND_ROWS`. Thus the server requirement recommendations needs to be updated to prioritize MariaDB.

To prevent users from setting up sites on incompatible database versions, this change updates the content to:

- Recommend MariaDB as the primary database solution.
- Specify that MySQL versions 8.0 or older are compatible where MySQL is mentioned.
- Update general references from "PHP and MySQL" to "PHP and MariaDB" or "PHP and MariaDB/MySQL" for accuracy.

This change addresses the compatibility issue and reflects MariaDB's widespread adoption within the hosting ecosystem and its alignment with the open source ethos of the WordPress project. Continued promotion of Oracle's MySQL and indirectly Oracle's expanding media ecosystem is not in the interest of WordPress and the ethos of "democratize publishing".

This affects the contents of the pages https://wordpress.org/about/requirements/ and https://wordpress.org/download/.

As seen on https://wordpress.org/about/stats/#mysql_version, over 60% of WordPress installations today use MariaDB:

<img width="621" height="541" alt="image" src="https://github.com/user-attachments/assets/ff5f61e9-b3ce-422e-89c3-ae59cea79314" />
