### PR TITLE
Fix content import in setup.sh by calling php directly 

### DIFF
--- a/env/setup.sh
+++ b/env/setup.sh
@@ -15,7 +15,9 @@ wp option update blogdescription "Blog Tool, Publishing Platform, and CMS"
 wp option update show_on_front 'page'
 
 # Import content from WordPress.org
-./refresh.sh
+# Note: setup.sh runs inside the container, so call php directly (not via wp-env).
+php env/import-content.php --url 'https://wordpress.org/wp-json/wp/v2/posts?context=wporg_export&per_page=50'
+php env/import-content.php --url 'https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&per_page=50'
 
 # Set front page after content is imported
 HOME_PAGE_ID=$(wp post list --post_type=page --name=home --posts_per_page=1 --field=ID --format=ids)


### PR DESCRIPTION
## Summary

### Fix content import in setup.sh
- `setup.sh` runs inside the container via `wp-env run cli bash env/setup.sh`, but `./refresh.sh` uses `yarn wp-env run cli` (a host command unavailable inside the container).
- This was broken in 0b605144539d9dea7c059c8c3d131c7af28d3dd9 which replaced the inline `php` calls with `./refresh.sh`.
- Replace with direct `php env/import-content.php` calls, which work inside the container.
- Fixes 404 screenshots in automated content-update PRs.

### Embed before/after/diff screenshots in content-update PRs
- Take "before" screenshots of all pages from localhost **before** building patterns
- Take "after" screenshots of changed pages **after** building patterns
- Generate visual diff images using `pixelmatch` highlighting changed pixels in red
- Push screenshots to a dedicated `content-update-screenshots` branch (force-pushed each run, never merged to trunk)
- Post a PR comment with collapsible before/after/diff images per changed page
- Each page shows pixel count of changes; pages with no visual changes are labeled as such

## Test plan

- [ ] Verify the content-update workflow runs successfully
- [ ] Verify screenshots show actual page content (not 404s)
- [ ] Verify the PR comment contains embedded before/after/diff images
- [ ] Verify the `content-update-screenshots` branch exists with the screenshot files

🤖 Generated with [Claude Code](https://claude.com/claude-code)