### PR TITLE
Add before/after/diff screenshots to content-update PRs

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -40,12 +40,12 @@ jobs:
           yarn wp-env start
           yarn setup:wp
           mkdir -p "$GITHUB_WORKSPACE/artifacts/"
-          yarn --silent screenshot-changes --before
           yarn build:patterns
-          git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php
+          CHANGED_FILES=$(git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php)
+          echo "$CHANGED_FILES"
           {
             echo 'changelist<<EOF'
-            git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php | xargs yarn --silent screenshot-changes
+            echo "$CHANGED_FILES" | xargs yarn --silent screenshot-changes
             echo EOF
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -35,14 +35,35 @@ jobs:
           chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
           yarn wp-env start
           yarn setup:wp
+          mkdir -p "$GITHUB_WORKSPACE/artifacts/"
+          yarn --silent screenshot-changes --before
           yarn build:patterns
-          mkdir "$GITHUB_WORKSPACE/artifacts/"
           git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php
           {
             echo 'changelist<<EOF'
             git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php | xargs yarn --silent screenshot-changes
             echo EOF
           } >> "$GITHUB_OUTPUT"
+
+      - name: Push screenshots to storage branch
+        run: |
+          cd /tmp
+          mkdir -p screenshots-repo && cd screenshots-repo
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          cp -r "$GITHUB_WORKSPACE/artifacts/before" . 2>/dev/null || true
+          cp -r "$GITHUB_WORKSPACE/artifacts/after" . 2>/dev/null || true
+          cp -r "$GITHUB_WORKSPACE/artifacts/diff" . 2>/dev/null || true
+
+          git add -A
+          git commit -m "Screenshots for content update" --allow-empty
+          git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/content-update-screenshots
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Upload screenshots
         id: upload-artifact
@@ -52,6 +73,7 @@ jobs:
           path: "${{ github.workspace }}/artifacts/"
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
           branch: automated/content-update
@@ -65,6 +87,14 @@ jobs:
             ```
             ${{ steps.build-patterns.outputs.changelist }}
             ```
-            Screenshots: ${{ steps.upload-artifact.outputs.artifact-url }}
-            
+
             Please review, merge, and deploy.
+
+      - name: Post screenshot comment
+        if: steps.create-pr.outputs.pull-request-number
+        run: |
+          if [ -f "$GITHUB_WORKSPACE/artifacts/screenshots.md" ] && [ -s "$GITHUB_WORKSPACE/artifacts/screenshots.md" ]; then
+            gh pr comment "${{ steps.create-pr.outputs.pull-request-number }}" --body-file "$GITHUB_WORKSPACE/artifacts/screenshots.md"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -6,6 +6,10 @@ on:
     - cron: '17 3 * * *'  # Runs daily at 3:17 AM UTC
   push:
     branches: [trunk]
+  pull_request:
+    paths:
+      - '.github/workflows/content-update.yml'
+      - 'env/screenshot-changes.js'
 
 permissions:
   contents: write
@@ -19,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: trunk
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'trunk' }}
 
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -50,10 +50,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Push screenshots to storage branch
+        id: push-screenshots
         run: |
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          BRANCH="content-update-screenshots"
+
           cd /tmp
-          mkdir -p screenshots-repo && cd screenshots-repo
-          git init
+          git clone --depth=1 "$REPO_URL" --branch "$BRANCH" screenshots-repo 2>/dev/null || {
+            mkdir -p screenshots-repo && cd screenshots-repo && git init
+            git remote add origin "$REPO_URL"
+            git checkout --orphan "$BRANCH"
+          }
+          cd /tmp/screenshots-repo
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -63,11 +72,21 @@ jobs:
 
           git add -A
           git commit -m "Screenshots for content update" --allow-empty
-          git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/content-update-screenshots
+          git push origin HEAD:refs/heads/$BRANCH
+
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Resolve screenshot URLs
+        run: |
+          if [ -f "$GITHUB_WORKSPACE/artifacts/screenshots.md" ]; then
+            sed -i "s|/${{ env.SCREENSHOTS_PLACEHOLDER }}/|/${{ steps.push-screenshots.outputs.sha }}/|g" "$GITHUB_WORKSPACE/artifacts/screenshots.md"
+          fi
+        env:
+          SCREENSHOTS_PLACEHOLDER: content-update-screenshots
 
       - name: Upload screenshots
         id: upload-artifact

--- a/env/screenshot-changes.js
+++ b/env/screenshot-changes.js
@@ -5,6 +5,7 @@
  */
 const path = require( 'path' );
 const fs = require( 'fs' );
+const { execSync } = require( 'child_process' );
 const puppeteer = require( 'puppeteer' );
 const { PNG } = require( 'pngjs' );
 const pixelmatch = require( 'pixelmatch' );
@@ -18,8 +19,8 @@ const ARTIFACTS_PATH = path.resolve( process.env.GITHUB_WORKSPACE || '.', 'artif
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY || 'WordPress/wporg-main-2022';
 const SCREENSHOTS_BRANCH = 'content-update-screenshots';
 
-const isBeforeMode = process.argv.includes( '--before' );
-const files = process.argv.slice( 2 ).filter( ( f ) => f !== '--before' );
+// node ./env/screenshot-changes.js [...files]
+const [ , , ...files ] = process.argv;
 
 async function getPageDetails( slug ) {
 	const apiUrl = `https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&slug=${ slug }`;
@@ -117,103 +118,97 @@ function generateDiff( beforePath, afterPath, diffPath ) {
 		deviceScaleFactor: 1,
 	} );
 
-	if ( isBeforeMode ) {
-		const beforeDir = path.join( ARTIFACTS_PATH, 'before' );
-		fs.mkdirSync( beforeDir, { recursive: true } );
+	const afterDir = path.join( ARTIFACTS_PATH, 'after' );
+	const beforeDir = path.join( ARTIFACTS_PATH, 'before' );
+	const diffDir = path.join( ARTIFACTS_PATH, 'diff' );
+	fs.mkdirSync( afterDir, { recursive: true } );
+	fs.mkdirSync( beforeDir, { recursive: true } );
+	fs.mkdirSync( diffDir, { recursive: true } );
 
-		for ( let i = 0; i < manifest.length; i++ ) {
-			const entry = manifest[ i ];
-			const post = await getPageDetails( entry.slug );
-			if ( ! post ) {
-				continue;
-			}
-			console.error( `[before] ${ post.title.rendered }` );
-			await takeScreenshot( page, post.localLink, path.join( beforeDir, `${ entry.slug }.png` ) );
+	// Match changed files to manifest entries.
+	const entries = [];
+	for ( const file of files ) {
+		const found = manifest.find(
+			( entry ) => entry.pattern === path.basename( file ) || `${ entry.slug }.php` === path.basename( file )
+		);
+		if ( found ) {
+			entries.push( { file, ...found } );
 		}
-	} else {
-		const afterDir = path.join( ARTIFACTS_PATH, 'after' );
-		const diffDir = path.join( ARTIFACTS_PATH, 'diff' );
-		fs.mkdirSync( afterDir, { recursive: true } );
-		fs.mkdirSync( diffDir, { recursive: true } );
-
-		const results = [];
-		const usedSlugs = new Set();
-
-		for ( let i = 0; i < files.length; i++ ) {
-			const file = files[ i ];
-			const found = manifest.find(
-				( entry ) => entry.pattern === path.basename( file ) || `${ entry.slug }.php` === path.basename( file )
-			);
-			if ( ! found ) {
-				continue;
-			}
-
-			const post = await getPageDetails( found.slug );
-			if ( ! post ) {
-				continue;
-			}
-
-			// Output changelist line (existing format).
-			console.log( `${ post.title.rendered } [${ post.link }]` );
-
-			const afterFile = path.join( afterDir, `${ found.slug }.png` );
-			await takeScreenshot( page, post.localLink, afterFile );
-
-			const beforeFile = path.join( ARTIFACTS_PATH, 'before', `${ found.slug }.png` );
-			let diffPixels = -1;
-			if ( fs.existsSync( beforeFile ) ) {
-				diffPixels = generateDiff( beforeFile, afterFile, path.join( diffDir, `${ found.slug }.png` ) );
-				usedSlugs.add( found.slug );
-			}
-
-			results.push( {
-				title: post.title.rendered,
-				link: post.link,
-				slug: found.slug,
-				hasBefore: fs.existsSync( beforeFile ),
-				diffPixels,
-			} );
-		}
-
-		// Clean up unused before screenshots to keep the commit small.
-		const beforeDir = path.join( ARTIFACTS_PATH, 'before' );
-		if ( fs.existsSync( beforeDir ) ) {
-			for ( const file of fs.readdirSync( beforeDir ) ) {
-				const slug = path.basename( file, '.png' );
-				if ( ! usedSlugs.has( slug ) ) {
-					fs.unlinkSync( path.join( beforeDir, file ) );
-				}
-			}
-		}
-
-		// Write screenshot markdown to a file for the PR body.
-		const baseUrl = `https://raw.githubusercontent.com/${ GITHUB_REPOSITORY }/${ SCREENSHOTS_BRANCH }`;
-		let markdown = '';
-
-		for ( const r of results ) {
-			if ( ! r.hasBefore ) {
-				markdown += `\n<details>\n<summary>${ r.title }</summary>\n\n`;
-				markdown += `![After](${ baseUrl }/after/${ r.slug }.png)\n\n`;
-				markdown += `</details>\n`;
-				continue;
-			}
-
-			if ( r.diffPixels === 0 ) {
-				markdown += `\n<details>\n<summary>${ r.title } (no visual changes)</summary>\n\n`;
-				markdown += `![After](${ baseUrl }/after/${ r.slug }.png)\n\n`;
-				markdown += `</details>\n`;
-				continue;
-			}
-
-			markdown += `\n<details>\n<summary>${ r.title } (${ r.diffPixels.toLocaleString() } pixels changed)</summary>\n\n`;
-			markdown += `#### Diff\n![Diff](${ baseUrl }/diff/${ r.slug }.png)\n\n`;
-			markdown += `#### Before\n![Before](${ baseUrl }/before/${ r.slug }.png)\n\n`;
-			markdown += `#### After\n![After](${ baseUrl }/after/${ r.slug }.png)\n\n`;
-			markdown += `</details>\n`;
-		}
-
-		fs.writeFileSync( path.join( ARTIFACTS_PATH, 'screenshots.md' ), markdown );
 	}
+
+	// Step 1: Take "after" screenshots (current state has new patterns).
+	for ( const entry of entries ) {
+		const post = await getPageDetails( entry.slug );
+		if ( ! post ) {
+			continue;
+		}
+		console.log( `${ post.title.rendered } [${ post.link }]` );
+		entry.post = post;
+		await takeScreenshot( page, post.localLink, path.join( afterDir, `${ entry.slug }.png` ) );
+	}
+
+	// Step 2: Revert changed files to take "before" screenshots.
+	const filesToRevert = entries.filter( ( e ) => e.post ).map( ( e ) => e.file );
+	if ( filesToRevert.length > 0 ) {
+		// Save new patterns to temp, revert to old, screenshot, then restore.
+		const tmpDir = path.join( ARTIFACTS_PATH, '.tmp' );
+		fs.mkdirSync( tmpDir, { recursive: true } );
+		for ( const file of filesToRevert ) {
+			fs.copyFileSync( file, path.join( tmpDir, path.basename( file ) ) );
+		}
+
+		execSync( `git checkout HEAD -- ${ filesToRevert.join( ' ' ) }`, { stdio: 'inherit' } );
+
+		for ( const entry of entries ) {
+			if ( ! entry.post ) {
+				continue;
+			}
+			await takeScreenshot( page, entry.post.localLink, path.join( beforeDir, `${ entry.slug }.png` ) );
+		}
+
+		// Restore new patterns from temp.
+		for ( const file of filesToRevert ) {
+			fs.copyFileSync( path.join( tmpDir, path.basename( file ) ), file );
+		}
+		fs.rmSync( tmpDir, { recursive: true } );
+	}
+
+	// Step 4: Generate diffs and write markdown.
+	const baseUrl = `https://raw.githubusercontent.com/${ GITHUB_REPOSITORY }/${ SCREENSHOTS_BRANCH }`;
+	let markdown = '';
+
+	for ( const entry of entries ) {
+		if ( ! entry.post ) {
+			continue;
+		}
+
+		const afterFile = path.join( afterDir, `${ entry.slug }.png` );
+		const beforeFile = path.join( beforeDir, `${ entry.slug }.png` );
+
+		if ( ! fs.existsSync( beforeFile ) ) {
+			markdown += `\n<details>\n<summary>${ entry.post.title.rendered }</summary>\n\n`;
+			markdown += `![After](${ baseUrl }/after/${ entry.slug }.png)\n\n`;
+			markdown += `</details>\n`;
+			continue;
+		}
+
+		const diffPixels = generateDiff( beforeFile, afterFile, path.join( diffDir, `${ entry.slug }.png` ) );
+
+		if ( diffPixels === 0 ) {
+			markdown += `\n<details>\n<summary>${ entry.post.title.rendered } (no visual changes)</summary>\n\n`;
+			markdown += `![After](${ baseUrl }/after/${ entry.slug }.png)\n\n`;
+			markdown += `</details>\n`;
+			continue;
+		}
+
+		markdown += `\n<details>\n<summary>${ entry.post.title.rendered } (${ diffPixels.toLocaleString() } pixels changed)</summary>\n\n`;
+		markdown += `#### Diff\n![Diff](${ baseUrl }/diff/${ entry.slug }.png)\n\n`;
+		markdown += `#### Before\n![Before](${ baseUrl }/before/${ entry.slug }.png)\n\n`;
+		markdown += `#### After\n![After](${ baseUrl }/after/${ entry.slug }.png)\n\n`;
+		markdown += `</details>\n`;
+	}
+
+	fs.writeFileSync( path.join( ARTIFACTS_PATH, 'screenshots.md' ), markdown );
 
 	await browser.close();
 } )();

--- a/env/screenshot-changes.js
+++ b/env/screenshot-changes.js
@@ -17,7 +17,7 @@ const manifest = require( './page-manifest.json' );
 
 const ARTIFACTS_PATH = path.resolve( process.env.GITHUB_WORKSPACE || '.', 'artifacts' );
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY || 'WordPress/wporg-main-2022';
-const SCREENSHOTS_BRANCH = 'content-update-screenshots';
+const SCREENSHOTS_COMMIT = process.env.SCREENSHOTS_COMMIT || 'content-update-screenshots';
 
 // node ./env/screenshot-changes.js [...files]
 const [ , , ...files ] = process.argv;
@@ -173,8 +173,8 @@ function generateDiff( beforePath, afterPath, diffPath ) {
 		fs.rmSync( tmpDir, { recursive: true } );
 	}
 
-	// Step 4: Generate diffs and write markdown.
-	const baseUrl = `https://raw.githubusercontent.com/${ GITHUB_REPOSITORY }/${ SCREENSHOTS_BRANCH }`;
+	// Step 4: Generate diffs and write markdown with side-by-side table.
+	const baseUrl = `https://raw.githubusercontent.com/${ GITHUB_REPOSITORY }/${ SCREENSHOTS_COMMIT }`;
 	let markdown = '';
 
 	for ( const entry of entries ) {
@@ -202,9 +202,11 @@ function generateDiff( beforePath, afterPath, diffPath ) {
 		}
 
 		markdown += `\n<details>\n<summary>${ entry.post.title.rendered } (${ diffPixels.toLocaleString() } pixels changed)</summary>\n\n`;
-		markdown += `#### Diff\n![Diff](${ baseUrl }/diff/${ entry.slug }.png)\n\n`;
-		markdown += `#### Before\n![Before](${ baseUrl }/before/${ entry.slug }.png)\n\n`;
-		markdown += `#### After\n![After](${ baseUrl }/after/${ entry.slug }.png)\n\n`;
+		markdown += `| Before | Changes | After |\n`;
+		markdown += `| --- | --- | --- |\n`;
+		markdown += `| ![Before](${ baseUrl }/before/${ entry.slug }.png) `;
+		markdown += `| ![Changes](${ baseUrl }/diff/${ entry.slug }.png) `;
+		markdown += `| ![After](${ baseUrl }/after/${ entry.slug }.png) |\n\n`;
 		markdown += `</details>\n`;
 	}
 

--- a/env/screenshot-changes.js
+++ b/env/screenshot-changes.js
@@ -4,17 +4,22 @@
  * External dependencies.
  */
 const path = require( 'path' );
+const fs = require( 'fs' );
 const puppeteer = require( 'puppeteer' );
+const { PNG } = require( 'pngjs' );
+const pixelmatch = require( 'pixelmatch' );
 
 /**
  * Internal dependencies.
  */
 const manifest = require( './page-manifest.json' );
 
-const IMAGE_PATH = path.resolve( process.env.GITHUB_WORKSPACE || '.', 'artifacts' );
+const ARTIFACTS_PATH = path.resolve( process.env.GITHUB_WORKSPACE || '.', 'artifacts' );
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY || 'WordPress/wporg-main-2022';
+const SCREENSHOTS_BRANCH = 'content-update-screenshots';
 
-// node ./env/screenshot-changes.js [...files]
-const [ , , ...files ] = process.argv;
+const isBeforeMode = process.argv.includes( '--before' );
+const files = process.argv.slice( 2 ).filter( ( f ) => f !== '--before' );
 
 async function getPageDetails( slug ) {
 	const apiUrl = `https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&slug=${ slug }`;
@@ -29,6 +34,79 @@ async function getPageDetails( slug ) {
 	return post;
 }
 
+async function takeScreenshot( page, url, outputPath ) {
+	await page.goto( url, { waitUntil: 'networkidle0' } );
+	await page.evaluate( async () => {
+		// eslint-disable-next-line no-undef
+		const images = document.querySelectorAll( 'img[class*=wp-image]' );
+
+		for ( let img = 0; img < images.length; img++ ) {
+			images[ img ].scrollIntoView();
+			await new Promise( ( r ) => setTimeout( r, 100 ) );
+		}
+
+		// Wait for all remaining lazy loading images to load
+		await Promise.all(
+			Array.from( images, ( image ) => {
+				if ( image.complete ) {
+					return;
+				}
+
+				return new Promise( ( resolve, reject ) => {
+					image.addEventListener( 'load', resolve );
+					image.addEventListener( 'error', reject );
+				} );
+			} )
+		);
+	} );
+	await page.evaluate( async () => {
+		// eslint-disable-next-line no-undef
+		document.body.scrollIntoView( true );
+	} );
+
+	await page.waitForNetworkIdle();
+
+	await page.screenshot( {
+		path: outputPath,
+		fullPage: true,
+	} );
+}
+
+/**
+ * Pad an image to a target size, filling extra space with white.
+ */
+function padImageData( img, targetWidth, targetHeight ) {
+	if ( img.width === targetWidth && img.height === targetHeight ) {
+		return img.data;
+	}
+	const padded = Buffer.alloc( targetWidth * targetHeight * 4, 255 );
+	for ( let y = 0; y < img.height; y++ ) {
+		const srcOffset = y * img.width * 4;
+		const dstOffset = y * targetWidth * 4;
+		img.data.copy( padded, dstOffset, srcOffset, srcOffset + img.width * 4 );
+	}
+	return padded;
+}
+
+function generateDiff( beforePath, afterPath, diffPath ) {
+	const beforeImg = PNG.sync.read( fs.readFileSync( beforePath ) );
+	const afterImg = PNG.sync.read( fs.readFileSync( afterPath ) );
+
+	const width = Math.max( beforeImg.width, afterImg.width );
+	const height = Math.max( beforeImg.height, afterImg.height );
+
+	const beforeData = padImageData( beforeImg, width, height );
+	const afterData = padImageData( afterImg, width, height );
+
+	const diff = new PNG( { width, height } );
+	const numDiffPixels = pixelmatch( beforeData, afterData, diff.data, width, height, {
+		threshold: 0.1,
+	} );
+
+	fs.writeFileSync( diffPath, PNG.sync.write( diff ) );
+	return numDiffPixels;
+}
+
 ( async () => {
 	const browser = await puppeteer.launch( { headless: true } );
 	const page = await browser.newPage();
@@ -39,51 +117,102 @@ async function getPageDetails( slug ) {
 		deviceScaleFactor: 1,
 	} );
 
-	for ( let i = 0; i < files.length; i++ ) {
-		const file = files[ i ];
-		const found = manifest.find(
-			( entry ) => entry.pattern === path.basename( file ) || `${ entry.slug }.php` === path.basename( file )
-		);
-		if ( found ) {
+	if ( isBeforeMode ) {
+		const beforeDir = path.join( ARTIFACTS_PATH, 'before' );
+		fs.mkdirSync( beforeDir, { recursive: true } );
+
+		for ( let i = 0; i < manifest.length; i++ ) {
+			const entry = manifest[ i ];
+			const post = await getPageDetails( entry.slug );
+			if ( ! post ) {
+				continue;
+			}
+			console.error( `[before] ${ post.title.rendered }` );
+			await takeScreenshot( page, post.localLink, path.join( beforeDir, `${ entry.slug }.png` ) );
+		}
+	} else {
+		const afterDir = path.join( ARTIFACTS_PATH, 'after' );
+		const diffDir = path.join( ARTIFACTS_PATH, 'diff' );
+		fs.mkdirSync( afterDir, { recursive: true } );
+		fs.mkdirSync( diffDir, { recursive: true } );
+
+		const results = [];
+		const usedSlugs = new Set();
+
+		for ( let i = 0; i < files.length; i++ ) {
+			const file = files[ i ];
+			const found = manifest.find(
+				( entry ) => entry.pattern === path.basename( file ) || `${ entry.slug }.php` === path.basename( file )
+			);
+			if ( ! found ) {
+				continue;
+			}
+
 			const post = await getPageDetails( found.slug );
+			if ( ! post ) {
+				continue;
+			}
+
+			// Output changelist line (existing format).
 			console.log( `${ post.title.rendered } [${ post.link }]` );
 
-			await page.goto( post.localLink, { waitUntil: 'networkidle0' } );
-			await page.evaluate( async () => {
-				// eslint-disable-next-line no-undef
-				const images = document.querySelectorAll( 'img[class*=wp-image]' );
+			const afterFile = path.join( afterDir, `${ found.slug }.png` );
+			await takeScreenshot( page, post.localLink, afterFile );
 
-				for ( let img = 0; img < images.length; img++ ) {
-					images[ img ].scrollIntoView();
-					await new Promise( ( r ) => setTimeout( r, 100 ) );
-				}
+			const beforeFile = path.join( ARTIFACTS_PATH, 'before', `${ found.slug }.png` );
+			let diffPixels = -1;
+			if ( fs.existsSync( beforeFile ) ) {
+				diffPixels = generateDiff( beforeFile, afterFile, path.join( diffDir, `${ found.slug }.png` ) );
+				usedSlugs.add( found.slug );
+			}
 
-				// Wait for all remaining lazy loading images to load
-				await Promise.all(
-					Array.from( images, ( image ) => {
-						if ( image.complete ) {
-							return;
-						}
-
-						return new Promise( ( resolve, reject ) => {
-							image.addEventListener( 'load', resolve );
-							image.addEventListener( 'error', reject );
-						} );
-					} )
-				);
-			} );
-			await page.evaluate( async () => {
-				// eslint-disable-next-line no-undef
-				document.body.scrollIntoView( true );
-			} );
-
-			await page.waitForNetworkIdle();
-
-			await page.screenshot( {
-				path: `${ IMAGE_PATH }/${ found.slug }.png`,
-				fullPage: true,
+			results.push( {
+				title: post.title.rendered,
+				link: post.link,
+				slug: found.slug,
+				hasBefore: fs.existsSync( beforeFile ),
+				diffPixels,
 			} );
 		}
+
+		// Clean up unused before screenshots to keep the commit small.
+		const beforeDir = path.join( ARTIFACTS_PATH, 'before' );
+		if ( fs.existsSync( beforeDir ) ) {
+			for ( const file of fs.readdirSync( beforeDir ) ) {
+				const slug = path.basename( file, '.png' );
+				if ( ! usedSlugs.has( slug ) ) {
+					fs.unlinkSync( path.join( beforeDir, file ) );
+				}
+			}
+		}
+
+		// Write screenshot markdown to a file for the PR body.
+		const baseUrl = `https://raw.githubusercontent.com/${ GITHUB_REPOSITORY }/${ SCREENSHOTS_BRANCH }`;
+		let markdown = '';
+
+		for ( const r of results ) {
+			if ( ! r.hasBefore ) {
+				markdown += `\n<details>\n<summary>${ r.title }</summary>\n\n`;
+				markdown += `![After](${ baseUrl }/after/${ r.slug }.png)\n\n`;
+				markdown += `</details>\n`;
+				continue;
+			}
+
+			if ( r.diffPixels === 0 ) {
+				markdown += `\n<details>\n<summary>${ r.title } (no visual changes)</summary>\n\n`;
+				markdown += `![After](${ baseUrl }/after/${ r.slug }.png)\n\n`;
+				markdown += `</details>\n`;
+				continue;
+			}
+
+			markdown += `\n<details>\n<summary>${ r.title } (${ r.diffPixels.toLocaleString() } pixels changed)</summary>\n\n`;
+			markdown += `#### Diff\n![Diff](${ baseUrl }/diff/${ r.slug }.png)\n\n`;
+			markdown += `#### Before\n![Before](${ baseUrl }/before/${ r.slug }.png)\n\n`;
+			markdown += `#### After\n![After](${ baseUrl }/after/${ r.slug }.png)\n\n`;
+			markdown += `</details>\n`;
+		}
+
+		fs.writeFileSync( path.join( ARTIFACTS_PATH, 'screenshots.md' ), markdown );
 	}
 
 	await browser.close();


### PR DESCRIPTION
## Summary

- Take **before** screenshots of all pages from localhost before building patterns
- Take **after** screenshots of changed pages after building patterns
- Generate visual **diff** images using `pixelmatch` highlighting changed pixels in red
- Push screenshots to a dedicated `content-update-screenshots` branch (force-pushed each run, never merged to trunk)
- Post a PR comment with collapsible before/after/diff images per changed page
- Each page shows pixel count of changes; pages with no visual changes are labeled as such
- Artifact ZIP still uploaded as before

## Test plan

- [ ] Verify the content-update workflow runs successfully
- [ ] Verify the PR comment contains embedded before/after/diff images
- [ ] Verify the `content-update-screenshots` branch exists with the screenshot files

🤖 Generated with [Claude Code](https://claude.com/claude-code)