### PR TITLE
Pause videos before taking screenshots

### DIFF
--- a/env/screenshot-changes.js
+++ b/env/screenshot-changes.js
@@ -61,6 +61,12 @@ async function takeScreenshot( page, url, outputPath ) {
 		);
 	} );
 	await page.evaluate( async () => {
+		// Pause all videos to prevent non-deterministic frames in screenshots.
+		// eslint-disable-next-line no-undef
+		document.querySelectorAll( 'video' ).forEach( ( v ) => {
+			v.pause();
+			v.currentTime = 0;
+		} );
 		// eslint-disable-next-line no-undef
 		document.body.scrollIntoView( true );
 	} );


### PR DESCRIPTION
## Summary

- Pause all `<video>` elements and reset to frame 0 before taking screenshots
- Prevents non-deterministic video frames from causing false differences in visual diffs

## Test plan

- [ ] Verify screenshots of pages with videos (e.g. home, blocks) show a consistent first frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)