### PR TITLE
Add a download button for variants

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -142,10 +142,10 @@ add_shortcode(
 
 		if ( defined( 'IS_ROSETTA_NETWORK' ) && IS_ROSETTA_NETWORK && ! empty( $GLOBALS['rosetta'] ) ) {
 			$rosetta_release = $GLOBALS['rosetta']->rosetta->get_latest_public_release();
-			
+
 			if ( $rosetta_release ) {
 				$locale = get_locale();
-				
+
 				// Map locales to the variants
 				$variant_map = array(
 					'de_DE' => 'de_DE_formal',

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -130,6 +130,43 @@ add_shortcode(
 );
 
 /**
+ * Shortcode for a link to the latest version of WordPress for locales with variants.
+ */
+add_shortcode(
+	'download_link_variant',
+	function( $attrs = array() ) {
+		$ext = ( ! empty( $attrs['type'] ) && 'tar.gz' === $attrs['type'] ) ? 'tar.gz' : 'zip';
+
+		$link = "https://wordpress.org/latest.{$ext}";
+
+		if ( defined( 'IS_ROSETTA_NETWORK' ) && IS_ROSETTA_NETWORK && ! empty( $GLOBALS['rosetta'] ) ) {
+			$rosetta_release = $GLOBALS['rosetta']->rosetta->get_latest_public_release();
+			
+			if ( $rosetta_release ) {
+				$locale = get_locale();
+				
+				// Map locales to the variants
+				$variant_map = array(
+					'de_DE' => 'de_DE_formal',
+					'nl_NL' => 'nl_NL_formal',
+					'de_CH' => 'de_CH_informal',
+					'pt_PT' => 'pt_PT_ao90',
+				);
+
+				// Check for variant
+				if ( array_key_exists( $locale, $variant_map ) ) {
+					$locale = $variant_map[ $locale ];
+				}
+
+				$link = home_url( 'latest-' . $locale . ".{$ext}" );
+			}
+		}
+
+		return $link;
+	}
+);
+
+/**
  * Shortcode for a formatted date & time when the latest version was published.
  */
 add_shortcode(

--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -131,6 +131,7 @@ add_shortcode(
 
 /**
  * Shortcode for a link to the latest version of WordPress for locales with variants.
+ * If no variant is defined, the same link as for the shortcode download_link is returned.
  */
 add_shortcode(
 	'download_link_variant',

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -30,13 +30,13 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version]', 'wporg' ); ?>"} -->
-	<?php get_template_part( 'templates/template-parts/modal', 'download' ); ?>
+<?php get_template_part( 'templates/template-parts/modal', 'download' ); ?>
 <!-- /wp:wporg/modal -->
 
 <?php if ( do_shortcode( '[download_link]' ) !== do_shortcode( '[download_link_variant]' ) ) : ?>
-	<!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link_variant]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version] non-default', 'wporg' ); ?>"} -->
-		<?php get_template_part( 'templates/template-parts/modal', 'download' ); ?>
-	<!-- /wp:wporg/modal -->
+<!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link_variant]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version] non-default', 'wporg' ); ?>"} -->
+<?php get_template_part( 'templates/template-parts/modal', 'download' ); ?>
+<!-- /wp:wporg/modal -->
 <?php endif; ?>
 
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}},"layout":{"type":"flex","justifyContent":"left"}} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -28,56 +28,15 @@
 <p class="is-style-short-text"><?php esc_html_e( 'For anyone comfortable getting their own hosting and domain.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<?php
-// Cache modal for both buttons
-ob_start();
-?><!-- wp:group 
-{"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|10"}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}}} -->
-<h2 class="wp-block-heading" style="margin-top:0"><?php esc_html_e( 'Howdy!', 'wporg' ); ?></h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"fontSize":"extra-large","fontFamily":"eb-garamond"} -->
-<p class="has-eb-garamond-font-family has-extra-large-font-size"><?php esc_html_e( 'Thanks for downloading WordPress', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"className":"is-style-default"} -->
-<p class="is-style-default"><?php esc_html_e( "You're an important part of the global community that has used, built, and transformed the platform into what it is today. Find out more ways you can contribute and make an impact on the future of the web.", 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:group {"className":"is-style-default","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group is-style-default"><!-- wp:paragraph -->
-<p><?php _e( '<a href="https://make.wordpress.org/">Get involved in WordPress ↗︎</a>', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><?php _e( '<a href="https://www.meetup.com/pro/wordpress/">Join a local WordPress meetup ↗︎</a>', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><?php _e( '<a href="https://central.wordcamp.org/">Attend a WordCamp ↗︎</a>', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><?php _e( '<a href="https://wordpressfoundation.org/donate/">Support WordPress and open source education ↗︎</a>', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-<!-- /wp:wporg/modal -->
-<?php
-$modal_content = ob_get_clean();
-?>
-
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version]', 'wporg' ); ?>"} -->
-	<?php echo $modal_content; ?>
-</div>
+	<?php get_template_part( 'templates/template-parts/modal', 'download' ); ?>
+<!-- /wp:wporg/modal -->
 
 <?php if ( do_shortcode( '[download_link]' ) !== do_shortcode( '[download_link_variant]' ) ) : ?>
 	<!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link_variant]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version] non-default', 'wporg' ); ?>"} -->
-		<?php echo $modal_content; ?>
+		<?php get_template_part( 'templates/template-parts/modal', 'download' ); ?>
+	<!-- /wp:wporg/modal -->
 <?php endif; ?>
 
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}},"layout":{"type":"flex","justifyContent":"left"}} -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/download.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/download.php
@@ -28,9 +28,11 @@
 <p class="is-style-short-text"><?php esc_html_e( 'For anyone comfortable getting their own hosting and domain.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group"><!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version]', 'wporg' ); ?>"} -->
-<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|10"}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"type":"constrained"}} -->
+<?php
+// Cache modal for both buttons
+ob_start();
+?><!-- wp:group 
+{"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|10"}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}}} -->
 <h2 class="wp-block-heading" style="margin-top:0"><?php esc_html_e( 'Howdy!', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
@@ -64,6 +66,19 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 <!-- /wp:wporg/modal -->
+<?php
+$modal_content = ob_get_clean();
+?>
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version]', 'wporg' ); ?>"} -->
+	<?php echo $modal_content; ?>
+</div>
+
+<?php if ( do_shortcode( '[download_link]' ) !== do_shortcode( '[download_link_variant]' ) ) : ?>
+	<!-- wp:wporg/modal {"closeButtonColor":"white","customCloseButtonColor":"#ffffff","href":"[download_link_variant]","label":"<?php /* translators: [latest_version] is a shortcode and should not be translated. */ esc_html_e( 'Download WordPress [latest_version] non-default', 'wporg' ); ?>"} -->
+		<?php echo $modal_content; ?>
+<?php endif; ?>
 
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}},"layout":{"type":"flex","justifyContent":"left"}} -->
 <div class="wp-block-buttons"><!-- wp:button {"textColor":"blue-1","className":"is-style-outline"} -->

--- a/source/wp-content/themes/wporg-main-2022/templates/template-parts/modal-download.php
+++ b/source/wp-content/themes/wporg-main-2022/templates/template-parts/modal-download.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Template part for displaying the download modal content.
+ */
+?>
+<!-- wp:group 
+{"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|10"}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}}} -->
+<h2 class="wp-block-heading" style="margin-top:0"><?php esc_html_e( 'Howdy!', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"extra-large","fontFamily":"eb-garamond"} -->
+<p class="has-eb-garamond-font-family has-extra-large-font-size"><?php esc_html_e( 'Thanks for downloading WordPress', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"className":"is-style-default"} -->
+<p class="is-style-default"><?php esc_html_e( "You're an important part of the global community that has used, built, and transformed the platform into what it is today. Find out more ways you can contribute and make an impact on the future of the web.", 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"className":"is-style-default","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group is-style-default"><!-- wp:paragraph -->
+<p><?php _e( '<a href="https://make.wordpress.org/">Get involved in WordPress ↗︎</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( '<a href="https://www.meetup.com/pro/wordpress/">Join a local WordPress meetup ↗︎</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( '<a href="https://central.wordcamp.org/">Attend a WordCamp ↗︎</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( '<a href="https://wordpressfoundation.org/donate/">Support WordPress and open source education ↗︎</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/templates/template-parts/modal-download.php
+++ b/source/wp-content/themes/wporg-main-2022/templates/template-parts/modal-download.php
@@ -2,6 +2,7 @@
 /**
  * Template part for displaying the download modal content.
  */
+
 ?>
 <!-- wp:group 
 {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|10"}},"backgroundColor":"blueberry-1","textColor":"white","layout":{"type":"constrained"}} -->


### PR DESCRIPTION
related to #515 
This PR adds a second download button for variants.

* It adds a second shortcode "download_link_variant". The shortcode has the same structure as the "download_link" shortcode, but replaces the locale with its variant. If no variant is defined, it returns the same link as "download_link". This way, we can check whether they are the same or not and don't have to check every locale. This allows us to add/remove locales without having to perform new checks.

* It moves the modal to a template-part file, so we can edit the modal on one place for both buttons.

I do not code very often. There may be some bugs or some better logic. Please feel free to modify or just use it as a draft ;)