### PR TITLE
Migrate Data Export & Erasure Request pages to block theme

### DIFF
--- a/env/page-manifest.json
+++ b/env/page-manifest.json
@@ -54,6 +54,16 @@
 		"template": "page-privacy.html"
 	},
 	{
+		"slug": "data-export-request",
+		"pattern": "about-privacy-data-export-request.php",
+		"template": "page-data-export-request.html"
+	},
+	{
+		"slug": "data-erasure-request",
+		"pattern": "about-privacy-data-erasure-request.php",
+		"template": "page-data-erasure-request.html"
+	},
+	{
 		"slug": "stats",
 		"pattern": "about-stats.php",
 		"template": "page-stats.html"

--- a/source/wp-content/mu-plugins/theme-switcher.php
+++ b/source/wp-content/mu-plugins/theme-switcher.php
@@ -31,8 +31,6 @@ function should_use_new_theme() {
 	$old_theme_pages = array(
 		'/40-percent-of-web/',
 		'/about/privacy/cookies/',
-		'/about/privacy/data-erasure-request/',
-		'/about/privacy/data-export-request/',
 		'/enterprise/content-marketing/',
 		'/enterprise/ecommerce/',
 		'/enterprise/education/',

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -270,8 +270,21 @@ function use_parent_page_title( $block_content, $block, $instance ) {
 		return $block_content;
 	}
 
-	$url = get_permalink( $parent->ID );
-	$title = get_the_title( $parent );
+	// For deeply nested pages (e.g., About > Privacy > Data Export Request),
+	// use the direct parent as the section title ("Privacy"), not the root ("About").
+	// For two-level pages, the direct parent IS the root, so behavior is unchanged.
+	$grandparent = get_post_parent( $parent );
+	if ( $grandparent ) {
+		$url   = get_permalink( $parent->ID );
+		$title = get_the_title( $parent );
+	} else {
+		// Loop up to the first child page, this is the section title.
+		while ( $parent ) {
+			$url   = get_permalink( $parent->ID );
+			$title = get_the_title( $parent );
+			$parent = get_post_parent( $parent );
+		}
+	}
 
 	return str_replace(
 		array( home_url(), get_bloginfo( 'name' ) ),

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -8,6 +8,8 @@ require_once __DIR__ . '/inc/page-meta-descriptions.php';
 require_once __DIR__ . '/inc/hreflang.php';
 require_once __DIR__ . '/inc/capabilities.php';
 require_once __DIR__ . '/inc/data-liberation-handbook.php';
+require_once __DIR__ . '/inc/recaptcha.php';
+require_once __DIR__ . '/inc/privacy-functions.php';
 
 // Block files
 require_once __DIR__ . '/src/download-counter/index.php';
@@ -15,6 +17,7 @@ require_once __DIR__ . '/src/google-search-embed/index.php';
 require_once __DIR__ . '/src/random-heading/index.php';
 require_once __DIR__ . '/src/release-tables/index.php';
 require_once __DIR__ . '/src/remembers-list/index.php';
+require_once __DIR__ . '/src/privacy-request-form/index.php';
 
 /**
  * Actions and filters.
@@ -178,6 +181,24 @@ function add_site_navigation_menus( $menus ) {
 		'about-details' => $about_details,
 		'about-technology' => $about_technology,
 		'about-people' => $about_people,
+		'privacy' => array(
+			array(
+				'label' => __( 'Privacy Policy', 'wporg' ),
+				'url' => '/about/privacy/',
+			),
+			array(
+				'label' => __( 'Cookie Policy', 'wporg' ),
+				'url' => '/about/privacy/cookies/',
+			),
+			array(
+				'label' => __( 'Data Export Request', 'wporg' ),
+				'url' => '/about/privacy/data-export-request/',
+			),
+			array(
+				'label' => __( 'Data Erasure Request', 'wporg' ),
+				'url' => '/about/privacy/data-erasure-request/',
+			),
+		),
 		'download' => array(
 			array(
 				'label' => __( 'Releases', 'wporg' ),
@@ -249,12 +270,8 @@ function use_parent_page_title( $block_content, $block, $instance ) {
 		return $block_content;
 	}
 
-	// Loop up to the first child page, this is the section title.
-	while ( $parent ) {
-		$url = get_permalink( $parent->ID );
-		$title = get_the_title( $parent );
-		$parent = get_post_parent( $parent );
-	}
+	$url = get_permalink( $parent->ID );
+	$title = get_the_title( $parent );
 
 	return str_replace(
 		array( home_url(), get_bloginfo( 'name' ) ),

--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -270,11 +270,8 @@ function use_parent_page_title( $block_content, $block, $instance ) {
 		return $block_content;
 	}
 
-	// For deeply nested pages (e.g., About > Privacy > Data Export Request),
-	// use the direct parent as the section title ("Privacy"), not the root ("About").
-	// For two-level pages, the direct parent IS the root, so behavior is unchanged.
-	$grandparent = get_post_parent( $parent );
-	if ( $grandparent ) {
+	// Privacy subpages (About > Privacy > Page) should show "Privacy" as section title.
+	if ( 'privacy' === $parent->post_name ) {
 		$url   = get_permalink( $parent->ID );
 		$title = get_the_title( $parent );
 	} else {

--- a/source/wp-content/themes/wporg-main-2022/inc/privacy-functions.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/privacy-functions.php
@@ -44,7 +44,7 @@ function privacy_process_request( $type ) {
 		$error_message = esc_html__( 'Your form session has expired. Please try again.', 'wporg' );
 	} elseif (
 		is_user_logged_in() &&
-		! wp_verify_nonce( isset( $_POST['_wpnonce'] ) ? wp_unslash( $_POST['_wpnonce'] ) : '', $nonce_action ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ?? '' ), $nonce_action ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	) {
 		$error_message = esc_html__( 'Your form session has expired. Please try again.', 'wporg' );
 	} elseif (

--- a/source/wp-content/themes/wporg-main-2022/inc/privacy-functions.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/privacy-functions.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Functions for the Privacy Tools - Exports and Erasures.
+ *
+ * @package WordPressdotorg\Theme\Main_2022
+ */
+
+namespace WordPressdotorg\Theme\Main_2022;
+
+use WordPressdotorg\Theme\Main_2022\reCAPTCHA;
+use WordPressdotorg\GDPR\Main as GDPR_Main;
+
+/**
+ * Processes privacy requests.
+ *
+ * @param string $type Type of request.
+ *
+ * @return array
+ */
+function privacy_process_request( $type ) {
+	$email         = false;
+	$error_message = false;
+	$success       = false;
+	$nonce_action  = 'request_' . $type;
+
+	if ( empty( $_POST['email'] ) || ! is_string( $_POST['email'] ) || ! $type || ! in_array( $type, [ 'erase', 'export' ], true ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return compact( 'email', 'error_message', 'success', 'nonce_action' );
+	}
+
+	$email           = trim( wp_unslash( $_POST['email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$requesting_user = is_user_logged_in() ? wp_get_current_user()->user_login : false;
+	$email_user      = get_user_by( 'email', $email );
+
+	// Check to see if the user is blocked, meaning they cannot log in.
+	$blocked_user = false;
+	if ( $email_user instanceof \WP_User && defined( 'WPORG_SUPPORT_FORUMS_BLOGID' ) ) {
+		$support_user = new \WP_User( $email_user->ID, '', WPORG_SUPPORT_FORUMS_BLOGID );
+		if ( ! empty( $support_user->allcaps['bbp_blocked'] ) ) {
+			$blocked_user = true;
+		}
+	}
+
+	if ( ! ReCAPTCHA\check_status() ) {
+		$error_message = esc_html__( 'Your form session has expired. Please try again.', 'wporg' );
+	} elseif (
+		is_user_logged_in() &&
+		! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), $nonce_action ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	) {
+		$error_message = esc_html__( 'Your form session has expired. Please try again.', 'wporg' );
+	} elseif (
+		false !== $email_user && $email_user->user_login !== $requesting_user && ! $blocked_user
+	) {
+		if ( is_user_logged_in() ) {
+			$error_message = sprintf(
+				/* translators: %s: link to the Login form */
+				__( 'The provided email address belongs to a different WordPress.org account. Please <a href="%s">log in to the account first</a>.', 'wporg' ),
+				wp_logout_url( wp_login_url( get_permalink() ) )
+			);
+		} else {
+			$error_message = sprintf(
+				/* translators: %s: link to the Login form */
+				__( 'The provided email address belongs to a WordPress.org account. Please <a href="%s">log in to the account first</a>.', 'wporg' ),
+				wp_login_url( get_permalink() )
+			);
+		}
+	} else {
+		if ( 'export' === $type ) {
+			$api_method = 'create-data-export-request';
+		} elseif ( 'erase' === $type ) {
+			$api_method = 'create-account-erasure-request';
+		}
+
+		$api_request = GDPR_Main::instance()->call_api_for_site(
+			'wordpress.org/',
+			[
+				'email'           => $email,
+				'requesting_user' => $requesting_user,
+			],
+			$api_method,
+			'POST'
+		);
+
+		if ( is_wp_error( $api_request ) ) {
+			$error_message = $api_request->get_error_message();
+
+			if ( 'duplicate_request' === $api_request->get_error_code() ) {
+				$error_message = esc_html__( 'A request for this email address already exists. Please check your spam folder for your confirmation email.', 'wporg' );
+			} elseif ( 'invalid_identifier' === $api_request->get_error_code() ) {
+				$error_message = esc_html__( 'The provided email was invalid. Please check the address and try again.', 'wporg' );
+			}
+		} elseif ( ! empty( $api_request['created'] ) ) {
+			$success = true;
+		}
+	}
+
+	return compact( 'email', 'error_message', 'success', 'nonce_action' );
+}

--- a/source/wp-content/themes/wporg-main-2022/inc/privacy-functions.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/privacy-functions.php
@@ -44,7 +44,7 @@ function privacy_process_request( $type ) {
 		$error_message = esc_html__( 'Your form session has expired. Please try again.', 'wporg' );
 	} elseif (
 		is_user_logged_in() &&
-		! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), $nonce_action ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		! wp_verify_nonce( isset( $_POST['_wpnonce'] ) ? wp_unslash( $_POST['_wpnonce'] ) : '', $nonce_action ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	) {
 		$error_message = esc_html__( 'Your form session has expired. Please try again.', 'wporg' );
 	} elseif (

--- a/source/wp-content/themes/wporg-main-2022/inc/recaptcha.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/recaptcha.php
@@ -57,7 +57,7 @@ function check_status() {
 
 	$verify = array(
 		'secret'   => RECAPTCHA_INVIS_PRIVKEY,
-		'remoteip' => wp_unslash( $_SERVER['REMOTE_ADDR'] ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		'remoteip' => isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		'response' => wp_unslash( $_POST['g-recaptcha-response'] ), // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	);
 

--- a/source/wp-content/themes/wporg-main-2022/inc/recaptcha.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/recaptcha.php
@@ -57,7 +57,7 @@ function check_status() {
 
 	$verify = array(
 		'secret'   => RECAPTCHA_INVIS_PRIVKEY,
-		'remoteip' => isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		'remoteip' => wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		'response' => wp_unslash( $_POST['g-recaptcha-response'] ), // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	);
 

--- a/source/wp-content/themes/wporg-main-2022/inc/recaptcha.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/recaptcha.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Functions for reCAPTCHA.
+ *
+ * @package WordPressdotorg\Theme\Main_2022
+ */
+
+namespace WordPressdotorg\Theme\Main_2022\reCAPTCHA;
+
+/**
+ * Enqueues reCAPTCHA scripts.
+ *
+ * @param mixed $form_id Form ID.
+ */
+function enqueue_script( $form_id ) {
+	if ( ! defined( 'RECAPTCHA_INVIS_PUBKEY' ) ) {
+		return;
+	}
+
+	wp_enqueue_script( 'recaptcha-api', 'https://www.google.com/recaptcha/api.js', array(), '2' );
+	wp_add_inline_script( 'recaptcha-api', 'function reCAPTCHAPostSubmit(token) { document.getElementById(' . wp_json_encode( (string) $form_id ) . ').submit(); }' );
+}
+
+/**
+ * Displays a submit button.
+ *
+ * @param string $submit_text Button text.
+ * @param string $classes     CSS classes.
+ */
+function display_submit_button( $submit_text = 'Submit', $classes = 'button' ) {
+	$sitekey = defined( 'RECAPTCHA_INVIS_PUBKEY' ) ? RECAPTCHA_INVIS_PUBKEY : '';
+
+	echo '<input' .
+		' data-sitekey="' . esc_attr( $sitekey ) . '"' .
+		' data-callback="reCAPTCHAPostSubmit"' .
+		' type="submit"' .
+		' name="form-submit" id="form-submit"' .
+		' class="g-recaptcha ' . esc_attr( $classes ) . '"' .
+		' value="' . esc_attr( $submit_text ) . '"' .
+		'/>';
+}
+
+/**
+ * Response status.
+ *
+ * @return bool
+ */
+function check_status() {
+	// If reCAPTCHA is not setup, skip it.
+	if ( ! defined( 'RECAPTCHA_INVIS_PUBKEY' ) ) {
+		return true;
+	}
+
+	if ( empty( $_POST['g-recaptcha-response'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return false;
+	}
+
+	$verify = array(
+		'secret'   => RECAPTCHA_INVIS_PRIVKEY,
+		'remoteip' => wp_unslash( $_SERVER['REMOTE_ADDR'] ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		'response' => wp_unslash( $_POST['g-recaptcha-response'] ), // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	);
+
+	$resp = wp_remote_post( 'https://www.google.com/recaptcha/api/siteverify', array( 'body' => $verify ) );
+
+	if ( is_wp_error( $resp ) || 200 !== wp_remote_retrieve_response_code( $resp ) ) {
+		return false;
+	}
+
+	$result = json_decode( wp_remote_retrieve_body( $resp ), true );
+
+	return (bool) $result['success'];
+}

--- a/source/wp-content/themes/wporg-main-2022/patterns/_nav-privacy.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/_nav-privacy.php
@@ -1,0 +1,20 @@
+<?php
+// phpcs:disable WordPress.Files.FileName -- Allow underscore for pattern partial.
+/**
+ * Title: Section Nav (Privacy)
+ * Slug: wporg-main-2022/nav-privacy
+ * Inserter: no
+ */
+
+?>
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"position":{"type":"sticky"},"border":{"top":{},"right":{},"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"left":{}}},"textColor":"charcoal-1","fontSize":"small"} -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
+
+		<!-- wp:post-title {"level":0,"fontSize":"small","fontFamily":"inter","className":"wporg-local-navigation-bar__fade-in-scroll"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:navigation {"menuSlug":"privacy","textColor":"charcoal-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","openSubmenusOnClick":true} /-->
+<!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-privacy-data-erasure-request.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-privacy-data-erasure-request.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Title: Data Erasure Request
+ * Slug: wporg-main-2022/data-erasure-request
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
+<h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e( 'Data Erasure Request', 'wporg' ); ?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'WordPress.org respects your privacy and intends to remain transparent about any personal data we store about individuals. Under the General Data Protection Regulation (GDPR), EU citizens and residents may request deletion of personal data stored on our servers.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'The following form will allow you to request deletion of your account and relevant personal and private data. You will be required to authenticate ownership of that address, and may be asked to provide additional identification or information necessary to verify the request.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php esc_html_e( 'Important!', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+printf(
+	/* translators: List of sites that use WordPress.org account. */
+	wp_kses_post( __( 'This will request permanent deletion of your <strong>WordPress.org</strong> account, and relevant personal or private data stored on <strong>%s</strong>, and other related domains and sites.', 'wporg' ) ),
+	'WordPress.org, WordPress.net, WordCamp.org, BuddyPress.org, bbPress.org'
+);
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'Please note that we cannot remove or provide access to data stored on WordPress sites hosted or administered by third parties.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php
+printf(
+	/* translators: link to privacy policy. */
+	wp_kses_post( __( 'Not all data can be erased, please review the <a href="%s">Privacy Policy</a> for details.', 'wporg' ) ),
+	esc_url( home_url( '/about/privacy/' ) )
+);
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'This will not erase your support forum activity. Any topics or replies created will remain associated with an anonymized account.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:wporg/privacy-request-form {"type":"erase"} /--></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/patterns/about-privacy-data-export-request.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-privacy-data-export-request.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Data Export Request
+ * Slug: wporg-main-2022/data-export-request
+ * Inserter: no
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
+<h1 class="wp-block-heading" style="margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e( 'Data Export Request', 'wporg' ); ?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'WordPress.org respects your privacy and intends to remain transparent about any personal data we store about individuals. Under the General Data Protection Regulation (GDPR), EU citizens and residents are entitled to receive a copy of any personal data we might hold about you.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'The following form will allow you to request an export of any data linked to your email address. You will be required to authenticate ownership of that address, and may be asked to provide additional identification or information necessary to verify the request and search our records.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'This export will contain relevant personal or private data stored on WordPress.org, WordPress.net, WordCamp.org, BuddyPress.org, bbPress.org, and other related domains and sites.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:wporg/privacy-request-form {"type":"export"} /--></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/block.json
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/privacy-request-form",
+	"version": "0.1.0",
+	"title": "Privacy Request Form",
+	"category": "widgets",
+	"icon": "",
+	"description": "Display a GDPR data export or erasure request form.",
+	"textdomain": "wporg",
+	"attributes": {
+		"type": {
+			"type": "string",
+			"enum": [ "export", "erase" ],
+			"default": "export"
+		}
+	},
+	"supports": {
+		"html": false,
+		"multiple": false
+	},
+	"editorScript": "file:./index.js"
+}

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { SelectControl } from '@wordpress/components';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit( { attributes, setAttributes } ) {
+	return (
+		<div { ...useBlockProps() }>
+			<SelectControl
+				label="Request Type"
+				value={ attributes.type }
+				options={ [
+					{ label: 'Data Export', value: 'export' },
+					{ label: 'Data Erasure', value: 'erase' },
+				] }
+				onChange={ ( type ) => setAttributes( { type } ) }
+			/>
+			<p><em>Privacy request form will render here.</em></p>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.js
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.js
@@ -22,7 +22,9 @@ function Edit( { attributes, setAttributes } ) {
 				] }
 				onChange={ ( type ) => setAttributes( { type } ) }
 			/>
-			<p><em>Privacy request form will render here.</em></p>
+			<p>
+				<em>Privacy request form will render here.</em>
+			</p>
 		</div>
 	);
 }

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -83,8 +83,8 @@ function render( $attributes, $content, $block ) {
 			: __( 'Accept Declaration and Request Permanent Account Deletion', 'wporg' );
 
 		$declaration = ( 'export' === $type )
-			? esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true.', 'wporg' )
-			: esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true. You also declare that it is your intention for accounts associated with that email address to be permanently deleted.', 'wporg' );
+			? __( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true.', 'wporg' )
+			: __( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true. You also declare that it is your intention for accounts associated with that email address to be permanently deleted.', 'wporg' );
 
 		printf(
 			'<form id="%s" class="privacy-request-form" method="POST" action="#">',

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -78,10 +78,6 @@ function render( $attributes, $content, $block ) {
 	}
 
 	if ( ! $success || 'export' === $type ) {
-		$submit_text = ( 'export' === $type )
-			? __( 'Accept Declaration and Request Export', 'wporg' )
-			: __( 'Accept Declaration and Request Permanent Account Deletion', 'wporg' );
-
 		printf(
 			'<form id="%s" class="privacy-request-form" method="POST" action="#">',
 			esc_attr( $form_id )
@@ -99,11 +95,11 @@ function render( $attributes, $content, $block ) {
 
 		if ( 'export' === $type ) {
 			printf( '<p>%s</p>', esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true.', 'wporg' ) );
+			display_submit_button( __( 'Accept Declaration and Request Export', 'wporg' ), 'wp-block-button__link wp-element-button' );
 		} else {
 			printf( '<p>%s</p>', esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true. You also declare that it is your intention for accounts associated with that email address to be permanently deleted.', 'wporg' ) );
+			display_submit_button( __( 'Accept Declaration and Request Permanent Account Deletion', 'wporg' ), 'wp-block-button__link wp-element-button' );
 		}
-
-		display_submit_button( $submit_text, 'wp-block-button__link wp-element-button' );
 
 		if ( is_user_logged_in() ) {
 			wp_nonce_field( $nonce_action );

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -100,7 +100,7 @@ function render( $attributes, $content, $block ) {
 			esc_attr__( 'you@example.com', 'wporg' ),
 			esc_attr( $email )
 		);
-		printf( '<p>%s</p>', $declaration );
+		printf( '<p>%s</p>', esc_html( $declaration ) );
 
 		display_submit_button( $submit_text, 'wp-block-button__link wp-element-button' );
 

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -82,10 +82,6 @@ function render( $attributes, $content, $block ) {
 			? __( 'Accept Declaration and Request Export', 'wporg' )
 			: __( 'Accept Declaration and Request Permanent Account Deletion', 'wporg' );
 
-		$declaration = ( 'export' === $type )
-			? __( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true.', 'wporg' )
-			: __( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true. You also declare that it is your intention for accounts associated with that email address to be permanently deleted.', 'wporg' );
-
 		printf(
 			'<form id="%s" class="privacy-request-form" method="POST" action="#">',
 			esc_attr( $form_id )
@@ -100,7 +96,12 @@ function render( $attributes, $content, $block ) {
 			esc_attr__( 'you@example.com', 'wporg' ),
 			esc_attr( $email )
 		);
-		printf( '<p>%s</p>', esc_html( $declaration ) );
+
+		if ( 'export' === $type ) {
+			printf( '<p>%s</p>', esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true.', 'wporg' ) );
+		} else {
+			printf( '<p>%s</p>', esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true. You also declare that it is your intention for accounts associated with that email address to be permanently deleted.', 'wporg' ) );
+		}
 
 		display_submit_button( $submit_text, 'wp-block-button__link wp-element-button' );
 

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Block Name: Privacy Request Form
+ * Description: Display a GDPR data export or erasure request form.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Main_2022\Privacy_Request_Form;
+
+use function WordPressdotorg\Theme\Main_2022\privacy_process_request;
+use function WordPressdotorg\Theme\Main_2022\reCAPTCHA\enqueue_script;
+use function WordPressdotorg\Theme\Main_2022\reCAPTCHA\display_submit_button;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/privacy-request-form',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	$type = $attributes['type'] ?? 'export';
+
+	if ( ! in_array( $type, [ 'export', 'erase' ], true ) ) {
+		return '';
+	}
+
+	nocache_headers();
+
+	$form_id = ( 'export' === $type ) ? 'export-request-form' : 'erase-request-form';
+
+	enqueue_script( $form_id );
+
+	$result = privacy_process_request( $type );
+
+	$email         = $result['email'];
+	$error_message = $result['error_message'];
+	$success       = $result['success'];
+	$nonce_action  = $result['nonce_action'];
+
+	if ( ! $email && is_user_logged_in() ) {
+		$email = wp_get_current_user()->user_email;
+	}
+
+	ob_start();
+
+	if ( $error_message ) {
+		printf(
+			'<div class="notice notice-error notice-alt"><p>%s</p></div>',
+			wp_kses_post( $error_message )
+		);
+	} elseif ( $success ) {
+		printf(
+			'<div class="notice notice-success notice-alt"><p>%s</p></div>',
+			esc_html__( 'Please check your email for a confirmation link, and follow the instructions to authenticate your request.', 'wporg' )
+		);
+	}
+
+	if ( ! $success || 'export' === $type ) {
+		$submit_text = ( 'export' === $type )
+			? __( 'Accept Declaration and Request Export', 'wporg' )
+			: __( 'Accept Declaration and Request Permanent Account Deletion', 'wporg' );
+
+		$declaration = ( 'export' === $type )
+			? esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true.', 'wporg' )
+			: esc_html__( 'By submitting this form, you declare that you are the individual owner of the specified email address and its associated accounts; and that all submitted information including any supplemental details necessary to verify your identity are true. You also declare that it is your intention for accounts associated with that email address to be permanently deleted.', 'wporg' );
+
+		printf(
+			'<form id="%s" class="privacy-request-form" method="POST" action="#">',
+			esc_attr( $form_id )
+		);
+		printf(
+			'<label for="email">%s</label>',
+			esc_html__( 'Email Address', 'wporg' )
+		);
+		printf(
+			'<input type="email" name="email" id="email" placeholder="%s" required value="%s" />',
+			/* translators: Example placeholder email address */
+			esc_attr__( 'you@example.com', 'wporg' ),
+			esc_attr( $email )
+		);
+		printf( '<p>%s</p>', $declaration );
+
+		display_submit_button( $submit_text, 'wp-block-button__link wp-element-button' );
+
+		if ( is_user_logged_in() ) {
+			wp_nonce_field( $nonce_action );
+		}
+
+		echo '</form>';
+
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'Please Note: Before we can begin processing your request, we&#8217;ll require that you verify ownership of the email address. If the email address is associated with an account, we&#8217;ll also require you to log in to that account first.', 'wporg' )
+		);
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf( '<div %s>%s</div>', $wrapper_attributes, ob_get_clean() );
+}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -691,3 +691,20 @@ body .is-layout-constrained > .alignfull {
 	margin-left: unset !important;
 	margin-right: unset !important;
 }
+
+/**
+ * Privacy request forms (data export & erasure).
+ */
+
+.privacy-request-form {
+	label {
+		display: block;
+		color: var(--wp--preset--color--charcoal-4);
+		font-size: var(--wp--preset--font-size--small);
+		margin-bottom: var(--wp--preset--spacing--10);
+	}
+
+	input[type="email"] {
+		width: 100%;
+	}
+}

--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -4,7 +4,7 @@
  * Author: WordPress.org
  * Author URI: https://wordpress.org/
  * Description: A block-based child theme for WordPress.org
- * Version: 1.0.4
+ * Version: 1.0.0
  * License: GNU General Public License v2 or later
  * Text Domain: wporg
  * Template: wporg-parent-2021

--- a/source/wp-content/themes/wporg-main-2022/style.css
+++ b/source/wp-content/themes/wporg-main-2022/style.css
@@ -4,7 +4,7 @@
  * Author: WordPress.org
  * Author URI: https://wordpress.org/
  * Description: A block-based child theme for WordPress.org
- * Version: 1.0.0
+ * Version: 1.0.4
  * License: GNU General Public License v2 or later
  * Text Domain: wporg
  * Template: wporg-parent-2021

--- a/source/wp-content/themes/wporg-main-2022/templates/page-data-erasure-request.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-data-erasure-request.html
@@ -1,0 +1,11 @@
+<!-- wp:wporg/global-header {"textColor":"charcoal-2","backgroundColor":"white","style":{"border":{"bottom":{"color":"var:preset|color|black-opacity-15","style":"solid","width":"1px"}}}} /-->
+
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-privacy"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/data-erasure-request"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"textColor":"charcoal-2","backgroundColor":"white"} /-->

--- a/source/wp-content/themes/wporg-main-2022/templates/page-data-export-request.html
+++ b/source/wp-content/themes/wporg-main-2022/templates/page-data-export-request.html
@@ -1,0 +1,11 @@
+<!-- wp:wporg/global-header {"textColor":"charcoal-2","backgroundColor":"white","style":{"border":{"bottom":{"color":"var:preset|color|black-opacity-15","style":"solid","width":"1px"}}}} /-->
+
+<!-- wp:pattern {"slug":"wporg-main-2022/nav-privacy"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/data-export-request"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"textColor":"charcoal-2","backgroundColor":"white"} /-->


### PR DESCRIPTION
## Summary

- Adds `wporg/privacy-request-form` server-rendered block for the GDPR data export/erasure forms (reCAPTCHA, form processing, success/error notices)
- Adds privacy-specific local navigation bar with links to Privacy Policy, Cookie Policy, Data Export Request, and Data Erasure Request
- Adds page templates and patterns for both `/about/privacy/data-export-request/` and `/about/privacy/data-erasure-request/`
- Removes these pages from the theme-switcher `$old_theme_pages` list so they use the new block theme
- Uses direct parent for site-title breadcrumb so grandchild pages show their section ("Privacy") instead of root ("About")

Closes #638

## Deployment notes

After merging, the page content on production needs to be updated to include the `<!-- wp:wporg/privacy-request-form {"type":"export"} /-->` and `<!-- wp:wporg/privacy-request-form {"type":"erase"} /-->` blocks respectively. Then run the content sync to regenerate the pattern files.

## Test plan

- [ ] Visit `/about/privacy/data-export-request/` and verify the page renders with the global header/footer, Privacy navigation bar, and the export request form
- [ ] Visit `/about/privacy/data-erasure-request/` and verify the page renders with the Important notice box and the erasure request form
- [ ] Verify the local navigation shows Privacy Policy, Cookie Policy, Data Export Request, and Data Erasure Request links
- [ ] Verify the breadcrumb shows "Privacy" linking to `/about/privacy/`
- [ ] Verify the submit button has the themed blue button styling
- [ ] Verify text content matches current production pages
- [ ] Verify existing about subpages (e.g. `/about/domains/`) still show "About" breadcrumb correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)