### PR TITLE
Fix notice styles for privacy request forms

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -67,12 +67,12 @@ function render( $attributes, $content, $block ) {
 
 	if ( $error_message ) {
 		printf(
-			'<div class="wp-block-group has-background" style="background-color:#fcf0f1;border-left:4px solid #d63638;padding:var(--wp--preset--spacing--20)">%s</div>',
+			'<div class="wp-block-group has-background" style="background-color:#fcf0f1;border-left:4px solid #d63638;padding:var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)">%s</div>',
 			wp_kses_post( $error_message )
 		);
 	} elseif ( $success ) {
 		printf(
-			'<div class="wp-block-group has-background" style="background-color:#edfaef;border-left:4px solid #00a32a;padding:var(--wp--preset--spacing--20)"><p>%s</p></div>',
+			'<div class="wp-block-group has-background" style="background-color:#edfaef;border-left:4px solid #00a32a;padding:var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"><p>%s</p></div>',
 			esc_html__( 'Please check your email for a confirmation link, and follow the instructions to authenticate your request.', 'wporg' )
 		);
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -67,14 +67,12 @@ function render( $attributes, $content, $block ) {
 
 	if ( $error_message ) {
 		printf(
-			'<div class="wp-block-group has-background" style="background-color:#fcf0f1;border-left:4px solid #d63638;padding:%1$s">%2$s</div>',
-			'var(--wp--preset--spacing--20)',
+			'<div class="wp-block-group has-background" style="background-color:#fcf0f1;border-left:4px solid #d63638;padding:var(--wp--preset--spacing--20)">%s</div>',
 			wp_kses_post( $error_message )
 		);
 	} elseif ( $success ) {
 		printf(
-			'<div class="wp-block-group has-background" style="background-color:#edfaef;border-left:4px solid #00a32a;padding:%s"><p>%s</p></div>',
-			'var(--wp--preset--spacing--20)',
+			'<div class="wp-block-group has-background" style="background-color:#edfaef;border-left:4px solid #00a32a;padding:var(--wp--preset--spacing--20)"><p>%s</p></div>',
 			esc_html__( 'Please check your email for a confirmation link, and follow the instructions to authenticate your request.', 'wporg' )
 		);
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
+++ b/source/wp-content/themes/wporg-main-2022/src/privacy-request-form/index.php
@@ -67,12 +67,14 @@ function render( $attributes, $content, $block ) {
 
 	if ( $error_message ) {
 		printf(
-			'<div class="notice notice-error notice-alt"><p>%s</p></div>',
+			'<div class="wp-block-group has-background" style="background-color:#fcf0f1;border-left:4px solid #d63638;padding:%1$s">%2$s</div>',
+			'var(--wp--preset--spacing--20)',
 			wp_kses_post( $error_message )
 		);
 	} elseif ( $success ) {
 		printf(
-			'<div class="notice notice-success notice-alt"><p>%s</p></div>',
+			'<div class="wp-block-group has-background" style="background-color:#edfaef;border-left:4px solid #00a32a;padding:%s"><p>%s</p></div>',
+			'var(--wp--preset--spacing--20)',
 			esc_html__( 'Please check your email for a confirmation link, and follow the instructions to authenticate your request.', 'wporg' )
 		);
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -707,20 +707,4 @@ body .is-layout-constrained > .alignfull {
 	input[type="email"] {
 		width: 100%;
 	}
-
-	.notice {
-		padding: var(--wp--preset--spacing--20);
-		margin-bottom: var(--wp--preset--spacing--20);
-		border-left: 4px solid;
-	}
-
-	.notice-error {
-		background-color: #fcf0f1;
-		border-left-color: #d63638;
-	}
-
-	.notice-success {
-		background-color: #edfaef;
-		border-left-color: #00a32a;
-	}
 }

--- a/source/wp-content/themes/wporg-main-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-main-2022/src/style/style.scss
@@ -707,4 +707,20 @@ body .is-layout-constrained > .alignfull {
 	input[type="email"] {
 		width: 100%;
 	}
+
+	.notice {
+		padding: var(--wp--preset--spacing--20);
+		margin-bottom: var(--wp--preset--spacing--20);
+		border-left: 4px solid;
+	}
+
+	.notice-error {
+		background-color: #fcf0f1;
+		border-left-color: #d63638;
+	}
+
+	.notice-success {
+		background-color: #edfaef;
+		border-left-color: #00a32a;
+	}
 }


### PR DESCRIPTION
## Summary

- Adds frontend CSS for `.notice-error` and `.notice-success` within the privacy request form
- The WP admin notice styles are not available on the frontend, so error/success messages were unstyled
- Error notices get a red background with red left border
- Success notices get a green background with green left border

Reported in #638.

## Test plan

- [ ] Submit the data export form with an invalid email and verify the error notice has a red background and red left border
- [ ] Submit a valid request and verify the success notice has a green background and green left border

🤖 Generated with [Claude Code](https://claude.com/claude-code)