### PR TITLE
Replace wp-env run cli with REST API endpoints

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'trunk' }}
 
+      - name: Disable AppArmor
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'trunk' }}
 
-      - name: Disable AppArmor
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:
@@ -47,7 +44,7 @@ jobs:
         id: build-patterns
         run: |
           chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
-          yarn wp-env start
+          yarn wp-env --config .wp-env.playground.json start --runtime=playground
           yarn setup:wp
           yarn build:patterns
           CHANGED_FILES=$(git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php)

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -5,7 +5,9 @@ on:
   schedule:
     - cron: '17 3 * * *'  # Runs daily at 3:17 AM UTC
   push:
-    branches: [trunk]
+    branches:
+      - trunk
+      - add/claude/playground-runtime-content-update
   pull_request:
     paths:
       - '.github/workflows/content-update.yml'

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -25,6 +25,9 @@ jobs:
   content-update:
     if: github.repository_owner == 'WordPress'
     runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: true
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -38,24 +41,30 @@ jobs:
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          skip-build: 'true'
 
-      - name: Run the content update
+      - name: Start WordPress and update content
         id: build-patterns
         run: |
           chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
           yarn wp-env start
           yarn setup:wp
-          mkdir -p "$GITHUB_WORKSPACE/artifacts/"
           yarn build:patterns
           CHANGED_FILES=$(git diff --name-only source/wp-content/themes/wporg-main-2022/**/*.php)
+          echo "has_changes=$( [ -n "$CHANGED_FILES" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
           echo "$CHANGED_FILES"
-          {
-            echo 'changelist<<EOF'
-            echo "$CHANGED_FILES" | xargs yarn --silent screenshot-changes
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
+          if [ -n "$CHANGED_FILES" ]; then
+            mkdir -p "$GITHUB_WORKSPACE/artifacts/"
+            npx puppeteer browsers install chrome
+            {
+              echo 'changelist<<EOF'
+              echo "$CHANGED_FILES" | xargs yarn --silent screenshot-changes
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Push screenshots to storage branch
+        if: steps.build-patterns.outputs.has_changes == 'true'
         id: push-screenshots
         run: |
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -87,6 +96,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Resolve screenshot URLs
+        if: steps.build-patterns.outputs.has_changes == 'true'
         run: |
           if [ -f "$GITHUB_WORKSPACE/artifacts/screenshots.md" ]; then
             sed -i "s|/${{ env.SCREENSHOTS_PLACEHOLDER }}/|/${{ steps.push-screenshots.outputs.sha }}/|g" "$GITHUB_WORKSPACE/artifacts/screenshots.md"
@@ -95,6 +105,7 @@ jobs:
           SCREENSHOTS_PLACEHOLDER: content-update-screenshots
 
       - name: Upload screenshots
+        if: steps.build-patterns.outputs.has_changes == 'true'
         id: upload-artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ phpcs.xml.dist
 !/source/wp-content/themes/wporg-main-2022
 !/source/wp-content/mu-plugins
 !/source/wp-content/mu-plugins/theme-switcher.php
+!/source/wp-content/mu-plugins/env-api.php
 lighthouse.html
 source/wp-content/tests/phpunit/.phpunit.result.cache

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -30,6 +30,7 @@
 		"env": "./env",
 		"wp-content/mu-plugins": "./source/wp-content/mu-plugins",
 		"wp-content/mu-plugins/0-sandbox.php": "./env/0-sandbox.php",
+		"wp-content/mu-plugins/env-api.php": "./env/env-api.php",
 		"wp-cli.yml": "./wp-cli.yml"
 	},
 	"env": {

--- a/.wp-env.playground.json
+++ b/.wp-env.playground.json
@@ -13,7 +13,7 @@
 	],
 	"mappings": {
 		"env": "./env",
-		"wp-content/mu-plugins": "./source/wp-content/mu-plugins"
+		"wp-content/mu-plugins": "./env/playground-mu-plugins"
 	},
 	"testsEnvironment": false
 }

--- a/.wp-env.playground.json
+++ b/.wp-env.playground.json
@@ -1,0 +1,19 @@
+{
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": "/tmp/wp-errors.log",
+		"WP_ENVIRONMENT_TYPE": "local",
+		"WPORG_SANDBOXED": true,
+		"WP_MARKET_SHARE": 43,
+		"WP_CORE_STABLE_BRANCH": "6.6",
+		"WP_CORE_LATEST_RELEASE": "6.6"
+	},
+	"themes": [
+		"./source/wp-content/themes/wporg-main-2022"
+	],
+	"mappings": {
+		"env": "./env",
+		"wp-content/mu-plugins": "./source/wp-content/mu-plugins"
+	},
+	"testsEnvironment": false
+}

--- a/env/build-patterns.sh
+++ b/env/build-patterns.sh
@@ -1,8 +1,49 @@
 #!/bin/bash
 
-# Refresh pattern files from the staging site
+# Refresh pattern files from the live wordpress.org site via REST API.
 
-#php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=front-page' --output 'source/wp-content/themes/wporg-main-2022/patterns/front-page.php'
-#php env/export-content.php --url 'http://wordpress.org/main-test/wp-json/wp/v2/pages?context=wporg_export&slug=download' --output 'source/wp-content/themes/wporg-main-2022/patterns/download.php'
+THEME_DIR="source/wp-content/themes/wporg-main-2022"
+MANIFEST="env/page-manifest.json"
+WP_URL="${WP_ENV_URL:-http://localhost:8888}"
 
-yarn wp-env run cli wp eval-file ./env/export-content/index.php ./env/page-manifest.json
+echo "Exporting patterns via REST API ($WP_URL)..."
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+	-H "Content-Type: application/json" \
+	-d @"$MANIFEST" \
+	"$WP_URL/?rest_route=/wporg-env/v1/export-patterns")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "207" ]; then
+	echo "Error: Export endpoint returned HTTP $HTTP_CODE"
+	echo "$BODY"
+	exit 1
+fi
+
+# Write each file from the JSON response.
+echo "$BODY" | python3 -c "
+import sys, json, os
+
+data = json.load(sys.stdin)
+
+for f in data.get('files', []):
+    path = '$THEME_DIR/' + f['path']
+    content = f['content']
+    file_type = f['type']
+
+    # For templates, only write if file does not exist (same as original behavior).
+    if file_type == 'template' and os.path.exists(path):
+        print(f'Skipping {path}')
+        continue
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as fh:
+        fh.write(content)
+    print(f'Wrote {len(content)} bytes to {path}')
+
+for err in data.get('errors', []):
+    print(f'!! Error: {err}')
+
+if data.get('errors'):
+    sys.exit(1)
+"

--- a/env/build-patterns.sh
+++ b/env/build-patterns.sh
@@ -6,11 +6,15 @@ THEME_DIR="source/wp-content/themes/wporg-main-2022"
 MANIFEST="env/page-manifest.json"
 WP_URL="${WP_ENV_URL:-http://localhost:8888}"
 
+COOKIE_JAR=$(mktemp)
+
 echo "Exporting patterns via REST API ($WP_URL)..."
-RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+RESPONSE=$(curl -s -w "\n%{http_code}" -L -b "$COOKIE_JAR" -c "$COOKIE_JAR" -X POST \
 	-H "Content-Type: application/json" \
 	-d @"$MANIFEST" \
 	"$WP_URL/?rest_route=/wporg-env/v1/export-patterns")
+
+rm -f "$COOKIE_JAR"
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 

--- a/env/build-patterns.sh
+++ b/env/build-patterns.sh
@@ -5,18 +5,20 @@
 THEME_DIR="source/wp-content/themes/wporg-main-2022"
 MANIFEST="env/page-manifest.json"
 WP_URL="${WP_ENV_URL:-http://localhost:8888}"
-
 COOKIE_JAR=$(mktemp)
 
+# Pre-flight request to handle Playground auto-login redirect.
+curl -s -o /dev/null -L -b "$COOKIE_JAR" -c "$COOKIE_JAR" "$WP_URL/?rest_route=/"
+
 echo "Exporting patterns via REST API ($WP_URL)..."
-RESPONSE=$(curl -s -w "\n%{http_code}" -L -b "$COOKIE_JAR" -c "$COOKIE_JAR" -X POST \
+RESPONSE=$(curl -s -w "\n%{http_code}" -b "$COOKIE_JAR" -X POST \
 	-H "Content-Type: application/json" \
 	-d @"$MANIFEST" \
 	"$WP_URL/?rest_route=/wporg-env/v1/export-patterns")
-
-rm -f "$COOKIE_JAR"
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
+
+rm -f "$COOKIE_JAR"
 
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "207" ]; then
 	echo "Error: Export endpoint returned HTTP $HTTP_CODE"

--- a/env/env-api.php
+++ b/env/env-api.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * REST API endpoints for local environment setup and content export.
+ *
+ * These endpoints replace WP-CLI commands, enabling use with the
+ * wp-env Playground runtime (which doesn't support `wp-env run`).
+ */
+
+defined( 'WPINC' ) || die();
+
+add_action( 'rest_api_init', 'wporg_env_register_api_routes' );
+
+function wporg_env_register_api_routes() {
+	register_rest_route(
+		'wporg-env/v1',
+		'/setup',
+		array(
+			'methods'             => 'POST',
+			'callback'            => 'wporg_env_api_setup',
+			'permission_callback' => 'wporg_env_api_permission_check',
+		)
+	);
+
+	register_rest_route(
+		'wporg-env/v1',
+		'/export-patterns',
+		array(
+			'methods'             => 'POST',
+			'callback'            => 'wporg_env_api_export_patterns',
+			'permission_callback' => 'wporg_env_api_permission_check',
+		)
+	);
+}
+
+function wporg_env_api_permission_check() {
+	return 'local' === wp_get_environment_type();
+}
+
+/**
+ * Setup the local environment: activate theme, set options, import content.
+ */
+function wporg_env_api_setup() {
+	$log = array();
+
+	// Activate theme.
+	switch_theme( 'wporg-main-2022' );
+	$log[] = 'Activated theme: wporg-main-2022';
+
+	// Set permalink structure.
+	global $wp_rewrite;
+	$wp_rewrite->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+	flush_rewrite_rules( true );
+	$log[] = 'Set permalink structure';
+
+	// Update options.
+	update_option( 'blogname', 'WordPress.org' );
+	update_option( 'blogdescription', 'Blog Tool, Publishing Platform, and CMS' );
+	update_option( 'show_on_front', 'page' );
+	$log[] = 'Updated site options';
+
+	// Import content from wordpress.org.
+	require_once ABSPATH . 'env/import-content-functions.php';
+
+	$urls = array(
+		'https://wordpress.org/wp-json/wp/v2/posts?context=wporg_export&per_page=50',
+		'https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&per_page=50',
+	);
+
+	foreach ( $urls as $url ) {
+		$result = wporg_env_import_rest_to_posts( $url );
+		$log    = array_merge( $log, $result );
+	}
+
+	// Set front page.
+	$home_page = get_posts(
+		array(
+			'post_type'      => 'page',
+			'name'           => 'home',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+
+	if ( ! empty( $home_page ) ) {
+		update_option( 'page_on_front', $home_page[0] );
+		$log[] = 'Front page set to ID: ' . $home_page[0];
+	}
+
+	return new WP_REST_Response( array( 'log' => $log ), 200 );
+}
+
+/**
+ * Export patterns from the page manifest.
+ *
+ * Accepts the manifest JSON as the request body.
+ * Returns an array of files with their paths and content.
+ */
+function wporg_env_api_export_patterns( $request ) {
+	require_once ABSPATH . 'env/export-content/includes/utils.php';
+
+	$manifest_items = json_decode( $request->get_body() );
+	if ( empty( $manifest_items ) ) {
+		return new WP_Error( 'invalid_manifest', 'Invalid or empty manifest JSON.', array( 'status' => 400 ) );
+	}
+
+	$rest_url = 'https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&slug=%s';
+	$files    = array();
+	$errors   = array();
+
+	foreach ( $manifest_items as $item ) {
+		if ( empty( $item->slug ) ) {
+			continue;
+		}
+
+		$pattern_filename  = $item->pattern ?? $item->slug . '.php';
+		$template_filename = $item->template ?? $item->slug . '.html';
+
+		try {
+			$pattern_content = wporg_env_generate_pattern_content( sprintf( $rest_url, $item->slug ) );
+			$files[]         = array(
+				'type'    => 'pattern',
+				'path'    => 'patterns/' . $pattern_filename,
+				'content' => $pattern_content,
+			);
+		} catch ( \Exception $e ) {
+			$errors[] = $item->slug . ': ' . $e->getMessage();
+		}
+
+		$template_content = wporg_env_generate_template_content( $item->slug );
+		$files[]          = array(
+			'type'    => 'template',
+			'path'    => 'templates/' . $template_filename,
+			'content' => $template_content,
+		);
+	}
+
+	return new WP_REST_Response(
+		array(
+			'files'  => $files,
+			'errors' => $errors,
+		),
+		empty( $errors ) ? 200 : 207
+	);
+}
+
+/**
+ * Generate pattern content from a REST API URL.
+ */
+function wporg_env_generate_pattern_content( $url ) {
+	$response    = wp_remote_get( $url );
+	$status_code = wp_remote_retrieve_response_code( $response );
+
+	if ( is_wp_error( $response ) ) {
+		throw new \Exception( $response->get_error_message() );
+	} elseif ( 200 !== $status_code ) {
+		throw new \Exception( "HTTP Error $status_code" );
+	}
+
+	$posts = json_decode( wp_remote_retrieve_body( $response ) );
+	$post  = $posts[0] ?? null;
+
+	if ( ! isset( $post->content_raw ) ) {
+		throw new \Exception( "No content_raw available at {$url}" );
+	}
+
+	$content = WordPress_org\Main_2022\ExportToPatterns\replace_with_i18n( $post->content_raw );
+
+	$header = "<?php\n/**\n * Title: {$post->title->rendered}\n * Slug: wporg-main-2022/{$post->slug}\n * Inserter: no\n */\n\n?>\n\n";
+
+	return $header . $content . "\n";
+}
+
+/**
+ * Generate template content for a pattern slug.
+ */
+function wporg_env_generate_template_content( $slug ) {
+	return <<<EOF
+<!-- wp:wporg/global-header {"style":"black-on-white"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-main-2022/{$slug}"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer {"style":"black-on-white"} /-->
+
+EOF;
+}

--- a/env/env-api.php
+++ b/env/env-api.php
@@ -165,7 +165,7 @@ function wporg_env_generate_pattern_content( $url ) {
 
 	$content = WordPress_org\Main_2022\ExportToPatterns\replace_with_i18n( $post->content_raw );
 
-	$header = "<?php\n/**\n * Title: {$post->title->rendered}\n * Slug: wporg-main-2022/{$post->slug}\n * Inserter: no\n */\n\n?>\n\n";
+	$header = "<?php\n/**\n * Title: {$post->title->rendered}\n * Slug: wporg-main-2022/{$post->slug}\n * Inserter: no\n */\n\n?>\n";
 
 	return $header . $content . "\n";
 }

--- a/env/import-content-functions.php
+++ b/env/import-content-functions.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Import content functions, shared between CLI script and REST API.
+ */
+
+/**
+ * Filter CURL requests to bypass sandboxes and always hit a production server.
+ */
+function wporg_env_filter_curl_options( $ch ) {
+	curl_setopt( $ch, CURLOPT_CONNECT_TO, array( 'wordpress.org::w.org:' ) );
+}
+
+/**
+ * Sanitize postmeta from the REST API for the format required by wp_insert_post.
+ */
+function wporg_env_sanitize_meta_input( $meta ) {
+	$meta = array( $meta );
+	foreach ( $meta as $k => $v ) {
+		if ( is_array( $v ) ) {
+			$meta[ $k ] = implode( ',', $v );
+		}
+	}
+	return $meta;
+}
+
+/**
+ * Import posts from a remote REST API to the local site.
+ *
+ * @param string $rest_url The remote REST API endpoint URL.
+ * @return array Log messages.
+ */
+function wporg_env_import_rest_to_posts( $rest_url ) {
+	$log = array();
+
+	add_action( 'http_api_curl', 'wporg_env_filter_curl_options' );
+
+	$response    = wp_remote_get( $rest_url, array( 'timeout' => 60 ) );
+	$status_code = wp_remote_retrieve_response_code( $response );
+
+	if ( is_wp_error( $response ) ) {
+		$log[] = 'Error: ' . $response->get_error_message();
+		return $log;
+	} elseif ( 200 !== $status_code ) {
+		$log[] = "Error: HTTP $status_code";
+		return $log;
+	}
+
+	$data = json_decode( wp_remote_retrieve_body( $response ) );
+
+	foreach ( $data as $post ) {
+		$new_post = array(
+			'import_id'      => $post->id,
+			'post_date'      => gmdate( 'Y-m-d H:i:s', strtotime( $post->date ) ),
+			'post_name'      => $post->slug,
+			'post_title'     => $post->title->rendered,
+			'post_status'    => $post->status,
+			'post_type'      => $post->type,
+			'post_content'   => ( $post->content_raw ?? $post->content->rendered ),
+			'post_excerpt'   => wp_strip_all_tags( $post->excerpt->rendered ),
+			'post_parent'    => $post->parent,
+			'comment_status' => $post->comment_status,
+			'meta_input'     => wporg_env_sanitize_meta_input( $post->meta ),
+		);
+
+		$existing_post = get_post( $post->id, ARRAY_A );
+
+		if ( $existing_post ) {
+			$new_post = array_merge( $existing_post, $new_post );
+			$log[]    = sprintf( 'Updating %s [%s]', html_entity_decode( $post->title->rendered ), $existing_post['ID'] );
+		} else {
+			$log[] = sprintf( 'Creating %s', html_entity_decode( $post->title->rendered ) );
+		}
+
+		$new_post_id = wp_insert_post( $new_post, true );
+
+		if ( is_wp_error( $new_post_id ) ) {
+			$log[] = 'Error: ' . $new_post_id->get_error_message();
+		} else {
+			$log[] = "Inserted {$post->type} {$post->id} as {$new_post_id}";
+		}
+	}
+
+	return $log;
+}

--- a/env/playground-mu-plugins/env-api.php
+++ b/env/playground-mu-plugins/env-api.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Loader for the environment REST API (Playground runtime).
+ *
+ * This file is mapped to wp-content/mu-plugins/ via .wp-env.playground.json.
+ * It loads the actual implementation from the env/ directory.
+ */
+if ( file_exists( ABSPATH . 'env/env-api.php' ) ) {
+	require_once ABSPATH . 'env/env-api.php';
+}

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -8,15 +8,13 @@ echo "Running setup via REST API ($WP_URL)..."
 
 # Wait for WordPress to be ready (Playground may need a moment).
 for i in $(seq 1 10); do
-	STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L "$WP_URL/?rest_route=/")
+	STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$WP_URL/?rest_route=/")
 	[ "$STATUS" = "200" ] && break
 	echo "Waiting for WordPress to be ready (attempt $i, status $STATUS)..."
-	# Debug: show redirect location
-	curl -s -o /dev/null -w "Redirect: %{redirect_url}\n" "$WP_URL/?rest_route=/"
 	sleep 2
 done
 
-RESPONSE=$(curl -s -w "\n%{http_code}" -L -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -6,13 +6,12 @@ WP_URL="${WP_ENV_URL:-http://localhost:8888}"
 
 echo "Running setup via REST API ($WP_URL)..."
 
-# Wait for WordPress to be ready (Playground may need a moment).
-for i in $(seq 1 10); do
-	STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$WP_URL/?rest_route=/")
-	[ "$STATUS" = "200" ] && break
-	echo "Waiting for WordPress to be ready (attempt $i, status $STATUS)..."
-	sleep 2
-done
+# Debug: check what WordPress returns.
+echo "Debug: REST root response:"
+curl -v "$WP_URL/?rest_route=/" 2>&1 | head -30
+echo ""
+echo "Debug: POST to setup endpoint:"
+curl -v -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup" 2>&1 | head -30
 
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -1,27 +1,18 @@
 #!/bin/bash
 
-root=$( dirname $( wp config path ) )
+# Setup the local WordPress environment via REST API.
 
-wp theme activate wporg-main-2022
+WP_URL="${WP_ENV_URL:-http://localhost:8888}"
 
-wp rewrite structure '/%year%/%monthnum%/%postname%/'
-wp rewrite flush --hard
+echo "Running setup via REST API ($WP_URL)..."
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
 
-wp option update blogname "WordPress.org"
-wp option update blogdescription "Blog Tool, Publishing Platform, and CMS"
-
-# wp import "${root}/env/data.xml" --authors=create
-
-wp option update show_on_front 'page'
-
-# Import content from WordPress.org
-# Note: setup.sh runs inside the container, so call php directly (not via wp-env).
-php env/import-content.php --url 'https://wordpress.org/wp-json/wp/v2/posts?context=wporg_export&per_page=50'
-php env/import-content.php --url 'https://wordpress.org/wp-json/wp/v2/pages?context=wporg_export&per_page=50'
-
-# Set front page after content is imported
-HOME_PAGE_ID=$(wp post list --post_type=page --name=home --posts_per_page=1 --field=ID --format=ids)
-if [ -n "$HOME_PAGE_ID" ]; then
-	wp option update page_on_front $HOME_PAGE_ID
-	echo "Front page set to ID: $HOME_PAGE_ID"
+if [ "$HTTP_CODE" != "200" ]; then
+	echo "Error: Setup endpoint returned HTTP $HTTP_CODE"
+	echo "$BODY"
+	exit 1
 fi
+
+echo "$BODY" | python3 -c "import sys,json; [print(l) for l in json.load(sys.stdin).get('log',[])]" 2>/dev/null || echo "$BODY"

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -7,7 +7,10 @@ COOKIE_JAR=$(mktemp)
 
 echo "Running setup via REST API ($WP_URL)..."
 
-RESPONSE=$(curl -s -w "\n%{http_code}" -L -b "$COOKIE_JAR" -c "$COOKIE_JAR" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
+# Pre-flight request to handle Playground auto-login redirect.
+curl -s -o /dev/null -L -b "$COOKIE_JAR" -c "$COOKIE_JAR" "$WP_URL/?rest_route=/"
+
+RESPONSE=$(curl -s -w "\n%{http_code}" -b "$COOKIE_JAR" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -8,13 +8,15 @@ echo "Running setup via REST API ($WP_URL)..."
 
 # Wait for WordPress to be ready (Playground may need a moment).
 for i in $(seq 1 10); do
-	STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$WP_URL/?rest_route=/")
+	STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L "$WP_URL/?rest_route=/")
 	[ "$STATUS" = "200" ] && break
 	echo "Waiting for WordPress to be ready (attempt $i, status $STATUS)..."
+	# Debug: show redirect location
+	curl -s -o /dev/null -w "Redirect: %{redirect_url}\n" "$WP_URL/?rest_route=/"
 	sleep 2
 done
 
-RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
+RESPONSE=$(curl -s -w "\n%{http_code}" -L -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -3,19 +3,15 @@
 # Setup the local WordPress environment via REST API.
 
 WP_URL="${WP_ENV_URL:-http://localhost:8888}"
+COOKIE_JAR=$(mktemp)
 
 echo "Running setup via REST API ($WP_URL)..."
 
-# Debug: check what WordPress returns.
-echo "Debug: REST root response:"
-curl -v "$WP_URL/?rest_route=/" 2>&1 | head -30
-echo ""
-echo "Debug: POST to setup endpoint:"
-curl -v -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup" 2>&1 | head -30
-
-RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
+RESPONSE=$(curl -s -w "\n%{http_code}" -L -b "$COOKIE_JAR" -c "$COOKIE_JAR" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
+
+rm -f "$COOKIE_JAR"
 
 if [ "$HTTP_CODE" != "200" ]; then
 	echo "Error: Setup endpoint returned HTTP $HTTP_CODE"

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -5,6 +5,15 @@
 WP_URL="${WP_ENV_URL:-http://localhost:8888}"
 
 echo "Running setup via REST API ($WP_URL)..."
+
+# Wait for WordPress to be ready (Playground may need a moment).
+for i in $(seq 1 10); do
+	STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$WP_URL/?rest_route=/")
+	[ "$STATUS" = "200" ] && break
+	echo "Waiting for WordPress to be ready (attempt $i, status $STATUS)..."
+	sleep 2
+done
+
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$WP_URL/?rest_route=/wporg-env/v1/setup")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"scripts": {
 		"setup:tools": "TEXTDOMAIN=wporg composer exec update-configs",
-		"setup:wp": "wp-env run cli bash env/setup.sh",
+		"setup:wp": "bash env/setup.sh",
 		"setup:refresh": "./env/refresh.sh",
 		"update:tools": "composer update && TEXTDOMAIN=wporg composer exec update-configs",
 		"wp-env": "wp-env",

--- a/source/wp-content/mu-plugins/env-api.php
+++ b/source/wp-content/mu-plugins/env-api.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Loader for the environment REST API.
+ *
+ * The actual implementation lives in env/env-api.php and is mapped via
+ * .wp-env.json file mapping for Docker. This loader ensures it also
+ * works when the mu-plugins directory is mapped as a whole (e.g. with
+ * the Playground runtime).
+ */
+if ( file_exists( ABSPATH . 'env/env-api.php' ) ) {
+	require_once ABSPATH . 'env/env-api.php';
+}


### PR DESCRIPTION
## Summary

Replaces `wp-env run cli` commands with REST API endpoints via a mu-plugin, and switches the content-update workflow to the wp-env Playground runtime (WebAssembly, no Docker).

### Changes
- `env/env-api.php` - mu-plugin with `/wporg-env/v1/setup` and `/wporg-env/v1/export-patterns` REST API endpoints
- `env/import-content-functions.php` - extracted import logic for REST API reuse
- `env/playground-mu-plugins/env-api.php` - loader for Playground runtime (avoids loading full wporg mu-plugins stack)
- `source/wp-content/mu-plugins/env-api.php` - loader for Docker runtime
- `env/setup.sh` and `env/build-patterns.sh` - rewritten to use `curl` against REST API
- `.wp-env.playground.json` - Playground-compatible config
- Workflow: skip puppeteer download, skip build, defer screenshots, use Playground runtime

### Timing comparison (content-update workflow, no content changes)

| Step | Trunk baseline | This PR |
|---|---|---|
| **Setup** | 2m23s | **1m22s** (-1m01s) |
| **Content update** | 1m52s | **1m00s** (-52s) |
| **Total** | **4m44s** | **2m28s** (-2m16s, **48% faster**) |

## Test plan

- [x] Tested locally: setup and export-patterns work via REST API on both Docker and Playground
- [x] CI: content-update workflow passes with Playground runtime ([run](https://github.com/WordPress/wporg-main-2022/actions/runs/22759563002))
- [x] Pattern output matches existing format (no whitespace diffs)
- [x] Screenshot steps correctly skipped when no changes

Builds on #645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)