### PR TITLE
Fix missing page_template during content import

### DIFF
--- a/env/import-content.php
+++ b/env/import-content.php
@@ -100,6 +100,7 @@ function import_rest_to_posts( $rest_url ) {
 			'post_excerpt' => wp_strip_all_tags( $post->excerpt->rendered ),
 			'post_parent' => $post->parent,
 			'comment_status' => $post->comment_status,
+			'page_template' => $post->template ?? '',
 			'meta_input' => sanitize_meta_input( $post->meta ),
 		);
 


### PR DESCRIPTION
## Summary

- The `import-content.php` script was not setting `page_template` from the REST API response when importing pages
- This caused WordPress to fall back to slug-based template resolution, resulting in wrong templates (e.g. `page-credits` instead of `page-education-credits` for the credits page under /education/)
- The `template` field is already available in the REST API response; it just was not being used

## Test plan

- Run `yarn wp-env run cli php env/import-content.php --url ...` to import pages
- Verify that pages like `/education/credits/` use the correct `page-education-credits` template instead of `page-credits`
- Verify that posts (which have no template field) import without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)