### PR TITLE
Handle page template errors during post insertion.

### DIFF
--- a/env/import-content.php
+++ b/env/import-content.php
@@ -122,6 +122,17 @@ function import_rest_to_posts( $rest_url ) {
 
 		$new_post_id = wp_insert_post( $new_post, true );
 
+		// If this theme doesn't support the template, wp_insert_post() will throw an error.
+		if ( is_wp_error( $new_post_id ) && 'invalid_page_template' === $new_post_id->get_error_code() ) {
+			unset( $new_post['page_template'] );
+			$new_post_id = wp_insert_post( $new_post, true );
+
+			// But we've probably got support through the older 'wporg-main' theme dynamically applied, so set it directly.
+			if ( ! is_wp_error( $new_post_id ) ) {
+				update_post_meta( $new_post_id, '_wp_page_template', $post->template ?? '' );
+			}
+		}
+		
 		if ( is_wp_error( $new_post_id ) ) {
 			throw new Exception( esc_html( $new_post_id->get_error_message() ) );
 		}


### PR DESCRIPTION
#657 fixed page creation, but failed to handle the case of creating a new page where the template isn't directly supported by this theme.

This resolves the environment throwing errors about trying to create the 40-percent-of-the-web page.