### PR TITLE
Support notranslate class to skip i18n wrapping in pattern export

### DIFF
--- a/env/export-content/includes/parser.php
+++ b/env/export-content/includes/parser.php
@@ -127,6 +127,11 @@ class BlockParser {
 	}
 
 	public function block_parser_to_strings( array $block ) : array {
+		// Skip blocks marked with 'notranslate' class — their content stays as plain HTML.
+		if ( ! empty( $block['attrs']['className'] ) && preg_match( '/\bnotranslate\b/', $block['attrs']['className'] ) ) {
+			return [];
+		}
+
 		$parser = $this->parsers[ $block['blockName'] ] ?? $this->fallback;
 
 		$strings = $parser->to_strings( $block );

--- a/env/export-content/tests/block-parser-test.php
+++ b/env/export-content/tests/block-parser-test.php
@@ -89,6 +89,26 @@ class BlockParser_Test extends WP_UnitTestCase {
 				"<!-- wp:paragraph {\"placeholder\":\"Type / to add a block\"} -->\n<p>Hello World</p>\n<!-- /wp:paragraph -->",
 				[ 'Hello World' ],
 			],
+			[
+				// Paragraph with notranslate class — strings should not be extracted.
+				"<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
+				[],
+			],
+			[
+				// Block with notranslate among other classes — strings should not be extracted.
+				"<!-- wp:paragraph {\"className\":\"is-style-serif notranslate\"} -->\n<p>5,425+</p>\n<!-- /wp:paragraph -->",
+				[],
+			],
+			[
+				// Table with notranslate class — all strings should be skipped.
+				"<!-- wp:table {\"className\":\"notranslate\"} -->\n<figure class=\"wp-block-table notranslate\"><table><thead><tr><th>Cookie</th></tr></thead><tbody><tr><th>devicePixelRatio</th></tr></tbody></table></figure>\n<!-- /wp:table -->",
+				[],
+			],
+			[
+				// Group with notranslate class — inner blocks should also be skipped.
+				"<!-- wp:group {\"className\":\"notranslate\"} -->\n<div class=\"wp-block-group notranslate\"><!-- wp:paragraph -->\n<p>Not translated</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+				[],
+			],
 		];
 	}
 
@@ -173,6 +193,16 @@ class BlockParser_Test extends WP_UnitTestCase {
 				// Paragraph with HTML and &amp; — _e with decoded ampersand.
 				"<!-- wp:paragraph -->\n<p>Read the <a href=\"https://example.com\">Terms &amp; Conditions</a>.</p>\n<!-- /wp:paragraph -->",
 				"<!-- wp:paragraph -->\n<p><?php _e( 'Read the <a href=\"https://example.com\">Terms & Conditions</a>.', 'wporg' ); ?></p>\n<!-- /wp:paragraph -->",
+			],
+			[
+				// Paragraph with notranslate class — content stays as plain HTML.
+				"<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
+				"<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
+			],
+			[
+				// Mixed: one paragraph translatable, one notranslate.
+				"<!-- wp:paragraph -->\n<p>Completed events</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
+				"<!-- wp:paragraph -->\n<p><?php esc_html_e( 'Completed events', 'wporg' ); ?></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

- Adds support for the `notranslate` CSS class on blocks to prevent their content from being wrapped in `esc_html_e()` / `_e()` during pattern export
- When a block has `notranslate` in its "Additional CSS class(es)" field, the block and all its inner blocks are skipped during string extraction — content stays as plain HTML
- The `notranslate` class was chosen for compatibility with Google Translate and other browser translation tools. In future, the HTML `translate="no"` attribute could also be supported.

**Note:** After merging, the WordPress editor content for the affected pages (cookie policy, education campus connect) will need the `notranslate` class added to the relevant blocks, then patterns regenerated.

Fixes https://meta.trac.wordpress.org/ticket/8213

## Test plan

- [x] All 38 existing + new unit tests pass
- [ ] Add `notranslate` class to a block in the editor, run `yarn build:patterns`, verify the block content is not wrapped in translation functions
- [ ] Verify blocks without the class are still wrapped normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)