### PR TITLE
Support notranslate class on inner HTML elements in pattern export

### DIFF
--- a/env/export-content/includes/parsers/BlockParser.php
+++ b/env/export-content/includes/parsers/BlockParser.php
@@ -105,7 +105,15 @@ trait TextNodesXPath {
 		'//*/@title', // title="" text.
 	];
 
+	/**
+	 * XPath predicate to exclude nodes inside elements with the 'notranslate' class.
+	 */
+	private $notranslate_exclude = '[not(ancestor-or-self::*[contains(concat(" ", @class, " "), " notranslate ")])]';
+
 	protected function text_nodes_xpath_query() {
-		return implode( ' | ', $this->xpaths );
+		return implode( ' | ', array_map(
+			fn( $xpath ) => $xpath . $this->notranslate_exclude,
+			$this->xpaths
+		) );
 	}
 }

--- a/env/export-content/tests/block-parser-test.php
+++ b/env/export-content/tests/block-parser-test.php
@@ -109,6 +109,11 @@ class BlockParser_Test extends WP_UnitTestCase {
 				"<!-- wp:group {\"className\":\"notranslate\"} -->\n<div class=\"wp-block-group notranslate\"><!-- wp:paragraph -->\n<p>Not translated</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
 				[],
 			],
+			[
+				// Table with notranslate on inner HTML elements (not block attributes) — those strings should be skipped.
+				"<!-- wp:table {\"align\":\"wide\",\"className\":\"is-style-stripes\"} -->\n<figure class=\"wp-block-table alignwide is-style-stripes\"><table><thead><tr><th>Cookie</th><th>Duration</th></tr></thead><tbody><tr><th class=\"notranslate\">devicePixelRatio</th><td>Browser default</td></tr><tr><th class=\"notranslate\">_ga</th><td>2 years</td></tr></tbody></table></figure>\n<!-- /wp:table -->",
+				[ 'Cookie', 'Duration', 'Browser default', '2 years' ],
+			],
 		];
 	}
 
@@ -203,6 +208,11 @@ class BlockParser_Test extends WP_UnitTestCase {
 				// Mixed: one paragraph translatable, one notranslate.
 				"<!-- wp:paragraph -->\n<p>Completed events</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
 				"<!-- wp:paragraph -->\n<p><?php esc_html_e( 'Completed events', 'wporg' ); ?></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"notranslate\"} -->\n<p>31</p>\n<!-- /wp:paragraph -->",
+			],
+			[
+				// Table with notranslate on inner HTML elements — cookie names stay as plain text.
+				"<!-- wp:table {\"align\":\"wide\"} -->\n<figure class=\"wp-block-table alignwide\"><table><thead><tr><th>Cookie</th><th>Duration</th></tr></thead><tbody><tr><th class=\"notranslate\">devicePixelRatio</th><td>Browser default</td></tr></tbody></table></figure>\n<!-- /wp:table -->",
+				"<!-- wp:table {\"align\":\"wide\"} -->\n<figure class=\"wp-block-table alignwide\"><table><thead><tr><th><?php esc_html_e( 'Cookie', 'wporg' ); ?></th><th><?php esc_html_e( 'Duration', 'wporg' ); ?></th></tr></thead><tbody><tr><th class=\"notranslate\">devicePixelRatio</th><td><?php esc_html_e( 'Browser default', 'wporg' ); ?></td></tr></tbody></table></figure>\n<!-- /wp:table -->",
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

Follow-up to #665. The previous `notranslate` support only checked block-level attributes (`$block["attrs"]["className"]`). This extends it to also respect `notranslate` on inner HTML elements (e.g. `<th class="notranslate">devicePixelRatio</th>`) by adding an XPath ancestor check to the `TextNodesXPath` trait.

- Adds an XPath predicate to exclude text nodes inside elements with `notranslate` class
- Fixes cookie name strings (e.g. `devicePixelRatio`, `_ga`) in the privacy/cookies page being incorrectly wrapped in translation functions
- Adds test cases for both string extraction and i18n replacement with HTML-level notranslate

## Test plan
- [ ] Run `vendor/bin/phpunit` — all 40 tests pass
- [ ] Run `build:patterns` and verify cookie names in `about-privacy-cookies.php` are not wrapped in `esc_html_e()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)