### PR TITLE
Fix PHPCS multi-line function call formatting in BlockParser

### DIFF
--- a/env/export-content/includes/parsers/BlockParser.php
+++ b/env/export-content/includes/parsers/BlockParser.php
@@ -111,9 +111,11 @@ trait TextNodesXPath {
 	private $notranslate_exclude = '[not(ancestor-or-self::*[contains(concat(" ", @class, " "), " notranslate ")])]';
 
 	protected function text_nodes_xpath_query() {
-		return implode( ' | ', array_map(
+		$xpaths = array_map(
 			fn( $xpath ) => $xpath . $this->notranslate_exclude,
 			$this->xpaths
-		) );
+		);
+
+		return implode( ' | ', $xpaths );
 	}
 }


### PR DESCRIPTION
## Summary
- Extracts `array_map()` result into a variable to fix PEAR.Functions.FunctionCallSignature PHPCS violations introduced in #670
- Fixes 3 errors: opening parenthesis content, multiple arguments per line, and closing parenthesis placement

## Test plan
- [ ] Verify CI lint job passes
- [ ] Verify export-content tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)