### PR TITLE
Refresh /about/requirements: three-column cards, warning callout, CTAs

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/about-requirements.php
@@ -12,50 +12,86 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php esc_html_e( 'To run WordPress, it’s recommended your host supports:', 'wporg' ); ?></p>
+<p><?php esc_html_e( 'To run WordPress, we recommend your host supports the following — a safe, modern baseline for performance and security.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li><?php
-/* translators: [recommended_php] is a shortcode and should not be translated. */
-_e( '<a href="https://www.php.net/">PHP</a> version [recommended_php] or greater.', 'wporg' );
-?></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><?php
-/* translators: [recommended_mariadb], [recommended_mysql] are shortcodes and should not be translated. */
-_e( '<a href="https://mariadb.org/">MariaDB</a> version [recommended_mariadb] or greater OR <a href="https://www.mysql.com/">MySQL</a> version [recommended_mysql] or greater.', 'wporg' );
-?></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><?php _e( '<a href="https://wordpress.org/news/2016/12/moving-toward-ssl/">HTTPS</a> support.', 'wporg' ); ?></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->
+<!-- wp:columns {"verticalAlignment":"stretch","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":{"left":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-columns are-vertically-aligned-stretch" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)"><!-- wp:column {"verticalAlignment":"stretch","backgroundColor":"light-grey-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}},"border":{"radius":"8px","top":{"color":"var:preset|color|blueberry-1","width":"3px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-stretch has-light-grey-2-background-color has-background" style="border-top-color:var(--wp--preset--color--blueberry-1);border-top-width:3px;border-radius:8px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|20"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'PHP', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'That’s really it. <a href="https://httpd.apache.org/">Apache</a> or <a href="https://nginx.org/">Nginx</a> is recommended as the most robust and featureful server for running WordPress, but any server that supports PHP and MySQL will do. That said, for the smoothest experience in setting up—and running—your site, <a href="https://wordpress.org/hosting/">each host on the hosting page</a> supports the above and more with no problems.', 'wporg' ); ?></p>
+<p><?php
+/* translators: [recommended_php] is a shortcode and should not be translated. */
+_e( 'Version <strong>[recommended_php]</strong> or greater.', 'wporg' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php _e( 'Powers WordPress on your server. <a href="https://www.php.net/">Learn more →</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"stretch","backgroundColor":"light-grey-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}},"border":{"radius":"8px","top":{"color":"var:preset|color|blueberry-1","width":"3px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-stretch has-light-grey-2-background-color has-background" style="border-top-color:var(--wp--preset--color--blueberry-1);border-top-width:3px;border-radius:8px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|20"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'Database', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php
+/* translators: [recommended_mariadb], [recommended_mysql] are shortcodes and should not be translated. */
+_e( 'MariaDB <strong>[recommended_mariadb]</strong>+ or MySQL <strong>[recommended_mysql]</strong>+.', 'wporg' );
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php _e( 'Stores your content and settings. <a href="https://mariadb.org/">MariaDB</a> · <a href="https://www.mysql.com/">MySQL</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"stretch","backgroundColor":"light-grey-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}},"border":{"radius":"8px","top":{"color":"var:preset|color|blueberry-1","width":"3px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-stretch has-light-grey-2-background-color has-background" style="border-top-color:var(--wp--preset--color--blueberry-1);border-top-width:3px;border-radius:8px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|20"}}}} -->
+<h3 class="wp-block-heading" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'HTTPS', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'Required for every install.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php _e( 'Encrypts your site’s connection. <a href="https://wordpress.org/news/2016/12/moving-toward-ssl/">Why HTTPS matters →</a>', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'That’s really it. <a href="https://httpd.apache.org/">Apache</a> or <a href="https://nginx.org/">Nginx</a> is recommended as the most robust and featureful server for running WordPress, but any server that supports PHP and MySQL will do. For the smoothest experience setting up — and running — your site, <a href="https://wordpress.org/hosting/">each host on the hosting page</a> supports the above and more with no problems.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p><?php _e( 'For detailed PHP extension recommendations, see the <a href="https://make.wordpress.org/hosting/handbook/handbook/server-environment/">Hosting Handbook</a>.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
+<!-- wp:group {"backgroundColor":"lemon-3","textColor":"charcoal-1","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"radius":"8px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-charcoal-1-color has-lemon-3-background-color has-text-color has-background" style="border-radius:8px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":4,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|20"}}}} -->
+<h4 class="wp-block-heading" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'Running on legacy versions?', 'wporg' ); ?></h4>
+<!-- /wp:heading -->
+
 <!-- wp:paragraph -->
 <p><?php
 /* translators: [minimum_php] is a shortcode and should not be translated. */
-_e( 'Note: If you are in a legacy environment where you only have older PHP or MySQL versions, WordPress also works with PHP [minimum_php]+ and MySQL 5.5.5+. However, these versions have reached their official End Of Life and <strong>may expose your site to security vulnerabilities</strong>.', 'wporg' );
+_e( 'WordPress will still run on PHP [minimum_php]+ and MySQL 5.5.5+, but those versions have reached official End Of Life and <strong>may expose your site to security vulnerabilities</strong>. Upgrading is strongly recommended.', 'wporg' );
 ?></p>
-<!-- /wp:paragraph -->
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:heading -->
 <h2 class="wp-block-heading"><?php esc_html_e( 'Ask your host to run WordPress', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php esc_html_e( 'If you’re unsure whether or not your host can already run WordPress, here’s a request you can copy and paste to send them!', 'wporg' ); ?></p>
+<p><?php esc_html_e( 'If you’re unsure whether your host can already run WordPress, here’s a request you can copy and send them:', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:quote {"backgroundColor":"white","textColor":"charcoal-4","fontSize":"normal","fontFamily":"inter"} -->
@@ -98,5 +134,15 @@ esc_html_e( 'MariaDB version [recommended_mariadb] or greater OR MySQL version [
 
 <!-- wp:paragraph -->
 <p><?php esc_html_e( 'Hosting is more secure when PHP applications, like WordPress, are run using your account’s username instead of the server’s default shared username. Ask your potential host what steps they take to ensure the security of your account.', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)"><!-- wp:button {"backgroundColor":"blueberry-1","textColor":"white"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-white-color has-blueberry-1-background-color has-text-color has-background wp-element-button" href="https://wordpress.org/download/"><?php esc_html_e( 'Download WordPress', 'wporg' ); ?></a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://wordpress.org/hosting/"><?php esc_html_e( 'Browse recommended hosts', 'wporg' ); ?></a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Refreshes the `/about/requirements` page with a cleaner layout, a proper warning callout, and clear next-step CTAs. Content-only changes to the `about-requirements.php` block pattern — no template, function, or shortcode logic touched.

- Convert the three core requirements (PHP, Database, HTTPS) from a bulleted list into a three-column card layout with equal heights and a `blueberry-1` top accent.
- Promote the legacy-version security note into a `lemon-3` warning callout with an H4 heading ("Running on legacy versions?") so the security risk reads as a warning rather than body text — consistent with the yellow warning convention used across wp-admin.
- Add a button pair at the bottom: "Download WordPress" (primary) and "Browse recommended hosts" (outlined), so readers have clear next steps after understanding the requirements.

All shortcodes (`[recommended_php]`, `[recommended_mariadb]`, `[recommended_mysql]`, `[minimum_php]`) preserved. Translator comments and i18n calls preserved. No functional changes — visual/content polish only.

### Screenshots

| Before | After |
|--------|-------|
| <img width="637" height="312" alt="Before" src="https://github.com/user-attachments/assets/3f93fa37-164f-4fab-9f1a-a87ce08185d2" /> | <img width="663" height="824" alt="After" src="https://github.com/user-attachments/assets/940417a2-9abc-49f5-a4ff-1d44686cb9ef" /> |

### How to test the changes in this Pull Request:

1. Check out this branch (`mary/refresh-about-requirements`) in a local `wporg-main-2022` environment
2. Run `yarn wp-env start` and visit http://localhost:8888/about/requirements/
3. Verify:
   - The three requirement cards (PHP, Database, HTTPS) render side-by-side with equal heights and a thin blueberry-blue line across the top of each
   - The legacy-version note appears on a soft-yellow background as a distinct warning callout with an H4 heading
   - Two buttons appear at the bottom of the page: a filled blueberry "Download WordPress" primary and an outlined "Browse recommended hosts" secondary
   - All version numbers (PHP 8.3, MariaDB 10.6, MySQL 8.0) still populate from the shortcodes and match the source of truth