### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write # Required to clone the repo and push to the build branch.
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,15 @@ concurrency:
   group: build
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to clone the repo and push to the build branch.
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -15,14 +15,17 @@ concurrency:
   group: content-update
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   content-update:
     if: github.repository_owner == 'WordPress'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to clone the repo and push the branches.
+      pull-requests: write # Required to create a PR and comment on it.
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -23,6 +23,7 @@ jobs:
   content-update:
     if: github.repository_owner == 'WordPress'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write      # Required to clone the repo and push the branches.
       pull-requests: write # Required to create a PR and comment on it.

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -9,10 +9,16 @@ concurrency:
   group: i18n
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   translation-strings:
     if: github.repository_owner == 'WordPress'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to clone the repo and push to trunk.
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -17,6 +17,7 @@ jobs:
   translation-strings:
     if: github.repository_owner == 'WordPress'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write # Required to clone the repo and push to trunk.
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,9 +6,15 @@ on:
     branches: [trunk]
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,11 +6,17 @@ on:
     branches: [trunk]
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   check:
     name: Test PHP
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,6 +15,7 @@ jobs:
     name: Test PHP
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
 


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a 20 minute timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wporg-main-2022/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes