### PR TITLE
Skip page-in-progress template when importing content locally

### DIFF
--- a/env/import-content.php
+++ b/env/import-content.php
@@ -87,6 +87,13 @@ function import_rest_to_posts( $rest_url ) {
 	foreach ( $data as $post ) {
 		echo "Got {$post->type} {$post->id} {$post->slug}\n";
 
+		// The live site hides unfinished pages behind the page-in-progress template;
+		// locally we want to see the real content, so fall back to the default template.
+		$template = $post->template ?? '';
+		if ( 'page-in-progress' === $template ) {
+			$template = '';
+		}
+
 		// Surely there's a neater way to do this.
 		$new_post = array(
 			'import_id' => $post->id,
@@ -100,7 +107,7 @@ function import_rest_to_posts( $rest_url ) {
 			'post_excerpt' => wp_strip_all_tags( $post->excerpt->rendered ),
 			'post_parent' => $post->parent,
 			'comment_status' => $post->comment_status,
-			'page_template' => $post->template ?? '',
+			'page_template' => $template,
 			'meta_input' => sanitize_meta_input( $post->meta ),
 		);
 
@@ -129,7 +136,7 @@ function import_rest_to_posts( $rest_url ) {
 
 			// But we've probably got support through the older 'wporg-main' theme dynamically applied, so set it directly.
 			if ( ! is_wp_error( $new_post_id ) ) {
-				update_post_meta( $new_post_id, '_wp_page_template', $post->template ?? '' );
+				update_post_meta( $new_post_id, '_wp_page_template', $template );
 			}
 		}
 


### PR DESCRIPTION
The live site uses the `page-in-progress` template to hide pages that are not yet ready for public viewing. When `env/import-content.php` pulled those pages into a local dev environment, the same template was applied locally — hiding the real content behind a placeholder and making it hard to work on those pages.

## Summary

- Drop the `page-in-progress` template during import and fall back to the default page template, so the actual post content is rendered locally.
- Apply the same fallback to the `_wp_page_template` post meta path that runs when `wp_insert_post` rejects the original template.

## Test plan

- [ ] Run the importer against a wordpress.org URL that includes a page using the `page-in-progress` template (e.g. an unfinished release landing page).
- [ ] Confirm the imported page renders its actual content locally rather than the in-progress placeholder.
- [ ] Confirm pages using other templates still import with their original template intact.

Generated with [Claude Code](https://claude.com/claude-code)