### PR TITLE
Disable the Site Editor for this theme

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/functions.php
+++ b/source/wp-content/themes/wporg-main-2022/functions.php
@@ -7,6 +7,7 @@ use function WordPressdotorg\MU_Plugins\Global_Header_Footer\is_rosetta_site;
 require_once __DIR__ . '/inc/page-meta-descriptions.php';
 require_once __DIR__ . '/inc/hreflang.php';
 require_once __DIR__ . '/inc/capabilities.php';
+require_once __DIR__ . '/inc/disable-site-editor.php';
 require_once __DIR__ . '/inc/data-liberation-handbook.php';
 require_once __DIR__ . '/inc/recaptcha.php';
 require_once __DIR__ . '/inc/privacy-functions.php';

--- a/source/wp-content/themes/wporg-main-2022/inc/disable-site-editor.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/disable-site-editor.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace WordPressdotorg\Theme\Main_2022;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Disable the Site Editor for this theme.
+ *
+ * Templates and template parts for this site are managed as files in the theme
+ * (and via the content-update pipeline), not in the database. Editing them in the
+ * Site Editor creates database overrides that diverge from the source files and can
+ * silently break the automated content export (e.g. emptying a page's content when it
+ * is moved onto a Site Editor template). To prevent that, the Site Editor is disabled.
+ *
+ * Note: super admins bypass normal capability checks, so simply hiding the menu or
+ * relying on `current_user_can()` is not enough. The redirect and REST guards below
+ * return regardless of the current user, and the capability mapping uses `do_not_allow`,
+ * which is the one primitive cap a super admin is still denied.
+ */
+
+/**
+ * Actions and filters.
+ */
+add_action( 'admin_menu', __NAMESPACE__ . '\remove_site_editor_menu', 999 );
+add_action( 'admin_bar_menu', __NAMESPACE__ . '\remove_site_editor_admin_bar', 999 );
+add_action( 'admin_init', __NAMESPACE__ . '\block_site_editor_screen' );
+add_filter( 'map_meta_cap', __NAMESPACE__ . '\block_template_editing_caps', 10, 4 );
+add_filter( 'rest_request_before_callbacks', __NAMESPACE__ . '\block_template_rest_writes', 10, 3 );
+
+/**
+ * Remove the "Editor" (Site Editor) item from the Appearance menu.
+ */
+function remove_site_editor_menu() {
+	remove_submenu_page( 'themes.php', 'site-editor.php' );
+}
+
+/**
+ * Remove the "Edit site" link from the admin bar.
+ *
+ * @param \WP_Admin_Bar $wp_admin_bar The admin bar instance.
+ */
+function remove_site_editor_admin_bar( $wp_admin_bar ) {
+	$wp_admin_bar->remove_node( 'site-editor' );
+}
+
+/**
+ * Block direct access to the Site Editor screen.
+ *
+ * This fires for every request to `site-editor.php` regardless of the current user,
+ * so it also stops super admins and the post editor's "Edit template" deep links.
+ */
+function block_site_editor_screen() {
+	global $pagenow;
+
+	if ( 'site-editor.php' === $pagenow ) {
+		wp_safe_redirect( admin_url() );
+		exit;
+	}
+}
+
+/**
+ * Deny the capabilities to edit or delete existing templates and template parts.
+ *
+ * Returning `do_not_allow` is the only way to deny these caps for a super admin, who
+ * would otherwise pass any `current_user_can()` check.
+ *
+ * @param string[] $required_caps The mapped primitive capabilities.
+ * @param string   $cap           The requested meta capability.
+ * @param int      $user_id       The user ID.
+ * @param array    $args          Context, where `$args[0]` is usually the object ID.
+ *
+ * @return string[]
+ */
+function block_template_editing_caps( $required_caps, $cap, $user_id, $args ) {
+	$object_meta_caps = array( 'edit_post', 'delete_post', 'publish_post' );
+
+	if ( in_array( $cap, $object_meta_caps, true ) && ! empty( $args[0] ) ) {
+		$post = get_post( $args[0] );
+		if ( $post && in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
+			return array( 'do_not_allow' );
+		}
+	}
+
+	return $required_caps;
+}
+
+/**
+ * Block REST writes to the templates and template-parts endpoints.
+ *
+ * The Site Editor saves entirely through these endpoints, so this stops template changes
+ * even if the editor UI is reached some other way. It returns a `WP_Error` directly, which
+ * applies to every user including super admins. Reads (GET) are left alone.
+ *
+ * @param mixed            $response The current response, possibly a WP_Error from an earlier filter.
+ * @param array            $handler  The matched route handler.
+ * @param \WP_REST_Request $request  The request being dispatched.
+ *
+ * @return mixed
+ */
+function block_template_rest_writes( $response, $handler, $request ) {
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	if ( ! in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true ) ) {
+		return $response;
+	}
+
+	if ( preg_match( '#/wp/v2/(templates|template-parts)(/|$)#', $request->get_route() ) ) {
+		return new \WP_Error(
+			'rest_forbidden',
+			__( 'Editing templates is disabled. Templates are managed in the theme files.', 'wporg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	return $response;
+}

--- a/source/wp-content/themes/wporg-main-2022/inc/disable-site-editor.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/disable-site-editor.php
@@ -110,7 +110,7 @@ function block_template_rest_writes( $response, $handler, $request ) {
 	if ( preg_match( '#/wp/v2/(templates|template-parts)(/|$)#', $request->get_route() ) ) {
 		return new \WP_Error(
 			'rest_forbidden',
-			__( 'Editing templates is disabled. Templates are managed in the theme files.', 'wporg' ),
+			'Editing templates is disabled. Templates are managed in the theme files.',
 			array( 'status' => rest_authorization_required_code() )
 		);
 	}

--- a/source/wp-content/themes/wporg-main-2022/inc/disable-site-editor.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/disable-site-editor.php
@@ -26,7 +26,7 @@ add_action( 'admin_menu', __NAMESPACE__ . '\remove_site_editor_menu', 999 );
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\remove_site_editor_admin_bar', 999 );
 add_action( 'admin_init', __NAMESPACE__ . '\block_site_editor_screen' );
 add_filter( 'map_meta_cap', __NAMESPACE__ . '\block_template_editing_caps', 10, 4 );
-add_filter( 'rest_request_before_callbacks', __NAMESPACE__ . '\block_template_rest_writes', 10, 3 );
+add_filter( 'rest_pre_dispatch', __NAMESPACE__ . '\block_template_rest_writes', 10, 3 );
 
 /**
  * Remove the "Editor" (Site Editor) item from the Appearance menu.
@@ -89,22 +89,23 @@ function block_template_editing_caps( $required_caps, $cap, $user_id, $args ) {
  * Block REST writes to the templates and template-parts endpoints.
  *
  * The Site Editor saves entirely through these endpoints, so this stops template changes
- * even if the editor UI is reached some other way. It returns a `WP_Error` directly, which
+ * even if the editor UI is reached some other way. Hooked on `rest_pre_dispatch` so it runs
+ * before route matching and parameter validation, it returns a `WP_Error` directly, which
  * applies to every user including super admins. Reads (GET) are left alone.
  *
- * @param mixed            $response The current response, possibly a WP_Error from an earlier filter.
- * @param array            $handler  The matched route handler.
- * @param \WP_REST_Request $request  The request being dispatched.
+ * @param mixed            $result  Response to short-circuit with, or null to continue dispatch.
+ * @param \WP_REST_Server  $server  The REST server instance.
+ * @param \WP_REST_Request $request The request being dispatched.
  *
  * @return mixed
  */
-function block_template_rest_writes( $response, $handler, $request ) {
-	if ( is_wp_error( $response ) ) {
-		return $response;
+function block_template_rest_writes( $result, $server, $request ) {
+	if ( null !== $result ) {
+		return $result;
 	}
 
 	if ( ! in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true ) ) {
-		return $response;
+		return $result;
 	}
 
 	if ( preg_match( '#/wp/v2/(templates|template-parts)(/|$)#', $request->get_route() ) ) {
@@ -115,5 +116,5 @@ function block_template_rest_writes( $response, $handler, $request ) {
 		);
 	}
 
-	return $response;
+	return $result;
 }


### PR DESCRIPTION
Templates and template parts for this site are managed as files in the theme (and synced via the content-update pipeline), not in the database. Editing them in the Site Editor creates database overrides that diverge from the source files.

This recently caused a real problem: the WordPress Campus Connect, Credits, and Student Clubs education pages were moved onto Site Editor templates (`education-*-new`), which emptied their `post_content`. The content-update export then read that empty content and generated [#699](https://github.com/WordPress/wporg-main-2022/pull/699), which strips those three patterns down to empty stubs.

## What this does

Disables the Site Editor for **everyone, including super admins**. Super admins bypass normal `current_user_can()` checks for every capability except those mapped to `do_not_allow`, so hiding the menu is not enough on its own. The guards that actually enforce the block are user-independent:

| Hook | Effect |
| --- | --- |
| `admin_menu` | Removes Appearance -> Editor |
| `admin_bar_menu` | Removes the "Edit site" admin-bar node |
| `admin_init` | Redirects any request to `site-editor.php` to the dashboard (also catches the post editor "Edit template" deep links) |
| `map_meta_cap` | Maps edit/delete/publish on `wp_template` / `wp_template_part` to `do_not_allow` (the one cap a super admin is still denied) |
| `rest_request_before_callbacks` | Returns `WP_Error` for write methods to `/wp/v2/templates` and `/wp/v2/template-parts` (the Site Editor saves entirely via REST) |

Reads (GET) and assigning an existing file-based template to a page (a page-meta change via the pages endpoint) are left alone, so legitimate editing and the content-update pipeline are unaffected. Only creating/editing database template overrides is blocked.

## Testing

- `php -l`: clean.
- phpcs (WordPress.org Meta standard): clean on the changed files.

Note: the repo bumped to PHP 8.4 in d02f76b, under which the bundled WPCS sniffs abort with an internal `Implicitly marking parameter ... nullable is deprecated` error on all existing files; running phpcs with `-d error_reporting="E_ALL & ~E_DEPRECATED"` lets it complete and the changed files pass with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)