### PR TITLE
Add Playground CLI boot path

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "node_modules/@wp-playground/blueprints/blueprint-schema.json",
+	"landingPage": "/",
+	"preferredVersions": {
+		"php": "8.4",
+		"wp": "latest"
+	},
+	"features": {
+		"intl": true,
+		"networking": true
+	},
+	"login": true,
+	"siteOptions": {
+		"blogname": "WordPress.org Local",
+		"blogdescription": "Blog Tool, Publishing Platform, and CMS"
+	},
+	"steps": [
+		{
+			"step": "defineWpConfigConsts",
+			"consts": {
+				"WP_DEBUG": true,
+				"SCRIPT_DEBUG": true,
+				"WP_DEBUG_LOG": true,
+				"FS_METHOD": "direct",
+				"WP_ENVIRONMENT_TYPE": "local",
+				"JETPACK_DEV_DEBUG": true,
+				"WPORG_SANDBOXED": true,
+				"WP_MARKET_SHARE": 43
+			}
+		},
+		{
+			"step": "writeFile",
+			"path": "/internal/shared/mu-plugins/wporg-playground-rewrite-local-links.php",
+			"data": "<?php function wporg_playground_rewrite_local_links() { if ( is_admin() || wp_is_json_request() || wp_doing_ajax() ) { return; } ob_start( 'wporg_playground_rewrite_local_link_attributes' ); } add_action( 'template_redirect', 'wporg_playground_rewrite_local_links' ); function wporg_playground_rewrite_local_link_attributes( $buffer ) { $local_home = untrailingslashit( home_url( '/' ) ); return preg_replace_callback( '#\\b(href|action)=([\"\\'])https?://wordpress\\.org(/[^\"\\']*)?\\2#i', function( $matches ) use ( $local_home ) { $path = $matches[3] ?? '/'; return sprintf( '%s=%s%s%s', $matches[1], $matches[2], esc_url( $local_home . $path ), $matches[2] ); }, $buffer ); }"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php\nrequire_once '/wordpress/env/playground-setup.php';\n"
+		}
+	]
+}

--- a/env/playground-setup.php
+++ b/env/playground-setup.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Bootstrap a usable local site for WordPress Playground CLI.
+ */
+
+require_once '/wordpress/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$playground_plugins = array(
+	'block-visibility/block-visibility.php',
+	'gutenberg/gutenberg.php',
+	'handbook/handbook.php',
+	'jetpack/jetpack.php',
+	'wordpress-importer/wordpress-importer.php',
+	'wporg-markdown/plugin.php',
+);
+
+foreach ( $playground_plugins as $playground_plugin ) {
+	if ( file_exists( WP_PLUGIN_DIR . '/' . $playground_plugin ) && ! is_plugin_active( $playground_plugin ) ) {
+		activate_plugin( $playground_plugin, '', false, true );
+	}
+}
+
+$theme = wp_get_theme( 'wporg-main-2022' );
+if ( $theme->exists() && ! $theme->errors() ) {
+	switch_theme( 'wporg-main-2022' );
+}
+
+update_option( 'blogname', 'WordPress.org Local' );
+update_option( 'blogdescription', 'Blog Tool, Publishing Platform, and CMS' );
+update_option( 'permalink_structure', '/%year%/%monthnum%/%postname%/' );
+
+$manifest = json_decode( file_get_contents( '/wordpress/env/page-manifest.json' ), true );
+$known_slugs = array_column( $manifest, 'slug' );
+$prefix_to_path = function( $prefix ) use ( $known_slugs ) {
+	$prefix_path = array();
+
+	while ( $prefix ) {
+		$matched_slug = '';
+
+		foreach ( $known_slugs as $slug ) {
+			if ( $prefix === $slug || str_starts_with( $prefix, $slug . '-' ) ) {
+				if ( strlen( $slug ) > strlen( $matched_slug ) ) {
+					$matched_slug = $slug;
+				}
+			}
+		}
+
+		if ( ! $matched_slug ) {
+			return str_replace( '-', '/', $prefix );
+		}
+
+		$prefix_path[] = $matched_slug;
+		$prefix = ltrim( substr( $prefix, strlen( $matched_slug ) ), '-' );
+	}
+
+	return implode( '/', $prefix_path );
+};
+$playground_pages = array();
+foreach ( $manifest as $manifest_page ) {
+	$playground_path = $manifest_page['slug'];
+
+	if ( ! empty( $manifest_page['pattern'] ) ) {
+		$pattern_slug = preg_replace( '/\.php$/', '', $manifest_page['pattern'] );
+		$suffix       = '-' . $manifest_page['slug'];
+		$prefix       = str_ends_with( $pattern_slug, $suffix ) ? substr( $pattern_slug, 0, -strlen( $suffix ) ) : $pattern_slug;
+
+		if ( $prefix && $prefix !== $pattern_slug ) {
+			$playground_path = $prefix_to_path( $prefix ) . '/' . $manifest_page['slug'];
+		}
+	}
+
+	$playground_pages[ $playground_path ] = array(
+		'title'    => ucwords( str_replace( '-', ' ', $manifest_page['slug'] ) ),
+		'template' => ! empty( $manifest_page['template'] ) && 'front-page.html' !== $manifest_page['template'] ? preg_replace( '/\.html$/', '', $manifest_page['template'] ) : '',
+	);
+}
+
+$page_ids = array();
+
+foreach ( $playground_pages as $playground_path => $playground_page ) {
+	$parts       = explode( '/', $playground_path );
+	$slug        = array_pop( $parts );
+	$parent_path = implode( '/', $parts );
+	$parent_id   = $parent_path && isset( $page_ids[ $parent_path ] ) ? $page_ids[ $parent_path ] : 0;
+	$existing    = get_page_by_path( $playground_path );
+
+	if ( $existing ) {
+		$page_id = $existing->ID;
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_title'  => $playground_page['title'],
+				'post_parent' => $parent_id,
+			)
+		);
+	} else {
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => $playground_page['title'],
+				'post_status' => 'publish',
+				'post_name'   => $slug,
+				'post_parent' => $parent_id,
+			)
+		);
+	}
+
+	if ( ! is_wp_error( $page_id ) ) {
+		$page_ids[ $playground_path ] = $page_id;
+
+		if ( ! empty( $playground_page['template'] ) ) {
+			update_post_meta( $page_id, '_wp_page_template', $playground_page['template'] );
+		}
+	}
+}
+
+if ( ! empty( $page_ids['home'] ) ) {
+	update_option( 'page_on_front', $page_ids['home'] );
+	update_option( 'show_on_front', 'page' );
+}
+
+flush_rewrite_rules();

--- a/env/playground-start.mjs
+++ b/env/playground-start.mjs
@@ -1,0 +1,83 @@
+import { spawn } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cwd = process.cwd();
+const scriptDir = dirname( fileURLToPath( import.meta.url ) );
+const wpEnv = JSON.parse( readFileSync( join( cwd, '.wp-env.json' ), 'utf8' ) );
+const themeDir = './source/wp-content/themes/wporg-main-2022';
+const sourceDir = join( cwd, themeDir, 'src' );
+
+const requiredPaths = [
+	'./source/wp-content/mu-plugins/pub',
+	'./source/wp-content/mu-plugins/wporg-mu-plugins',
+	...wpEnv.plugins,
+	...wpEnv.themes,
+	...readdirSync( sourceDir, { withFileTypes: true } )
+		.filter( ( entry ) => entry.isDirectory() )
+		.filter( ( entry ) => existsSync( join( sourceDir, entry.name, 'index.php' ) ) )
+		.map( ( entry ) => `${ themeDir }/build/${ entry.name }/block.json` ),
+	`${ themeDir }/build/rosetta/style-index.css`,
+	`${ themeDir }/build/style/style-index.css`,
+].map( ( path ) => path.replace( /^\.\//, './' ) );
+
+const missingPaths = requiredPaths.filter( ( path ) => ! existsSync( join( cwd, path ) ) );
+
+if ( missingPaths.length ) {
+	console.error(
+		[
+			'Cannot start WordPress Playground because required local dependencies are missing.',
+			'',
+			'Run the project dependency setup first:',
+			'  yarn',
+			'  composer install',
+			'  yarn setup:tools',
+			'  yarn build:theme',
+			'',
+			'Missing paths:',
+			...missingPaths.map( ( path ) => `  - ${ path }` ),
+		].join( '\n' )
+	);
+	process.exit( 1 );
+}
+
+const mountIfExists = ( hostPath, runtimePath, args ) => {
+	if ( existsSync( join( cwd, hostPath ) ) ) {
+		args.push( `--mount=${ hostPath }:${ runtimePath }` );
+		return true;
+	}
+
+	return false;
+};
+
+const args = [
+	'@wp-playground/cli',
+	'start',
+	'--noAutoMount',
+];
+
+Object.entries( wpEnv.mappings ).forEach( ( [ runtimePath, hostPath ] ) => {
+	mountIfExists( hostPath, `/wordpress/${ runtimePath }`, args );
+} );
+mountIfExists( './source/wp-content/plugins', '/wordpress/wp-content/plugins', args );
+mountIfExists( './source/wp-content/themes', '/wordpress/wp-content/themes', args );
+
+args.push(
+	`--blueprint=${ join( scriptDir, '../blueprint.json' ) }`,
+	...process.argv.slice( 2 )
+);
+
+const child = spawn( 'npx', args, {
+	cwd,
+	stdio: 'inherit',
+} );
+
+child.on( 'exit', ( code, signal ) => {
+	if ( signal ) {
+		process.kill( process.pid, signal );
+		return;
+	}
+
+	process.exit( code ?? 1 );
+} );

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"puppeteer": "^24.38.0"
 	},
 	"scripts": {
+		"playground": "node ./env/playground-start.mjs",
 		"setup:tools": "TEXTDOMAIN=wporg composer exec update-configs",
 		"setup:wp": "wp-env run cli bash env/setup.sh",
 		"setup:refresh": "./env/refresh.sh",

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,20 @@ The "theme-switcher" in `mu-plugins` here should control which theme is used, ba
 
 1. Log in with username `admin` and password `password`.
 
+### WordPress Playground
+
+To run the environment without Docker, use WordPress Playground:
+
+```bash
+yarn
+composer install
+yarn setup:tools
+yarn build:theme
+yarn playground
+```
+
+Run the dependency setup first so Composer-installed plugins, parent themes, and theme build files are available. The Playground setup mounts the same WordPress.org sandbox bootstrap used by `wp-env`, activates the local plugins and theme, and creates the starter pages. If those dependencies are missing, `yarn playground` will stop before booting WordPress instead of falling back to a bundled default theme.
+
 ### Environment management
 
 These must be run in the project's root folder, _not_ in theme/plugin subfolders.


### PR DESCRIPTION
## Summary

Adds a Docker-free local boot path using WordPress Playground CLI. `yarn playground` runs a small launcher that mirrors the repo's wp-env mappings, checks for Composer-installed dependencies and theme build artifacts, and applies a Playground blueprint.

The blueprint defines the local/debug constants, writes a Playground-only internal MU plugin to rewrite frontend `wordpress.org` links to the local Playground URL, activates the local plugins/theme, creates starter pages from `env/page-manifest.json`, sets the front page, and configures permalinks.

The README documents the no-Docker startup path.

## Testing

Follow the README instructions:

```bash
yarn
composer install
yarn setup:tools
yarn build:theme
yarn playground
```

Then open the Playground URL and verify the rendered pages use the local `wporg-main-2022` theme and local navigation, including links that stay on the Playground host instead of navigating to `wordpress.org`.