### PR TITLE
Make content-update dispatch respect the selected branch

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -6,6 +6,12 @@ on:
     - cron: '17 3 * * *'  # Runs daily at 3:17 AM UTC
   push:
     branches: [trunk]
+    # Only the manifest and the export/parser code change what build:patterns
+    # produces from the live site; regenerate patterns when those change.
+    paths:
+      - 'env/page-manifest.json'
+      - 'env/export-content/**'
+      - 'env/build-patterns.sh'
   pull_request:
     paths:
       - '.github/workflows/content-update.yml'
@@ -31,7 +37,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'trunk' }}
+          # PRs check out the PR branch; a manual run uses the branch selected in the
+          # UI; scheduled/push runs always operate on trunk (the content-sync target).
+          ref: ${{ (github.event_name == 'pull_request' && github.head_ref) || (github.event_name == 'workflow_dispatch' && github.ref_name) || 'trunk' }}
 
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
@@ -61,6 +69,9 @@ jobs:
 
       - name: Push screenshots to storage branch
         id: push-screenshots
+        # Only write to the shared storage branch from trunk, so branch/PR runs
+        # exercise the sync without mutating shared refs.
+        if: github.ref_name == 'trunk'
         run: |
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           BRANCH="content-update-screenshots"
@@ -111,6 +122,8 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
+        # Only open the content-update PR from trunk; branch/PR runs stop after diffing.
+        if: github.ref_name == 'trunk'
         uses: peter-evans/create-pull-request@v6
         with:
           branch: automated/content-update


### PR DESCRIPTION
## Summary

Follow-up to #710. Tightens the `content-update` workflow so it can be safely dry-run from a branch, and so it only does heavy work when it actually needs to.

## Changes

1. **`workflow_dispatch` honors the selected branch.** The checkout step previously pinned `trunk` for every non-PR event, overriding the branch you pick in the GitHub UI. It now uses `github.ref_name` on manual runs, so you can validate a change to this workflow (or the export/parser) against a branch before merging. Scheduled/push runs still operate on `trunk`; PRs still use the PR branch.

2. **Shared-branch writes gated to `trunk`.** "Push screenshots to storage branch" and "Create Pull Request" now carry `if: github.ref_name == 'trunk'`. Branch and PR runs exercise the regenerate-and-diff steps but no longer push to the shared `content-update-screenshots` branch or open a stray `automated/content-update` PR. (The screenshot-comment step already no-ops when no PR is created.)

3. **`push: trunk` scoped with a `paths:` filter.** `build:patterns` output is a function of the live site plus two repo inputs — `env/page-manifest.json` and the `env/export-content/**` parser. The trigger now fires only when those (or `build-patterns.sh`) change, instead of booting wp-env + syncing on every unrelated trunk push. The output pattern/template dirs are deliberately excluded so merged content PRs don't re-trigger.

## Why this is safe

- The `github.ref_name == 'trunk'` guard is true for scheduled and push-to-trunk runs and for a manual run on trunk; it's false for PRs and for manual runs on a feature branch — exactly the runs that shouldn't touch shared refs.
- No change to what production runs do: scheduled and trunk runs behave identically to before.

## Note for maintainers

Point 3 changes when the daily-vs-push regeneration fires. If there's an intentional reason `content-update` ran on *every* trunk push (not just generator/manifest changes), let me know and I'll drop that part — the first two changes stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)