### PR TITLE
Update @wordpress packages and drop the npm peer-deps workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write # Required to clone the repo and push to the build branch.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: trunk
 

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write # Required to create a PR and comment on it.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PRs check out the PR branch; a manual run uses the branch selected in the
           # UI; scheduled/push runs always operate on trunk (the content-sync target).
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload screenshots
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshot-artifacts
           path: "${{ github.workspace }}/artifacts/"

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write # Required to clone the repo and push to trunk.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: i18n
         uses: WordPress/wporg-repo-tools/.github/actions/i18n@trunk

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read # Required to clone the repo.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ wp-cli.local.yml
 
 # Configs from wporg-repo-tools.
 .eslintrc.js
+eslint.config.js
 .prettierrc.js
 .stylelintrc
 phpcs.xml.dist

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-# @wordpress/scripts declares an optional peer on @wordpress/env@^10, but we pin
-# @wordpress/env@11. yarn (classic) ignored peer conflicts; npm enforces them, so
-# opt back into the lenient behavior to keep installs working with the pinned versions.
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,26 +12,12 @@
 				"source/wp-content/themes/wporg-main-2022"
 			],
 			"devDependencies": {
-				"@wordpress/env": "11.1.0",
-				"@wordpress/eslint-plugin": "24.3.0",
-				"@wordpress/scripts": "31.6.0",
+				"@wordpress/env": "11.11.0",
+				"@wordpress/eslint-plugin": "25.7.0",
+				"@wordpress/scripts": "33.0.0",
 				"backstopjs": "^6.1.4",
 				"lighthouse-ci": "^1.13.1",
 				"puppeteer": "^24.38.0"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -112,9 +98,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
-			"integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+			"integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2030,6 +2016,23 @@
 				"keyv": "^5.6.0"
 			}
 		},
+		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"keyv": "^5.6.0"
+			}
+		},
 		"node_modules/@cacheable/memory/node_modules/keyv": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -2225,29 +2228,6 @@
 				"@csstools/css-tokenizer": "^3.0.1"
 			}
 		},
-		"node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2304,18 +2284,40 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
-			"integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
+			"version": "0.50.2",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+			"integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@types/estree": "^1.0.6",
+				"@typescript-eslint/types": "^8.11.0",
 				"comment-parser": "1.4.1",
-				"esquery": "^1.5.0",
-				"jsdoc-type-pratt-parser": "~4.0.0"
+				"esquery": "^1.6.0",
+				"jsdoc-type-pratt-parser": "~4.1.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+			"integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0",
+				"ignore": "^7.0.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -2360,25 +2362,104 @@
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@eslint/compat": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+			"integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"peerDependencies": {
+				"eslint": "^8.40 || 9 || 10"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/object-schema": "^2.1.7",
+				"debug": "^4.3.1",
+				"minimatch": "^3.1.5"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+			"integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
+				"js-yaml": "^4.3.0",
+				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -2390,6 +2471,7 @@
 			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2406,17 +2488,32 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
-		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
@@ -2435,6 +2532,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -2447,29 +2545,61 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+			"integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -2528,98 +2658,42 @@
 				"tslib": "^2.8.0"
 			}
 		},
-		"node_modules/@hapi/address": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-			"integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^11.0.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@hapi/formula": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-			"integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/hoek": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-			"integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/pinpoint": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
-			"integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/tlds": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
-			"integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@hapi/topo": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-			"integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^11.0.2"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-			"deprecated": "Use @eslint/config-array instead",
+		"node_modules/@humanfs/core": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.3",
-				"debug": "^4.3.1",
-				"minimatch": "^3.0.5"
+				"@humanfs/types": "^0.15.0"
 			},
 			"engines": {
-				"node": ">=10.10.0"
+				"node": ">=18.18.0"
 			}
 		},
-		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+		"node_modules/@humanfs/node": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
 			"dev": true,
-			"license": "MIT",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -2636,13 +2710,19 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-			"deprecated": "Use @eslint/object-schema instead",
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
 			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
 		},
 		"node_modules/@inquirer/ansi": {
 			"version": "1.0.2",
@@ -3756,23 +3836,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@keyv/bigmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
-			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hashery": "^1.4.0",
-				"hookified": "^1.15.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@keyv/serialize": {
@@ -5715,6 +5778,23 @@
 				"url": "https://opencollective.com/pkgr"
 			}
 		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"playwright": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
 			"version": "0.5.17",
 			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
@@ -5804,27 +5884,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
 			}
 		},
 		"node_modules/@puppeteer/browsers/node_modules/semver": {
@@ -5928,6 +5987,32 @@
 				"@opentelemetry/semantic-conventions": "^1.34.0"
 			}
 		},
+		"node_modules/@sentry/node/node_modules/brace-expansion": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@sentry/node/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/@sentry/opentelemetry": {
 			"version": "9.47.1",
 			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
@@ -6004,13 +6089,6 @@
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0"
 			}
-		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@stylistic/stylelint-plugin": {
 			"version": "3.1.3",
@@ -6607,6 +6685,13 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -6800,13 +6885,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "26.1.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+			"version": "20.19.43",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~8.3.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/node-forge": {
@@ -6911,13 +6996,6 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7044,137 +7122,149 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+			"integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/type-utils": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.65.0",
+				"@typescript-eslint/type-utils": "8.65.0",
+				"@typescript-eslint/utils": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0",
+				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
+				"@typescript-eslint/parser": "^8.65.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+			"integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
 			"dev": true,
-			"license": "BSD-2-Clause",
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.65.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+			"integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.65.0",
+				"@typescript-eslint/types": "^8.65.0",
+				"debug": "^4.4.3"
 			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+			"integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+			"integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
-			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+			"integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0",
+				"@typescript-eslint/utils": "8.65.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.5.0"
 			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+			"integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7182,32 +7272,70 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+			"integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
 			"dev": true,
-			"license": "BSD-2-Clause",
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"@typescript-eslint/project-service": "8.65.0",
+				"@typescript-eslint/tsconfig-utils": "8.65.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/visitor-keys": "8.65.0",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -7224,56 +7352,41 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+			"integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.65.0",
+				"@typescript-eslint/types": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+			"integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
+				"@typescript-eslint/types": "8.65.0",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7281,24 +7394,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
-		},
-		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-			"integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
 			"version": "1.12.2",
@@ -7875,6 +7981,19 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/react": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@wordpress/base-styles": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
@@ -7931,25 +8050,14 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/compose/node_modules/@wordpress/element": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
-			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+		"node_modules/@wordpress/compose/node_modules/use-memo-one": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.51.0",
-				"@wordpress/escape-html": "^3.51.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
@@ -8020,44 +8128,82 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.46.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/element/node_modules/react": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/react-dom": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/scheduler": {
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
 		"node_modules/@wordpress/env": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.1.0.tgz",
-			"integrity": "sha512-fhpE6a7jmTLvaCvSqq0oSW/EH/UsgWxefZm8iV5q558jF2Ri97exmmGtoI8+wskYj8ivzIwNXPat7idBtYubtg==",
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.11.0.tgz",
+			"integrity": "sha512-E4Riaan41uAcm70FFTD78Z1qtObQJwRlIyXdsr04X+mrg8XkBuHSqM1iSvgqnOpVzUuF9EYANYKF0CTm9tKW5w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
 				"@wp-playground/cli": "^3.0.48",
-				"chalk": "^4.0.0",
+				"adm-zip": "^0.5.9",
+				"chalk": "^4.1.1",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
 				"docker-compose": "^0.24.3",
-				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
-				"js-yaml": "^3.13.1",
+				"js-yaml": "^3.15.0",
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
-				"simple-git": "^3.5.0",
+				"simple-git": "^3.24.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -8080,31 +8226,32 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.3.0.tgz",
-			"integrity": "sha512-7AG8Mc6mKfoAEthNVC95SaiWIOjzdifjbRnU6B3Xe5YWtuUU4JlVO/Ce/jUqV+iyRZw+bCSUE38TxWjUbVfeKg==",
+			"version": "25.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.7.0.tgz",
+			"integrity": "sha512-OY22qfNDQjBJ5Y4OWiEPhCPp0KGaGWr0kRK05e1Kh73ps2XEv8yyp74EJdkxqqog8R/W7mLH+RB/YogY5fUHMg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/eslint-parser": "7.25.7",
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.41.0",
-				"@wordpress/prettier-config": "^4.41.0",
-				"@wordpress/theme": "^0.8.0",
+				"@babel/eslint-parser": "^7.28.6",
+				"@eslint-community/eslint-plugin-eslint-comments": "^4.7.0",
+				"@eslint/compat": "^2.0.0",
+				"@wordpress/babel-preset-default": "^8.51.0",
+				"@wordpress/prettier-config": "^4.51.0",
+				"@wordpress/theme": "^1.0.0",
 				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^8.3.0",
+				"eslint-config-prettier": "^10.0.0",
 				"eslint-import-resolver-typescript": "^4.4.4",
-				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.4.3",
-				"eslint-plugin-jsdoc": "^46.4.6",
-				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-prettier": "^5.0.0",
-				"eslint-plugin-react": "^7.27.0",
-				"eslint-plugin-react-hooks": "^4.3.0",
-				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
+				"eslint-plugin-import": "^2.31.0",
+				"eslint-plugin-jest": "^28.11.0",
+				"eslint-plugin-jsdoc": "^50.0.0",
+				"eslint-plugin-jsx-a11y": "^6.10.0",
+				"eslint-plugin-playwright": "^2.1.0",
+				"eslint-plugin-prettier": "^5.5.5",
+				"eslint-plugin-react": "^7.37.0",
+				"eslint-plugin-react-hooks": "^7.1.1",
+				"globals": "^16.0.0",
+				"requireindex": "^1.2.0",
+				"typescript-eslint": "^8.57.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8112,7 +8259,7 @@
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7",
-				"eslint": ">=8",
+				"eslint": "^9.0.0 || ^10.0.0",
 				"prettier": ">=3",
 				"typescript": ">=5"
 			},
@@ -8302,68 +8449,62 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "31.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.6.0.tgz",
-			"integrity": "sha512-nZVu2KiZNYbpZXVPG8kabGwTsKVh6QnHEexE30RqtWP4WdVM0eSHJBf+CbRQgA2iGoP34RfrJDO0msCQa/iBoA==",
+			"version": "33.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-33.0.0.tgz",
+			"integrity": "sha512-dGZDzzJWudAlidbi52kyXzCM+Lfqpzi3W7iqpRUCD5O5Q5ejcWZbaxseL2fT2j79PbbxIh7BD9aMZghEGanaQA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/core": "7.25.7",
+				"@babel/core": "^7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.41.0",
-				"@wordpress/browserslist-config": "^6.41.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.41.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.41.0",
-				"@wordpress/eslint-plugin": "^24.3.0",
-				"@wordpress/jest-preset-default": "^12.41.0",
-				"@wordpress/npm-package-json-lint-config": "^5.41.0",
-				"@wordpress/postcss-plugins-preset": "^5.41.0",
-				"@wordpress/prettier-config": "^4.41.0",
-				"@wordpress/stylelint-config": "^23.33.0",
+				"@wordpress/babel-preset-default": "^8.51.0",
+				"@wordpress/browserslist-config": "^6.51.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.51.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.51.0",
+				"@wordpress/eslint-plugin": "^25.7.0",
+				"@wordpress/jest-preset-default": "^12.51.0",
+				"@wordpress/npm-package-json-lint-config": "^5.51.0",
+				"@wordpress/postcss-plugins-preset": "^5.51.0",
+				"@wordpress/prettier-config": "^4.51.0",
+				"@wordpress/stylelint-config": "^24.0.0",
 				"adm-zip": "^0.5.9",
-				"babel-jest": "29.7.0",
-				"babel-loader": "9.2.1",
-				"browserslist": "^4.21.10",
-				"chalk": "^4.0.0",
+				"babel-jest": "^29.7.0",
+				"babel-loader": "^9.2.1",
+				"browserslist": "^4.28.4",
+				"chalk": "^4.1.1",
 				"check-node-version": "^4.1.0",
 				"copy-webpack-plugin": "^10.2.0",
 				"cross-spawn": "^7.0.6",
 				"css-loader": "^6.2.0",
 				"cssnano": "^6.0.1",
-				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.57.1",
-				"expect-puppeteer": "^4.4.0",
+				"eslint": "^10.0.0",
 				"fast-glob": "^3.2.7",
-				"filenamify": "^4.2.0",
 				"jest": "^29.6.2",
-				"jest-dev-server": "^10.1.4",
 				"jest-environment-jsdom": "^30.2.0",
 				"jest-environment-node": "^29.6.2",
 				"json2php": "^0.0.9",
 				"markdownlint-cli": "^0.31.1",
-				"merge-deep": "^3.0.3",
 				"mini-css-extract-plugin": "^2.9.2",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
-				"postcss": "^8.4.5",
+				"postcss": "^8.4.38",
 				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@3.0.3",
-				"puppeteer-core": "^23.10.1",
+				"prettier": "npm:wp-prettier@^3.0.3",
 				"react-refresh": "^0.14.0",
 				"read-pkg-up": "^7.0.1",
-				"resolve-bin": "^0.4.0",
+				"resolve-bin": "^1.0.1",
 				"rtlcss": "^4.3.0",
 				"sass": "^1.54.0",
 				"sass-loader": "^16.0.3",
 				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",
-				"stylelint": "^16.8.2",
+				"stylelint": "^16.26.1",
 				"terser-webpack-plugin": "^5.3.10",
 				"url-loader": "^4.1.1",
-				"webpack": "^5.97.0",
+				"webpack": "^5.108.1",
 				"webpack-bundle-analyzer": "^4.9.1",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^4.15.1"
@@ -8376,52 +8517,307 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.58.2",
-				"@wordpress/env": "^10.0.0",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
+				"@playwright/test": ">=1",
+				"@wordpress/env": ">=10.0.0",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
 			},
 			"peerDependenciesMeta": {
+				"@playwright/test": {
+					"optional": true
+				},
 				"@wordpress/env": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/@babel/core": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+		"node_modules/@wordpress/scripts/node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@eslint/config-helpers": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@eslint/plugin-kit": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
 			},
 			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+			"integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.2",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/scripts/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@wordpress/style-runtime": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
-			"integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.7.0.tgz",
+			"integrity": "sha512-PeAcF7qoIMg9ChS5SfkRrLLcUx9D7Te6weRcQmoKYgxE7jSzzXpoaiy3Z+Us+ChyisolF4xhTg5DblMBPL1iug==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8430,19 +8826,19 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.42.0.tgz",
-			"integrity": "sha512-k9lNU4sK3fdipdhHI2d/Rzd/NnfznPmOZ60ok8O8QhfCMZw2Jd1M8ckYqaIrHTKU62ZrcsugdfJlHodsdrxEzA==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-24.0.0.tgz",
+			"integrity": "sha512-KmDPgStzIeQFsu1ja8WpZ1ahXg/P5ZKavsapG5ls5bEONIsHx0O5Bz9o2iE/M/112nnRkyI3iKv082SGtYr7TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@stylistic/stylelint-plugin": "^3.0.1",
-				"@wordpress/theme": "^0.17.0",
+				"@stylistic/stylelint-plugin": "^3.1.3",
+				"@wordpress/theme": "^1.0.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
 			"engines": {
-				"node": ">=18.12.0",
+				"node": "^20.19.0 || >=22.13.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
@@ -8450,52 +8846,31 @@
 				"stylelint-scss": "^6.4.0"
 			}
 		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/element": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
-			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+		"node_modules/@wordpress/theme": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.0.0.tgz",
+			"integrity": "sha512-zPwDgv7xx3f4h+lLCq95szofMAMjSIlkIIfR7U2cxQws5J6XnnTsOxHWJTE6V4jPzS19vzFdQdZ9wiR/X3c0Lw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
+				"@wordpress/compose": "^8.4.0",
 				"@wordpress/deprecated": "^4.51.0",
-				"@wordpress/escape-html": "^3.51.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.17.0.tgz",
-			"integrity": "sha512-BU+PLBLxMBM4WJYrd1QEwy+IA64vUP+8IEEB9lLx2NfB+3/45vvuvXx9o3qPKRDHvtMtEaRArld4Kn05UIW9IA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/compose": "^8.2.0",
-				"@wordpress/deprecated": "^4.49.0",
-				"@wordpress/element": "^8.1.0",
-				"@wordpress/private-apis": "^1.49.0",
-				"@wordpress/style-runtime": "^0.5.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/style-runtime": "^0.7.0",
 				"colorjs.io": "^0.6.0",
 				"memize": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": "^20.19.0 || >=22.13.0",
+				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
-				"@types/react": "^18.3.27",
+				"@types/react": "^18 || ^19",
 				"esbuild": "^0.27.2",
 				"postcss": "^8.0.0",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19",
 				"stylelint": "^16.8.2",
 				"vite": "^7.3.2"
 			},
@@ -8513,33 +8888,6 @@
 					"optional": true
 				},
 				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/theme": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.8.0.tgz",
-			"integrity": "sha512-xXGjWNFHICBuMNfjCjTui5ChkiKmmPTJtsF5tPXnUBXJaw43xxGlL0y7lpCNPJQxz+NPMJ01KlGfxhRsHXjKrQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^6.41.0",
-				"@wordpress/private-apis": "^1.41.0",
-				"colorjs.io": "^0.6.0",
-				"memize": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0",
-				"stylelint": "^16.8.2"
-			},
-			"peerDependenciesMeta": {
-				"stylelint": {
 					"optional": true
 				}
 			}
@@ -8951,19 +9299,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ansi-html": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
@@ -9073,16 +9408,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/arr-union": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/array-buffer-byte-length": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -9131,13 +9456,16 @@
 			}
 		},
 		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+			"integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/array.prototype.findlast": {
@@ -9324,13 +9652,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/atomically": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
@@ -9405,56 +9726,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/axios": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.16.0",
-				"form-data": "^4.0.5",
-				"https-proxy-agent": "^5.0.1",
-				"proxy-from-env": "^2.1.0"
-			}
-		},
-		"node_modules/axios/node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/axios/node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/axios/node_modules/proxy-from-env": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -9463,21 +9734,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/b4a": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peerDependencies": {
-				"react-native-b4a": "*"
-			},
-			"peerDependenciesMeta": {
-				"react-native-b4a": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/babel-jest": {
@@ -9752,27 +10008,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/backstopjs/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
 		"node_modules/backstopjs/node_modules/fs-extra": {
 			"version": "11.3.6",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
@@ -9954,6 +10189,21 @@
 				}
 			}
 		},
+		"node_modules/bare-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/bare-url": {
 			"version": "2.4.5",
 			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
@@ -10055,6 +10305,31 @@
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
 				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/bl/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/bl/node_modules/readable-stream": {
@@ -10175,6 +10450,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/boxen/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/boxen/node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -10194,13 +10482,14 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/braces": {
@@ -10268,9 +10557,9 @@
 			"license": "MIT"
 		},
 		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
 			"dev": true,
 			"funding": [
 				{
@@ -10289,7 +10578,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -10315,19 +10604,6 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/builtin-modules": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
@@ -10719,6 +10995,16 @@
 				"devtools-protocol": "*"
 			}
 		},
+		"node_modules/chromium-bidi/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
 		"node_modules/ci-info": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -10852,20 +11138,18 @@
 			}
 		},
 		"node_modules/clone-deep": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-			"integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"for-own": "^0.1.3",
-				"is-plain-object": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"lazy-cache": "^1.0.3",
-				"shallow-clone": "^0.1.2"
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/clone-deep/node_modules/is-plain-object": {
@@ -10957,27 +11241,14 @@
 				"url": "https://opencollective.com/color"
 			}
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+			"integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": "^12.20.0 || >=14"
 			}
 		},
 		"node_modules/comment-parser": {
@@ -11062,22 +11333,6 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
-			"engines": [
-				"node >= 0.8"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
-			}
 		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
@@ -11197,53 +11452,6 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.1.0"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/array-union": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-			"integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/globby": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
-			"integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^3.0.1",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.7",
-				"ignore": "^5.1.9",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/core-js": {
@@ -11657,20 +11865,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cwd": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
-			"integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-pkg": "^0.1.2",
-				"fs-exists-sync": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -12003,16 +12197,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -12182,16 +12366,16 @@
 			}
 		},
 		"node_modules/doctrine": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -12790,70 +12974,77 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+			"integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.1",
-				"@humanwhocodes/config-array": "^0.13.0",
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
+				"@eslint/eslintrc": "^3.3.6",
+				"@eslint/js": "9.39.5",
+				"@eslint/plugin-kit": "^0.4.1",
+				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@nodelib/fs.walk": "^1.2.8",
-				"@ungap/structured-clone": "^1.2.0",
-				"ajv": "^6.12.4",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
 				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
+				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
-				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1",
-				"esquery": "^1.4.2",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
+				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^6.0.1",
+				"file-entry-cache": "^8.0.0",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.19.0",
-				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"is-path-inside": "^3.0.3",
-				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"strip-ansi": "^6.0.1",
-				"text-table": "^0.2.0"
+				"optionator": "^0.9.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/eslint"
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
-			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
+			"version": "10.1.8",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-config-prettier"
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
@@ -13027,17 +13218,6 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
-		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -13048,47 +13228,21 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"node_modules/eslint-plugin-import/node_modules/doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "27.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
-			"integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+			"version": "28.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
+			"integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "^5.10.0"
+				"@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^16.10.0 || ^18.12.0 || >=20.0.0"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
-				"eslint": "^7.0.0 || ^8.0.0",
+				"@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
 				"jest": "*"
 			},
 			"peerDependenciesMeta": {
@@ -13100,156 +13254,26 @@
 				}
 			}
 		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "46.10.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
-			"integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+			"version": "50.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+			"integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.41.0",
+				"@es-joy/jsdoccomment": "~0.50.2",
 				"are-docs-informative": "^0.0.2",
 				"comment-parser": "1.4.1",
-				"debug": "^4.3.4",
+				"debug": "^4.4.1",
 				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.5.0",
-				"is-builtin-module": "^3.2.1",
-				"semver": "^7.5.4",
+				"espree": "^10.3.0",
+				"esquery": "^1.6.0",
+				"parse-imports-exports": "^0.2.4",
+				"semver": "^7.7.2",
 				"spdx-expression-parse": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -13298,44 +13322,33 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 			}
 		},
-		"node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+		"node_modules/eslint-plugin-playwright": {
+			"version": "2.10.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.5.tgz",
+			"integrity": "sha512-4k+ml4cEd55kePUIW1WsCiOLDwZkAdPZPKMFulR83XpplCaVOTKHF6yvXLYixLtdVbkMjmKV5F3BaGuI3aH8aQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"globals": "^17.3.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16.9.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
 			}
 		},
-		"node_modules/eslint-plugin-playwright": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
-			"integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
+		"node_modules/eslint-plugin-playwright/node_modules/globals": {
+			"version": "17.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+			"integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
 			"dev": true,
 			"license": "MIT",
-			"peerDependencies": {
-				"eslint": ">=7",
-				"eslint-plugin-jest": ">=25"
+			"engines": {
+				"node": ">=18"
 			},
-			"peerDependenciesMeta": {
-				"eslint-plugin-jest": {
-					"optional": true
-				}
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
@@ -13403,53 +13416,23 @@
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+			"integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"hermes-parser": "^0.25.1",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-validation-error": "^3.5.0 || ^4.0.0"
+			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-			}
-		},
-		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-react/node_modules/doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-react/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -13510,12 +13493,27 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/eslint/node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
 		"node_modules/eslint/node_modules/ajv": {
 			"version": "6.15.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
 			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -13527,49 +13525,33 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/eslint/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -13581,6 +13563,7 @@
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -13592,27 +13575,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/puzrin"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/nodeca"
-				}
-			],
 			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/eslint/node_modules/json-schema-traverse": {
@@ -13620,7 +13591,8 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -13628,6 +13600,7 @@
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -13638,25 +13611,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/eslint/node_modules/p-locate": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -13668,31 +13629,31 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.9.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.4.1"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -13858,19 +13819,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/expand-tilde": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-			"integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"os-homedir": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -13887,13 +13835,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/expect-puppeteer": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
-			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/express": {
 			"version": "4.22.2",
@@ -13960,37 +13901,25 @@
 			"license": "MIT"
 		},
 		"node_modules/extract-zip": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"concat-stream": "^1.6.2",
-				"debug": "^2.6.9",
-				"mkdirp": "^0.5.4",
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
 				"yauzl": "^2.10.0"
 			},
 			"bin": {
 				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
 			}
-		},
-		"node_modules/extract-zip/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/extract-zip/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -14168,63 +14097,17 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/file-entry-cache": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^3.0.4"
+				"flat-cache": "^4.0.0"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/filenamify": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
-			"integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.1",
-				"trim-repeated": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/fill-range": {
@@ -14293,54 +14176,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/find-file-up": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
-			"integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fs-exists-sync": "^0.1.0",
-				"resolve-dir": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/find-parent-dir": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.1.tgz",
 			"integrity": "sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/find-pkg": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
-			"integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-file-up": "^0.1.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/find-process": {
-			"version": "1.4.11",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.11.tgz",
-			"integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "~4.1.2",
-				"commander": "^12.1.0",
-				"loglevel": "^1.9.2"
-			},
-			"bin": {
-				"find-process": "bin/find-process.js"
-			}
 		},
 		"node_modules/find-up": {
 			"version": "4.1.0",
@@ -14367,35 +14208,17 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flatted": "^3.2.9",
-				"keyv": "^4.5.3",
-				"rimraf": "^3.0.2"
+				"keyv": "^4.5.4"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/flat-cache/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=16"
 			}
 		},
 		"node_modules/flatted": {
@@ -14442,29 +14265,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -14480,23 +14280,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.4",
-				"mime-types": "^2.1.35"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/forwarded": {
@@ -14538,16 +14321,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fs-exists-sync": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/fs-ext-extra-prebuilt": {
@@ -14865,30 +14638,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/global-dirs": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
@@ -14916,33 +14665,31 @@
 			}
 		},
 		"node_modules/global-modules": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-			"integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"global-prefix": "^0.1.4",
-				"is-windows": "^0.2.0"
+				"global-prefix": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/global-prefix": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-			"integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"homedir-polyfill": "^1.0.0",
-				"ini": "^1.3.4",
-				"is-windows": "^0.2.0",
-				"which": "^1.2.12"
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/global-prefix/node_modules/ini": {
@@ -14966,16 +14713,13 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14999,21 +14743,44 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"version": "12.2.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
+			"integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"array-union": "^2.1.0",
+				"array-union": "^3.0.1",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
+				"fast-glob": "^3.2.7",
+				"ignore": "^5.1.9",
 				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
+				"slash": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globby/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/globby/node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -15071,13 +14838,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/graphemer": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/gzip-size": {
 			"version": "6.0.0",
@@ -15240,17 +15000,21 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/homedir-polyfill": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+		"node_modules/hermes-estree": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hermes-parser": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"parse-passwd": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"hermes-estree": "0.25.1"
 			}
 		},
 		"node_modules/hookified": {
@@ -15304,6 +15068,46 @@
 				"obuf": "^1.0.0",
 				"readable-stream": "^2.0.1",
 				"wbuf": "^1.1.0"
+			}
+		},
+		"node_modules/hpack.js/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hpack.js/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/hpack.js/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hpack.js/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -15565,9 +15369,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15585,30 +15389,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/ignore-walk/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/image-ssim": {
@@ -15931,22 +15711,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-builtin-module": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
-			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"builtin-modules": "^3.3.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-bun-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -16084,16 +15848,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -16506,16 +16260,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-windows": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-			"integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -16537,9 +16281,9 @@
 			"license": "MIT"
 		},
 		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16586,56 +16330,14 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/isomorphic-git/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/isomorphic-git/node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+		"node_modules/isomorphic-git/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/isomorphic-git/node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
+				"node": ">= 4"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -16905,25 +16607,6 @@
 				"ts-node": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/jest-dev-server": {
-			"version": "10.1.4",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.4.tgz",
-			"integrity": "sha512-bGQ6sedNGtT6AFHhCVqGTXMPz7UyJi/ZrhNBgyqsP0XU9N8acCEIfqZEA22rOaZ+NdEVsaltk6tL7UT6aXfI7w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2",
-				"cwd": "^0.10.0",
-				"find-process": "^1.4.7",
-				"prompts": "^2.4.2",
-				"spawnd": "^10.1.4",
-				"tree-kill": "^1.2.2",
-				"wait-on": "^8.0.1"
-			},
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/jest-diff": {
@@ -17574,25 +17257,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/joi": {
-			"version": "18.2.3",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
-			"integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/address": "^5.1.1",
-				"@hapi/formula": "^3.0.2",
-				"@hapi/hoek": "^11.0.7",
-				"@hapi/pinpoint": "^2.0.1",
-				"@hapi/tlds": "^1.1.1",
-				"@hapi/topo": "^6.0.2",
-				"@standard-schema/spec": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
 		"node_modules/jpeg-js": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -17632,9 +17296,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-			"integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+			"integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -17887,14 +17551,11 @@
 			}
 		},
 		"node_modules/kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -17968,16 +17629,6 @@
 			"dependencies": {
 				"picocolors": "^1.1.1",
 				"shell-quote": "^1.8.4"
-			}
-		},
-		"node_modules/lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/legacy-javascript": {
@@ -18427,19 +18078,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lighthouse-ci/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/lighthouse-ci/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -18662,54 +18300,6 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.43.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
-			"integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@puppeteer/browsers": "2.13.2",
-				"chromium-bidi": "14.0.0",
-				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1608973",
-				"typed-query-selector": "^2.12.2",
-				"webdriver-bidi-protocol": "0.4.1",
-				"ws": "^8.20.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1608973",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
-			"integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/lighthouse/node_modules/ws": {
 			"version": "7.5.13",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
@@ -18902,7 +18492,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -18947,20 +18538,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/loglevel": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6.0"
-			},
-			"funding": {
-				"type": "tidelift",
-				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
 		"node_modules/lookup-closest-locale": {
@@ -19150,27 +18727,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
-		},
-		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/commander": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
-			"integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || >=14"
-			}
 		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
 			"version": "5.2.4",
@@ -19366,21 +18922,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/merge-deep": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
-			"integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"arr-union": "^3.1.0",
-				"clone-deep": "^0.2.4",
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/merge-descriptors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -19534,19 +19075,16 @@
 			"license": "ISC"
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": "*"
 			}
 		},
 		"node_modules/minimist": {
@@ -19572,16 +19110,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/minimist-options/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/minimisted": {
@@ -19703,41 +19231,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mixin-object/node_modules/for-in": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-			"integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/module-details-from-path": {
@@ -20062,6 +19566,16 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/npm-package-json-lint/node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/npm-package-json-lint/node_modules/cosmiconfig": {
 			"version": "8.3.6",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -20087,6 +19601,37 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/npm-package-json-lint/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-package-json-lint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/is-plain-obj": {
@@ -20640,16 +20185,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/own-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -21022,6 +20557,16 @@
 			"integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
 			"dev": true
 		},
+		"node_modules/parse-imports-exports": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+			"integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parse-statements": "1.0.11"
+			}
+		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -21041,15 +20586,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/parse-passwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+		"node_modules/parse-statements": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+			"integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/parse5": {
 			"version": "7.3.0",
@@ -22518,110 +22060,30 @@
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "23.11.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
-			"integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+			"version": "24.43.1",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+			"integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.6.1",
-				"chromium-bidi": "0.11.0",
-				"debug": "^4.4.0",
-				"devtools-protocol": "0.0.1367902",
-				"typed-query-selector": "^2.12.0",
-				"ws": "^8.18.0"
+				"@puppeteer/browsers": "2.13.2",
+				"chromium-bidi": "14.0.0",
+				"debug": "^4.4.3",
+				"devtools-protocol": "0.0.1608973",
+				"typed-query-selector": "^2.12.2",
+				"webdriver-bidi-protocol": "0.4.1",
+				"ws": "^8.20.0"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
-			"integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"extract-zip": "^2.0.1",
-				"progress": "^2.0.3",
-				"proxy-agent": "^6.5.0",
-				"semver": "^7.6.3",
-				"tar-fs": "^3.0.6",
-				"unbzip2-stream": "^1.4.3",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"browsers": "lib/cjs/main-cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
-			"integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"mitt": "3.0.1",
-				"zod": "3.23.8"
-			},
-			"peerDependencies": {
-				"devtools-protocol": "*"
 			}
 		},
 		"node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1367902",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
-			"integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+			"version": "0.0.1608973",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+			"integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
 			"dev": true,
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/puppeteer-core/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/zod": {
-			"version": "3.23.8",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
 		},
 		"node_modules/puppeteer/node_modules/argparse": {
 			"version": "2.0.1",
@@ -22685,25 +22147,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/puppeteer/node_modules/puppeteer-core": {
-			"version": "24.43.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
-			"integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@puppeteer/browsers": "2.13.2",
-				"chromium-bidi": "14.0.0",
-				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1608973",
-				"typed-query-selector": "^2.12.2",
-				"webdriver-bidi-protocol": "0.4.1",
-				"ws": "^8.20.0"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/pure-rand": {
@@ -22919,30 +22362,28 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+			"integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+			"integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.2"
+				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^18.3.1"
+				"react": "^19.2.7"
 			}
 		},
 		"node_modules/react-is": {
@@ -23083,27 +22524,21 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
-		},
-		"node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/readdirp": {
 			"version": "5.0.0",
@@ -23363,9 +22798,9 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve-bin": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.3.tgz",
-			"integrity": "sha512-9u8TMpc+SEHXxQXblXHz5yRvRZERkCZimFN9oz85QI3uhkh7nqfjm6OGTLg+8vucpXGcY4jLK6WkylPmt7GSvw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-1.0.1.tgz",
+			"integrity": "sha512-4G9C3udcDB1c9qaopB+9dygm2bMyF2LeJ2JHBIc24N7ob+UuSSwX3ID1hQwpDEQep9ZRNdhT//rgEd6xbWA/SA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23383,20 +22818,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-dir": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-			"integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expand-tilde": "^1.2.2",
-				"global-modules": "^0.2.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -23498,6 +22919,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/rimraf/node_modules/glob": {
@@ -23624,16 +23055,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/rxjs": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
-		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
@@ -23653,13 +23074,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/safe-array-concat/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -23698,13 +23112,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/safe-push-apply/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
@@ -23817,14 +23224,12 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			}
+			"peer": true
 		},
 		"node_modules/schema-utils": {
 			"version": "4.3.3",
@@ -24138,42 +23543,16 @@
 			}
 		},
 		"node_modules/shallow-clone": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-			"integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^2.0.1",
-				"lazy-cache": "^0.2.3",
-				"mixin-object": "^2.0.1"
+				"kind-of": "^6.0.2"
 			},
 			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shallow-clone/node_modules/kind-of": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-			"integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shallow-clone/node_modules/lazy-cache": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-			"integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -24563,20 +23942,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/spawnd": {
-			"version": "10.1.4",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.4.tgz",
-			"integrity": "sha512-drqHc0mKJmtMsiGMOCwzlc5eZ0RPtRvT7tQAluW2A0qUc0G7TQ8KLcn3E6K5qzkLkH2UkS3nYQiVGULvvsD9dw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"signal-exit": "^4.1.0",
-				"tree-kill": "^1.2.2"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/spdx-correct": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -24780,21 +24145,14 @@
 			}
 		},
 		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "~5.2.0"
 			}
-		},
-		"node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -25042,29 +24400,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/strip-outer/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/strnum": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
@@ -25294,12 +24629,45 @@
 				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
+		"node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			}
+		},
 		"node_modules/stylelint/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
+		},
+		"node_modules/stylelint/node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
@@ -25357,50 +24725,36 @@
 				"hookified": "^1.15.0"
 			}
 		},
-		"node_modules/stylelint/node_modules/global-modules": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+		"node_modules/stylelint/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"global-prefix": "^3.0.0"
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/stylelint/node_modules/global-prefix": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ini": "^1.3.5",
-				"kind-of": "^6.0.2",
-				"which": "^1.3.1"
+				"node": ">=10"
 			},
-			"engines": {
-				"node": ">=6"
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/stylelint/node_modules/ignore": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+		"node_modules/stylelint/node_modules/globby/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/stylelint/node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/stylelint/node_modules/js-yaml": {
 			"version": "4.3.0",
@@ -25423,16 +24777,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/stylelint/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/meow": {
@@ -25460,19 +24804,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/stylelint/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
 			}
 		},
 		"node_modules/stylelint/node_modules/write-file-atomic": {
@@ -25704,6 +25035,21 @@
 				"streamx": "^2.15.0"
 			}
 		},
+		"node_modules/tar-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/teex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
@@ -25726,6 +25072,19 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/temp/node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/temp/node_modules/rimraf": {
@@ -25909,30 +25268,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/text-decoder": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -25943,12 +25278,20 @@
 				"b4a": "^1.6.4"
 			}
 		},
-		"node_modules/text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+		"node_modules/text-decoder/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/third-party-web": {
 			"version": "0.27.0",
@@ -25996,6 +25339,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
@@ -26090,13 +25451,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/to-buffer/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/to-readable-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -26166,16 +25520,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/tree-kill": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"tree-kill": "cli.js"
-			}
-		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -26186,40 +25530,17 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/trim-repeated/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/ts-api-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=16"
+				"node": ">=18.12"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.2.0"
+				"typescript": ">=4.8.4"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -26265,29 +25586,6 @@
 			"dev": true,
 			"license": "0BSD"
 		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -26312,9 +25610,9 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
@@ -26423,13 +25721,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/typedarray-to-buffer": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -26438,6 +25729,45 @@
 			"license": "MIT",
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/typescript-eslint": {
+			"version": "8.65.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+			"integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.65.0",
+				"@typescript-eslint/parser": "8.65.0",
+				"@typescript-eslint/typescript-estree": "8.65.0",
+				"@typescript-eslint/utils": "8.65.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/uc.micro": {
@@ -26477,10 +25807,35 @@
 				"through": "^2.3.8"
 			}
 		},
+		"node_modules/unbzip2-stream/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/undici-types": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -26908,16 +26263,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/use-memo-one": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
 		"node_modules/util": {
 			"version": "0.10.4",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -27031,26 +26376,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/wait-on": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
-			"integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"axios": "^1.12.1",
-				"joi": "^18.0.1",
-				"lodash": "^4.17.21",
-				"minimist": "^1.2.8",
-				"rxjs": "^7.8.2"
-			},
-			"bin": {
-				"wait-on": "bin/wait-on"
-			},
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/walker": {
@@ -27465,57 +26790,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/webpack-merge/node_modules/clone-deep": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.2",
-				"shallow-clone": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/shallow-clone": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^6.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/webpack-sources": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
@@ -27682,13 +26956,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/which-builtin-type/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/which-collection": {
 			"version": "1.0.2",
@@ -28033,13 +27300,26 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-validation-error": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+			"integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
 			}
 		},
 		"node_modules/zstddec": {
@@ -28054,9 +27334,9 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@wordpress/element": "^6.41.0",
+				"@wordpress/element": "^8.3.0",
 				"@wordpress/i18n": "^6.24.0",
-				"@wordpress/scripts": "31.6.0"
+				"@wordpress/scripts": "33.0.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
 	"license": "GPL-2.0-or-later",
 	"private": true,
 	"devDependencies": {
-		"@wordpress/env": "11.1.0",
-		"@wordpress/eslint-plugin": "24.3.0",
-		"@wordpress/scripts": "31.6.0",
+		"@wordpress/env": "11.11.0",
+		"@wordpress/eslint-plugin": "25.7.0",
+		"@wordpress/scripts": "33.0.0",
 		"backstopjs": "^6.1.4",
 		"lighthouse-ci": "^1.13.1",
 		"puppeteer": "^24.38.0"
+	},
+	"overrides": {
+		"prettier": "npm:wp-prettier@^3.0.3"
 	},
 	"scripts": {
 		"playground": "node ./env/playground-start.mjs",

--- a/source/wp-content/themes/wporg-main-2022/package.json
+++ b/source/wp-content/themes/wporg-main-2022/package.json
@@ -6,9 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"private": true,
 	"devDependencies": {
-		"@wordpress/element": "^6.41.0",
+		"@wordpress/element": "^8.3.0",
 		"@wordpress/i18n": "^6.24.0",
-		"@wordpress/scripts": "31.6.0"
+		"@wordpress/scripts": "33.0.0"
 	},
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js"
@@ -19,7 +19,7 @@
 	"scripts": {
 		"build": "wp-scripts build",
 		"start": "wp-scripts start",
-		"lint:js": "wp-scripts lint-js src",
+		"lint:js": "wp-scripts lint-js src --config ../../../../eslint.config.js",
 		"lint:css": "wp-scripts lint-style *.css src/**/*.scss",
 		"format": "wp-scripts format src"
 	}

--- a/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
+++ b/source/wp-content/themes/wporg-main-2022/src/download-counter/view.js
@@ -23,7 +23,7 @@ const init = () => {
 				try {
 					const count = await apiFetch( { path: `/wporg/v1/core-downloads/${ branch }?_locale=site` } );
 					element.textContent = decodeEntities( count );
-				} catch ( error ) {}
+				} catch {}
 			}, 5000 );
 		} );
 	}


### PR DESCRIPTION
## Summary

Now that [WordPress/wporg-repo-tools#44](https://github.com/WordPress/wporg-repo-tools/pull/44) generates a flat ESLint config, this brings the `@wordpress` toolchain current and removes the `.npmrc` workaround added during the yarn→npm migration.

- `@wordpress/scripts` 31.6.0 → **33.0.0** (root + theme)
- `@wordpress/eslint-plugin` 24.3.0 → **25.7.0** (required — `scripts@33` depends on it)
- `@wordpress/env` 11.1.0 → **11.11.0**
- `@wordpress/element` `^6.41.0` → **`^8.3.0`** (theme)
- **Removes `.npmrc`** — `scripts@33`'s `@wordpress/env` peer widened to `>=10.0.0`, so it accepts our pinned `env@11` and the `legacy-peer-deps` workaround is no longer needed.

## Two things the upgrade required

**1. `prettier` override.** `@wordpress/scripts` aliases `prettier` → the `wp-prettier` fork (which preserves WordPress's spaces-in-parens style via `parenSpacing`). Under npm, upstream `prettier` gets hoisted over the alias and silently reformats everything. An `overrides` entry pins `prettier` back to the fork.

**2. Flat ESLint config wiring.** `scripts@33` uses ESLint flat config and ignores the legacy `.eslintrc.js`. `setup:tools` now also generates a root `eslint.config.js` (gitignored, like the other generated wporg configs). Because `wp-scripts lint-js` runs from the theme workspace and would otherwise fall back to its own bundled config, the theme's `lint:js` points it at the generated root config with `--config ../../../../eslint.config.js`.

## Genuine fix surfaced by ESLint 9

`download-counter/view.js` had an empty `catch ( error ) {}` with an unused binding — ESLint 9's `no-unused-vars` (`caughtErrors: 'all'`) correctly flags it. Changed to an optional catch binding (`catch {}`).

## Verification

Local, from a clean tree:
- `npm install` resolves with **no `.npmrc`** (no ERESOLVE).
- `npm run lint:frontend` (js + css) passes — the flat config reproduces the wporg standard exactly (the bundled config alone produced 30+ spurious errors from dropped customizations).
- `npm run build:theme` compiles.

CI exercises the real path: the `setup` action's `setup:tools` generates the root `eslint.config.js`, then the shared `lint` action lints the theme against it via the `--config` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: bump deprecated GitHub Actions

GitHub is retiring the Node 20 action runtime. Pinned `actions/checkout` (was v3.5.3) and `actions/upload-artifact` (was `@v4`) to **v7.0.1** (Node 24) across the workflows, matching the pin-by-SHA style. `actions/setup-node` is also flagged but lives in the shared `wporg-repo-tools` setup action, so it needs a separate upstream bump. Separate commit.
