### PR TITLE
Bump create-pull-request to v8.1.1 to fix the content sync

### DIFF
--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -124,7 +124,7 @@ jobs:
         id: create-pr
         # Only open the content-update PR from trunk; branch/PR runs stop after diffing.
         if: github.ref_name == 'trunk'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: automated/content-update
           delete-branch: true


### PR DESCRIPTION
## Problem

The `Update existing content` workflow has failed on **every run since 2026-07-21** (7 scheduled + 2 manual dispatches). No "Content updates from Page Editor" PR has been opened in a week, so page edits made in the Page Editor are not reaching the repo.

#712 bumped `actions/checkout` from v3.5.3 → v7.0.1 but left `peter-evans/create-pull-request` on v6. Those versions are incompatible:

- checkout v7 persists credentials by writing `http.https://github.com/.extraheader AUTHORIZATION` into a **separate** config file, wired in via `includeIf.gitdir` entries.
- create-pull-request v6 then also sets `http.https://github.com/.extraheader AUTHORIZATION` in the **local** config.

Git sends the header twice and GitHub rejects the request at `git remote prune origin`, before the action even diffs:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/WordPress/wporg-main-2022/': The requested URL returned error: 400
##[error]The process '/usr/bin/git' failed with exit code 128
```

Known upstream bug — peter-evans/create-pull-request#4228 — fixed in v7.0.9.

Everything upstream of that step is healthy: the export runs, all patterns are regenerated, screenshots are handled. Only PR creation fails.

## Fix

Move `create-pull-request` to the current **v8.1.1**, pinned by SHA to match the other actions in this workflow. v8's only breaking change is requiring Actions Runner ≥ 2.327.1 for Node 24, which is a non-issue on `ubuntu-latest`; it also clears the `Node.js 20 is deprecated` warning the workflow currently emits.

This is the only workflow in the repo that uses `create-pull-request`, so nothing else is affected.

## Note on why CI didn't catch this

The `Create Pull Request` step is gated on `if: github.ref_name == 'trunk'`, so the workflow validation runs on the #710/#711/#712 branches all reported green **because they skipped the step that breaks**. Worth a follow-up on making this failure mode noisier.

## Testing

The fix can't be fully exercised from a PR branch for the reason above. After merge, dispatch the workflow against `trunk` — it should open a fresh `automated/content-update` PR carrying everything accumulated since July 21. (The `automated/content-update` branch does not currently exist; #707 was merged on July 20 and the branch was deleted, so this will be a clean new PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
