### PR TITLE
Home: Add alt text to homepage feature images

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/patterns/home.php
+++ b/source/wp-content/themes/wporg-main-2022/patterns/home.php
@@ -45,7 +45,7 @@
 <div class="wp-block-group alignfull has-light-grey-2-background-color has-background" style="padding-top:5rem;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:5rem;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":48979,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-design.png" alt="" class="wp-image-48979" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-design.png" alt="<?php esc_attr_e( 'The WordPress block inserter, showing a grid of blocks including paragraph, quote, and image.', 'wporg' ); ?>" class="wp-image-48979" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"18px","lineHeight":"1.88"}},"fontFamily":"inter"} -->
@@ -59,7 +59,7 @@
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":48978,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-build.png" alt="" class="wp-image-48978" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-build.png" alt="<?php esc_attr_e( 'An image block selected in the WordPress editor, with its toolbar showing alignment, crop, and replace options.', 'wporg' ); ?>" class="wp-image-48978" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"18px","lineHeight":"1.88"}},"fontFamily":"inter"} -->
@@ -77,7 +77,7 @@
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":48981,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-publish.png" alt="" class="wp-image-48981" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-publish.png" alt="<?php esc_attr_e( 'A published website with a full-width mountain photograph and large display type.', 'wporg' ); ?>" class="wp-image-48981" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"18px","lineHeight":"1.88"}},"fontFamily":"inter"} -->
@@ -116,7 +116,7 @@ esc_html_e( 'https://wordpress.org/download/releases/[stable_branch]/', 'wporg' 
 
 <!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:image {"id":51400,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2026/05/wporg-70-new.png" alt="" class="wp-image-51400" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2026/05/wporg-70-new.png" alt="<?php esc_attr_e( 'A collage of WordPress 7.0 features: an AI Connectors toggle, a revision history slider, and pattern editing controls.', 'wporg' ); ?>" class="wp-image-51400" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
@@ -126,7 +126,7 @@ esc_html_e( 'https://wordpress.org/download/releases/[stable_branch]/', 'wporg' 
 <div class="wp-block-group alignfull has-light-grey-2-background-color has-background" style="padding-top:5rem;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:5rem;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":48979,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-design.png" alt="" class="wp-image-48979" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-design.png" alt="<?php esc_attr_e( 'The WordPress block inserter, showing a grid of blocks including paragraph, quote, and image.', 'wporg' ); ?>" class="wp-image-48979" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"18px","lineHeight":"1.88"}},"fontFamily":"inter"} -->
@@ -140,7 +140,7 @@ esc_html_e( 'https://wordpress.org/download/releases/[stable_branch]/', 'wporg' 
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":48978,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-build.png" alt="" class="wp-image-48978" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-build.png" alt="<?php esc_attr_e( 'An image block selected in the WordPress editor, with its toolbar showing alignment, crop, and replace options.', 'wporg' ); ?>" class="wp-image-48978" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"18px","lineHeight":"1.88"}},"fontFamily":"inter"} -->
@@ -158,7 +158,7 @@ esc_html_e( 'https://wordpress.org/download/releases/[stable_branch]/', 'wporg' 
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":48981,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-publish.png" alt="" class="wp-image-48981" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-publish.png" alt="<?php esc_attr_e( 'A published website with a full-width mountain photograph and large display type.', 'wporg' ); ?>" class="wp-image-48981" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"style":{"typography":{"fontSize":"18px","lineHeight":"1.88"}},"fontFamily":"inter"} -->
@@ -200,7 +200,7 @@ esc_html_e( 'Discover WordPress [stable_branch]', 'wporg' );
 
 <!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:image {"id":48980,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-new.png" alt="" class="wp-image-48980" /></figure>
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/files/2025/12/wporg-69-new.png" alt="<?php esc_attr_e( 'A collage of WordPress 6.9 features: a comment left on a photo, a MathML equation block, and an image being dragged into place.', 'wporg' ); ?>" class="wp-image-48980" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>


### PR DESCRIPTION
Adds `alt` text to the homepage feature images that convey information but currently ship with `alt=""`.

See https://meta.trac.wordpress.org/ticket/8125

### What changed

Five unique images across eight `<img>` instances. The hidden "Core Features 6.9" group reuses the same image IDs as the visible "Core Features 7.0" group, so each shared image is updated in both places to keep its alt text identical.

Each string is wrapped in `esc_attr_e( '…', 'wporg' )`, matching how the existing alt text in this pattern is handled (the six brand logos and the community photo), so the descriptions are translatable rather than hardcoded English:

| Image | New alt text |
| --- | --- |
| `wporg-69-design.png` (48979) | The WordPress block inserter, showing a grid of blocks including paragraph, quote, and image. |
| `wporg-69-build.png` (48978) | An image block selected in the WordPress editor, with its toolbar showing alignment, crop, and replace options. |
| `wporg-69-publish.png` (48981) | A published website with a full-width mountain photograph and large display type. |
| `wporg-70-new.png` (51400) | A collage of WordPress 7.0 features: an AI Connectors toggle, a revision history slider, and pattern editing controls. |
| `wporg-69-new.png` (48980) | A collage of WordPress 6.9 features: a comment left on a photo, a MathML equation block, and an image being dragged into place. |

Also removes a stray newline from inside the `wp-image-51400` alt attribute.

### Notes from the audit

A few findings from auditing all 20 `<img>` tags in the pattern, which may help when triaging the ticket:

- **All 15 non-empty alt attributes in the pattern are now translatable**, and the five decorative ones remain `alt=""`. `php -l` passes on the result.
- **No `alt` attributes are actually missing.** Every `<img>` in `home.php` already has an `alt` attribute present. The problem is that some are empty on images that carry meaning.
- **The empty values are hardcoded in this pattern**, not unset in the Media Library. Updating the media items would have no effect, because `home.php` writes `alt=""` directly into the `wp:image` block markup.
- **The images named in the ticket description** (`whats-new-visual-6-7.png`, `dotorg_banner_wceu-6.png`) are no longer on the homepage.
- **Deliberately left empty:** `brush.png` (39758) and the three `showcase-*-row` images (22644, 22641, 22642) are decorative, and the WCUS banner logo (52112) sits beside a paragraph that already conveys the same information. `alt=""` is correct for all five.
- **`role="presentation"` was not added.** For an image with `alt=""` it is redundant — the HTML spec already maps such images out of the accessibility tree.
- **Position-based alt text was avoided.** The ticket suggests "Top/Middle/Bottom Showcase Image"; alt text should describe content rather than position, and those three images are decorative in any case.
- **Possible unrelated content issue:** the third feature column is headed **Extend** with body copy about plugins, but its image is `wporg-69-publish.png`, which shows a finished website rather than anything plugin-related. The alt text here describes the image as it actually is. If the image is meant to match the copy, that is probably worth a separate ticket.

### Screenshots

Not applicable. This change only affects the accessibility tree — the rendered page is pixel-identical before and after. The meaningful verification is the computed accessible name, covered in the test steps below.

| Before | After |
|--------|-------|
| `alt=""` — images exposed with no accessible name | Accessible name matches the table above |

### How to test the changes in this Pull Request:

1. Load the homepage with this patch applied.
2. Open the browser accessibility inspector (Firefox: *Accessibility* panel; Chrome: *DevTools → Elements → Accessibility*).
3. Select each image in the Design / Build / Extend row and the "See what's new" image, and confirm the computed **Name** matches the table above.
4. Confirm `brush.png` and the three showcase row images are still ignored by the accessibility tree.
5. Optionally, run a screen reader (NVDA or VoiceOver) over the page and confirm each feature image is announced with its description and the decorative images stay silent.
