### PR TITLE
Request meta team review on pattern changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Content-sync PRs (and any other PR touching page patterns) automatically
+# request a review from the meta team.
+/source/wp-content/themes/wporg-main-2022/patterns/ @WordPress/wordpress-org-meta-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# Content-sync PRs (and any other PR touching page patterns) automatically
-# request a review from the meta team.
+# Content-sync PRs automatically request a review from the meta team.
 /source/wp-content/themes/wporg-main-2022/patterns/ @WordPress/wordpress-org-meta-team


### PR DESCRIPTION
Adds a `CODEOWNERS` file so GitHub automatically requests a review from @WordPress/wordpress-org-meta-team on any PR that touches page patterns — most notably the automated content-update PRs, which currently open without a reviewer.

CODEOWNERS is used instead of the `team-reviewers` option of the create-pull-request action because the latter requires a PAT/App token with org permissions; code-owner review requests are made natively by GitHub and work with the default `GITHUB_TOKEN`.

Props @ocean90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)