### PR TITLE
CI: Speed up workflows with shared setup and caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,84 @@
+name: "Setup dependencies"
+description: "Install Node, PHP, Composer and npm dependencies, with caching."
+
+inputs:
+  skip-composer:
+    description: "Skip PHP/Composer setup entirely, for jobs that only build JS/CSS."
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install NodeJS
+      id: node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version-file: ".nvmrc"
+
+    - name: Setup PHP
+      if: inputs.skip-composer != 'true'
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+      with:
+        php-version: "8.4"
+
+    - name: Get cache day
+      if: inputs.skip-composer != 'true'
+      id: cache-day
+      shell: bash
+      run: echo "day=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+    # There is deliberately no committed composer.lock (#562): dependencies
+    # track moving branches, so every CI run re-resolved them from scratch
+    # (~50s). Instead, cache the installed tree under a key that rotates
+    # daily — an exact hit skips Composer entirely, and after a rotation the
+    # restored tree just seeds an incremental `composer update`, so CI
+    # dependencies are never more than a day stale.
+    - name: Cache Composer packages
+      if: inputs.skip-composer != 'true'
+      id: composer-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          composer.lock
+          vendor
+          source/wp-content/plugins
+          source/wp-content/mu-plugins/pub
+          source/wp-content/mu-plugins/wporg-mu-plugins
+          source/wp-content/themes/wporg
+          source/wp-content/themes/wporg-main
+          source/wp-content/themes/wporg-parent-2021
+        key: composer-${{ runner.os }}-${{ steps.cache-day.outputs.day }}-${{ hashFiles('composer.json') }}
+        restore-keys: |
+          composer-${{ runner.os }}-
+
+    - name: Install Composer dependencies
+      if: inputs.skip-composer != 'true' && steps.composer-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # Subversion is only needed to fetch the meta.svn.wordpress.org packages.
+        sudo apt-get install -y subversion
+        composer update
+
+    # Skips `npm ci` on a hit. Deliberately no `restore-keys` — a stale
+    # node_modules is only safe on an exact lockfile + Node match.
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          node_modules
+          source/wp-content/themes/wporg-main-2022/node_modules
+        key: node-modules-${{ runner.os }}-${{ steps.node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
+    - name: Install npm dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm ci --no-audit --no-fund
+
+    # Generates the gitignored lint configs (phpcs.xml.dist, eslint.config.js,
+    # .stylelintrc, …) from wporg-repo-tools, so it needs the Composer deps.
+    - name: Generate tool configs
+      if: inputs.skip-composer != 'true'
+      shell: bash
+      run: npm run setup:tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,15 +24,21 @@ jobs:
         with:
           ref: trunk
 
+      # The webpack build is self-contained, so PHP/Composer are not needed.
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+        uses: ./.github/actions/setup
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          packageManager: npm
+          skip-composer: true
 
+      - name: Build the theme
+        run: npm run build:theme
+
+      # node_modules is parked in $RUNNER_TEMP and restored after the push, so
+      # the setup action's cache can still be saved at the end of the job.
       - name: Trim the repo down to just the theme
         run: |
           rm -rf source/wp-content/themes/wporg-main-2022/node_modules
+          mv node_modules "$RUNNER_TEMP"
           mv source/wp-content/themes/wporg-main-2022 $RUNNER_TEMP
           git rm -rfq .
           rm -rf *
@@ -55,3 +61,6 @@ jobs:
           branch: build
           force: true
           message: 'Build: ${{ github.sha }}'
+
+      - name: Restore node_modules for the cache save
+        run: mv "$RUNNER_TEMP/node_modules" node_modules

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -45,17 +45,37 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+        uses: ./.github/actions/setup
+
+      - name: Get cache week
+        id: cache-week
+        run: echo "week=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
+
+      # Caches the WordPress/WordPress#master checkout wp-env downloads.
+      # Cache entries are immutable, so the key rotates weekly; `restore-keys`
+      # seeds from the newest snapshot and `--update` fetches only the delta.
+      - name: Cache WordPress source
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          packageManager: npm
+          # wp-env uses `~/wp-env` on hosts with Snap (like Ubuntu runners)
+          # and `~/.wp-env` elsewhere.
+          path: |
+            ~/wp-env
+            ~/.wp-env
+          key: wp-env-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('.wp-env.json') }}
+          restore-keys: |
+            wp-env-${{ runner.os }}-
+
+      # The screenshots need built theme assets.
+      - name: Build the theme
+        run: npm run build:theme
 
       - name: Run the content update
         id: build-patterns
         run: |
           chmod -R ugo+w source/wp-content/themes/wporg-main-2022/
           echo '{ "testsEnvironment": false }' > .wp-env.override.json
-          npx wp-env start
+          npx wp-env start --update
           npm run setup:wp
           mkdir -p "$GITHUB_WORKSPACE/artifacts/"
           npm run build:patterns

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -76,6 +76,18 @@ jobs:
           rm -rf ~/wp-env/*/WordPress/wp-content/mu-plugins ~/wp-env/*/tests-WordPress/wp-content/mu-plugins \
             ~/.wp-env/*/WordPress/wp-content/mu-plugins ~/.wp-env/*/tests-WordPress/wp-content/mu-plugins
 
+      # Puppeteer downloads Chrome in its npm postinstall script, which is
+      # skipped when node_modules is restored from cache, so the browser is
+      # cached and ensured separately. The install is a no-op when present.
+      - name: Cache Puppeteer Chrome
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Ensure Chrome for Puppeteer
+        run: npx puppeteer browsers install chrome
+
       # The screenshots need built theme assets.
       - name: Build the theme
         run: npm run build:theme

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -66,6 +66,16 @@ jobs:
           restore-keys: |
             wp-env-${{ runner.os }}-
 
+      # Docker creates mountpoint artifacts for the .wp-env.json file mappings
+      # inside the core checkouts (wp-content/mu-plugins/0-sandbox.php); restored
+      # from cache on a fresh runner they break container startup with a "file
+      # exists" mount error. Core ships no mu-plugins, so the directory is safe
+      # to scrub — Docker recreates the mountpoints, as on a cold run.
+      - name: Scrub Docker mountpoint artifacts from the restored cache
+        run: |
+          rm -rf ~/wp-env/*/WordPress/wp-content/mu-plugins ~/wp-env/*/tests-WordPress/wp-content/mu-plugins \
+            ~/.wp-env/*/WordPress/wp-content/mu-plugins ~/.wp-env/*/tests-WordPress/wp-content/mu-plugins
+
       # The screenshots need built theme assets.
       - name: Build the theme
         run: npm run build:theme

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,6 +6,11 @@ on:
     branches: [trunk]
   pull_request:
 
+# Pushing a fixup cancels the superseded PR run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
@@ -21,10 +26,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          packageManager: npm
+        uses: ./.github/actions/setup
 
-      - name: Lint
-        uses: WordPress/wporg-repo-tools/.github/actions/lint@trunk
+      - name: Lint front-end
+        run: npm run lint:frontend
+
+      - name: Lint PHP
+        run: npm run lint:php

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -5,6 +5,18 @@ on:
   push:
     branches: [trunk]
   pull_request:
+    # The suite only covers PHP code (the export-content parsers), so
+    # content-only PRs — pattern/template syncs from the Page Editor — skip it.
+    paths-ignore:
+      - 'source/wp-content/themes/wporg-main-2022/patterns/**'
+      - 'source/wp-content/themes/wporg-main-2022/templates/**'
+      - 'source/wp-content/themes/wporg-main-2022/parts/**'
+      - '**.md'
+
+# Pushing a fixup cancels the superseded PR run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -24,10 +36,45 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
-        uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+        uses: ./.github/actions/setup
+
+      - name: Get cache week
+        id: cache-week
+        run: echo "week=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
+
+      # Caches the WordPress/WordPress#master checkout wp-env downloads.
+      # Cache entries are immutable, so the key rotates weekly; `restore-keys`
+      # seeds from the newest snapshot and `--update` fetches only the delta.
+      - name: Cache WordPress source
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          packageManager: npm
+          # wp-env uses `~/wp-env` on hosts with Snap (like Ubuntu runners)
+          # and `~/.wp-env` elsewhere.
+          path: |
+            ~/wp-env
+            ~/.wp-env
+          key: wp-env-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('.wp-env.json') }}
+          restore-keys: |
+            wp-env-${{ runner.os }}-
+
+      # `--update` is required with the cache: a restored config would otherwise
+      # skip the WordPress setup on a pristine runner. The environment starts in
+      # the background while the theme builds.
+      - name: Build theme and start the WordPress environment
+        run: |
+          # The trap prints the log on every exit path, including the
+          # SIGINT a timeout cancellation sends to a hung `wait`.
+          trap 'cat "$RUNNER_TEMP/wp-env.log"' EXIT
+          npx wp-env start --update > "$RUNNER_TEMP/wp-env.log" 2>&1 &
+          WP_ENV_PID=$!
+
+          BUILD_STATUS=0
+          npm run build:theme || BUILD_STATUS=$?
+
+          WP_ENV_STATUS=0
+          wait "$WP_ENV_PID" || WP_ENV_STATUS=$?
+
+          exit "$(( BUILD_STATUS ? BUILD_STATUS : WP_ENV_STATUS ))"
 
       - name: Test
-        uses: WordPress/wporg-repo-tools/.github/actions/test-php@trunk
+        run: npm run test:php

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -57,6 +57,16 @@ jobs:
           restore-keys: |
             wp-env-${{ runner.os }}-
 
+      # Docker creates mountpoint artifacts for the .wp-env.json file mappings
+      # inside the core checkouts (wp-content/mu-plugins/0-sandbox.php); restored
+      # from cache on a fresh runner they break container startup with a "file
+      # exists" mount error. Core ships no mu-plugins, so the directory is safe
+      # to scrub — Docker recreates the mountpoints, as on a cold run.
+      - name: Scrub Docker mountpoint artifacts from the restored cache
+        run: |
+          rm -rf ~/wp-env/*/WordPress/wp-content/mu-plugins ~/wp-env/*/tests-WordPress/wp-content/mu-plugins \
+            ~/.wp-env/*/WordPress/wp-content/mu-plugins ~/.wp-env/*/tests-WordPress/wp-content/mu-plugins
+
       # `--update` is required with the cache: a restored config would otherwise
       # skip the WordPress setup on a pristine runner. The environment starts in
       # the background while the theme builds.


### PR DESCRIPTION
Nearly all CI time is setup, not work: on a recent run ([example](https://github.com/WordPress/wporg-main-2022/actions/runs/31812582530/job/94806508869)) the test job spent ~3 minutes installing dependencies and starting wp-env to run **1.4 seconds** of PHPUnit. Measured breakdown: Composer ~49s (full resolution every run), `npm install` ~30s, `wp-env start` ~71s (cold WordPress checkout + Docker pulls), runner/tool setup ~25s.

This follows the same approach as WordPress/wporg-mu-plugins#756, adapted to this repo.

## Changes

- **New composite action `.github/actions/setup`** shares Node/PHP/Composer/npm setup across the workflows, replacing the `wporg-repo-tools` setup action, so caching is configured in one place.
- **Composer caching without a lock file.** `composer.lock` is deliberately not committed (#562 — dependencies track moving branches), so every run re-resolved everything from scratch. The installed tree (vendor + Composer-installed plugins/themes/mu-plugins) is now cached under a daily-rotating key: an exact hit skips Composer entirely, and after a rotation the restored tree seeds an incremental `composer update`. CI dependencies are never more than a day stale, consistent with the "run `composer update`" policy from #562. Subversion is only installed on a cache miss.
- **`node_modules` caching**: `npm ci` is skipped on an exact lockfile + Node version match. Deliberately no `restore-keys` — a stale `node_modules` is only safe on an exact match. Puppeteer's Chrome (normally fetched by an npm postinstall script the cache skips) is cached and ensured separately in content-update.yml, the only workflow that needs it.
- **wp-env source caching**: caches the `WordPress/WordPress#master` checkout (~480MB) with a weekly-rotating key; `wp-env start --update` fetches only the delta, so tests still run against current core master. wp-env starts in the background while the theme builds. Docker's mountpoint artifacts for the `.wp-env.json` file mappings (e.g. `wp-content/mu-plugins/0-sandbox.php`) are scrubbed from the restored checkouts before starting — left in place they fail container startup with a "file exists" mount error.
- **Content-only PRs skip the PHPUnit job** via `paths-ignore` on `patterns/`, `templates/`, `parts/`, and Markdown. The suite only covers the `env/export-content` parsers, so Page Editor content syncs — most of this repo's PR traffic — currently pay the full 3 minutes for nothing. Trunk has no required status checks, so a skipped run doesn't block merges.
- **PR concurrency cancellation** in linters.yml and phpunit.yml, so pushing a fixup cancels the superseded run.
- **build.yml drops PHP/Composer entirely** — the webpack build is self-contained (the only parent-theme reference in the theme's scss is a comment). The trim step parks `node_modules` in `$RUNNER_TEMP` and restores it after the push so the cache save at job end still works.
- **linters.yml** runs `npm run lint:frontend` / `lint:php` directly instead of the shared lint action (which hardcodes yarn); **content-update.yml** (the nightly content sync) uses the same cached setup and wp-env cache.

## Measured impact (runs on this PR)

| Workflow | Cold (before/first run) | Warm caches |
|---|---|---|
| PHP Unit Tests | ~3m13s | **1m27s–1m45s** |
| Static Analysis (Linting) | ~2m03s | **42s** |
| Update existing content | ~3m55s | **2m26s** |
| Content-only PRs (PHPUnit) | ~3m | **skipped** |

The remaining test-job floor is the Docker image builds inside `wp-env start`, which now overlap with the theme build. Cold runs (first of the day, or lockfile/composer.json changes) stay near current times while they warm the caches.

## Not included (follow-up ideas)

- Running PHPUnit on the host (PHP 8.4 + MySQL service container + wp-phpunit) instead of inside wp-env would eliminate the Docker startup entirely, but changes what the tests run against (released core instead of the `WordPress#master` checkout) — a policy call.

### How to test the changes in this Pull Request:

1. Check the workflow runs on this PR — the latest runs exercise fully warm caches; the first runs were the cold, cache-warming path.
2. Confirm the PHPUnit job is skipped on a content-only PR (e.g. the next automated content update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)