### PR TITLE
Fix two CI failures introduced by the caching changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,14 @@ jobs:
       - name: Build the theme
         run: npm run build:theme
 
-      # node_modules is parked in $RUNNER_TEMP and restored after the push, so
-      # the setup action's cache can still be saved at the end of the job.
+      # node_modules and .github are parked in $RUNNER_TEMP and restored after
+      # the push: the setup action's post steps need .github/actions/setup to
+      # save the caches at the end of the job.
       - name: Trim the repo down to just the theme
         run: |
           rm -rf source/wp-content/themes/wporg-main-2022/node_modules
           mv node_modules "$RUNNER_TEMP"
+          cp -r .github "$RUNNER_TEMP"
           mv source/wp-content/themes/wporg-main-2022 $RUNNER_TEMP
           git rm -rfq .
           rm -rf *
@@ -62,5 +64,8 @@ jobs:
           force: true
           message: 'Build: ${{ github.sha }}'
 
-      - name: Restore node_modules for the cache save
-        run: mv "$RUNNER_TEMP/node_modules" node_modules
+      - name: Restore action files and node_modules for the cache save
+        run: |
+          mv "$RUNNER_TEMP/node_modules" node_modules
+          rm -rf .github
+          mv "$RUNNER_TEMP/.github" .github

--- a/.github/workflows/content-update.yml
+++ b/.github/workflows/content-update.yml
@@ -66,15 +66,14 @@ jobs:
           restore-keys: |
             wp-env-${{ runner.os }}-
 
-      # Docker creates mountpoint artifacts for the .wp-env.json file mappings
-      # inside the core checkouts (wp-content/mu-plugins/0-sandbox.php); restored
-      # from cache on a fresh runner they break container startup with a "file
-      # exists" mount error. Core ships no mu-plugins, so the directory is safe
-      # to scrub — Docker recreates the mountpoints, as on a cold run.
-      - name: Scrub Docker mountpoint artifacts from the restored cache
-        run: |
-          rm -rf ~/wp-env/*/WordPress/wp-content/mu-plugins ~/wp-env/*/tests-WordPress/wp-content/mu-plugins \
-            ~/.wp-env/*/WordPress/wp-content/mu-plugins ~/.wp-env/*/tests-WordPress/wp-content/mu-plugins
+      # The 0-sandbox.php file mapping's mountpoint resolves into the repo's
+      # mu-plugins directory, which all of the environment's containers bind.
+      # Containers starting concurrently race to create the missing placeholder
+      # (runc uses O_EXCL) and the loser fails with a "file exists" mount error.
+      # Pre-creating it removes the race; inside the containers the bind mount
+      # covers it with env/0-sandbox.php. The path is gitignored.
+      - name: Pre-create the 0-sandbox.php mountpoint
+        run: touch source/wp-content/mu-plugins/0-sandbox.php
 
       # Puppeteer downloads Chrome in its npm postinstall script, which is
       # skipped when node_modules is restored from cache, so the browser is

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -57,15 +57,14 @@ jobs:
           restore-keys: |
             wp-env-${{ runner.os }}-
 
-      # Docker creates mountpoint artifacts for the .wp-env.json file mappings
-      # inside the core checkouts (wp-content/mu-plugins/0-sandbox.php); restored
-      # from cache on a fresh runner they break container startup with a "file
-      # exists" mount error. Core ships no mu-plugins, so the directory is safe
-      # to scrub — Docker recreates the mountpoints, as on a cold run.
-      - name: Scrub Docker mountpoint artifacts from the restored cache
-        run: |
-          rm -rf ~/wp-env/*/WordPress/wp-content/mu-plugins ~/wp-env/*/tests-WordPress/wp-content/mu-plugins \
-            ~/.wp-env/*/WordPress/wp-content/mu-plugins ~/.wp-env/*/tests-WordPress/wp-content/mu-plugins
+      # The 0-sandbox.php file mapping's mountpoint resolves into the repo's
+      # mu-plugins directory, which all of the environment's containers bind.
+      # Containers starting concurrently race to create the missing placeholder
+      # (runc uses O_EXCL) and the loser fails with a "file exists" mount error.
+      # Pre-creating it removes the race; inside the containers the bind mount
+      # covers it with env/0-sandbox.php. The path is gitignored.
+      - name: Pre-create the 0-sandbox.php mountpoint
+        run: touch source/wp-content/mu-plugins/0-sandbox.php
 
       # `--update` is required with the cache: a restored config would otherwise
       # skip the WordPress setup on a pristine runner. The environment starts in


### PR DESCRIPTION
Follow-up to #727, fixing the two failures on the first trunk runs ([build](https://github.com/WordPress/wporg-main-2022/actions/runs/31820311960/job/94831713121), [tests](https://github.com/WordPress/wporg-main-2022/actions/runs/31820311999/job/94831713338)).

## build.yml: cache save failed after a successful deploy

The trim step deletes the whole repo — including `.github/` — before pushing the theme to the build branch. The setup action's **post steps** (the cache saves) re-read `action.yml` from the workspace at the end of the job and failed with "Can't find 'action.yml'". The deploy itself succeeded; only the job status was red. `.github` is now parked in `$RUNNER_TEMP` alongside `node_modules` and restored after the push.

## phpunit.yml / content-update.yml: the `0-sandbox.php` mount error is a startup race

The trunk failure reproduced the "file exists" mount error **with the scrub step running and full cache hits**, disproving #727's "cached mountpoint artifact" theory. The actual cause: the `.wp-env.json` file mapping `wp-content/mu-plugins/0-sandbox.php → ./env/0-sandbox.php` has its mountpoint resolve through the `mu-plugins` bind into the repo's `source/wp-content/mu-plugins/` — a host directory shared by all of the environment's containers. Containers starting concurrently race to create the missing placeholder (runc uses `O_EXCL`), and the loser fails container startup. Hence the intermittency: pass, fail, pass, pass, fail.

The fix pre-creates the placeholder before `wp-env start`, so no container ever has to create it. The path is gitignored, and inside the containers the bind mount covers it with the real `env/0-sandbox.php`. The scrub step addressed the wrong cause and is removed.

**Why not fix it in `.wp-env.json`?** The config can't express this — the file-into-mapped-directory mount is exactly what the mapping feature is for, and there's no alternative shape that avoids it (moving `0-sandbox.php` into `source/wp-content/mu-plugins/` would put env-only scaffolding into the deployable mu-plugins source). Local developers effectively never see the race because the placeholder persists in the working copy after the first `wp-env start`; only pristine CI runners recreate it every run. The proper fix is upstream: `@wordpress/env` should pre-create file-mapping mountpoint targets before `docker compose up` — worth filing on Gutenberg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)