### PR TITLE
Designer role: apply page-edit guard to all REST edit methods

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/capabilities.php
@@ -26,7 +26,7 @@ function check_caps_for_page_update( $response, $handler, $request ) {
 	// It's probably sufficient for the purpose of this plugin, which is a safety measure, not a security check.
 	$user = wp_get_current_user();
 	if ( $user && in_array( 'designer', $user->roles ) ) {
-		if ( 'PUT' === $request->get_method() && $request->has_param( 'id' ) && $request->get_route() == rest_get_route_for_post( $request->get_param( 'id' ) ) ) {
+		if ( in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH' ), true ) && $request->has_param( 'id' ) && $request->get_route() == rest_get_route_for_post( $request->get_param( 'id' ) ) ) {
 			if ( 'page' === get_post_type( $request->get_param( 'id' ) ) ) {
 				$page = get_post( $request->get_param( 'id' ) );
 				if ( $request->has_param( 'status' ) && 'publish' !== $request->get_param( 'status' ) && 'publish' === get_post_status( $page->ID ) ) {


### PR DESCRIPTION
### What

`check_caps_for_page_update()` guards a Designer's edits to a page's status, slug, title, template, password, and featured image. The check only ran when the request method was `PUT`.

The core REST page-update route (`/wp/v2/pages/<id>`) is registered with `WP_REST_Server::EDITABLE`, which is `POST, PUT, PATCH`. This updates the guard to match against the full method set so the same restriction applies consistently to every edit method the route accepts, rather than only `PUT`.

### Change

```php
if ( in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH' ), true ) && ... )
```

One-line change in `inc/capabilities.php`. No behavior change for `PUT`; `POST`/`PATCH` now follow the same rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)