### PR TITLE
Escape latest_version_date shortcode output

### DIFF
--- a/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-main-2022/inc/shortcodes.php
@@ -148,6 +148,6 @@ add_shortcode(
 			}
 		}
 
-		return gmdate( $format, $timestamp );
+		return esc_html( gmdate( $format, $timestamp ) );
 	}
 );


### PR DESCRIPTION
Wraps the `[latest_version_date]` shortcode's return value in `esc_html()` so the formatted date is escaped when it's rendered into page content.

The shortcode returns `gmdate( $format, $timestamp )` directly, where `$format` comes from the shortcode's `format` attribute. Escaping the result on output keeps it consistent with the escape-on-output convention the theme follows elsewhere, and makes the shortcode self-contained regardless of the value passed to `format`.

The legitimate default (and any real date format) is unaffected — `esc_html()` is a no-op on a plain date string. The existing JSON-LD caller in `page-meta-descriptions.php` already applies `esc_js()` for its own context and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)